### PR TITLE
Add worktree creation script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ All docs except CLAUDE.md, AGENTS.md, TODOS.md, and CHANGELOG.md live in `./docs
 
 - [docs/workflows/agent-loop.md](./docs/workflows/agent-loop.md) — repeatable autonomous task execution loop
 - [docs/workflows/agent-review.md](./docs/workflows/agent-review.md) — review personas, findings format, quality checklist, escalation rules
+- [docs/workflows/worktrees.md](./docs/workflows/worktrees.md) — creating and managing parallel worktrees
 
 **Guidelines**
 

--- a/apps/website/vite.config.ts
+++ b/apps/website/vite.config.ts
@@ -13,7 +13,7 @@ const tauriConf = JSON.parse(readFileSync(tauriConfPath, "utf-8")) as {
 const RELEASE_REPO = "joelbqz/writer-computer";
 const VERSION = tauriConf.version;
 const DMG_URL = `https://github.com/${RELEASE_REPO}/releases/download/v${VERSION}/Writer_${VERSION}_aarch64.dmg`;
-const RELEASES_URL = `https://github.com/${RELEASE_REPO}/releases`;
+const RELEASES_URL = `https://github.com/${RELEASE_REPO}/releases/tag/v${VERSION}`;
 const REPO_URL = "https://github.com/joelbqz/writer-computer";
 
 export default defineConfig({

--- a/docs/workflows/worktrees.md
+++ b/docs/workflows/worktrees.md
@@ -1,0 +1,42 @@
+# Worktrees
+
+Use git worktrees to work on parallel tasks without stashing or switching branches. Each worktree gets its own directory under `.worktrees/` with a random two-word name.
+
+## Creating a worktree
+
+Source the script so the `cd` takes effect in your shell:
+
+```bash
+. ./scripts/worktree.sh
+```
+
+This will:
+
+1. Generate a random name (e.g. `wild-reef`)
+2. Create a new branch and worktree at `.worktrees/<name>/`
+3. Copy `.env` into the worktree
+4. `cd` into the worktree
+
+## Listing worktrees
+
+```bash
+git worktree list
+```
+
+## Removing a worktree
+
+```bash
+git worktree remove .worktrees/<name>
+```
+
+To also delete the branch:
+
+```bash
+git branch -d <name>
+```
+
+## Notes
+
+- `.worktrees/` is gitignored — worktrees are local-only.
+- Each worktree shares the same git history but has its own working tree and index.
+- Run `vp install` inside a new worktree before developing.

--- a/scripts/worktree.sh
+++ b/scripts/worktree.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORKTREES_DIR="$ROOT_DIR/.worktrees"
+
+ADJECTIVES=(amber ashen azure bleak bold brave brisk calm clear cold cool coral crisp dark dawn deep dense dire draft dry dull dusk eager even fair fast fell fern fierce fine firm flat fond free fresh frost full gilt glad gold good gray green grim hale hazel hazy held high holy iron ivory jade just keen kind lank last lean light lilac live lone long lost lucid lunar main maple mild mint mossy mute near neat next noble north oaken odd olive open pale past pearl pine plain plum prime proud pure quartz quiet rare raw real red rich ripe rosy rough ruby safe sage salt sharp sheer silver slim slow small smoky soft solid south spare stark steep still stone stout strong subtle sure swift tall tame taut teal thick thin tidy tough true umber vast vivid warm west white whole wide wild wiry wise woven young)
+NOUNS=(acre alder apex arc ash atlas axle bark basin bay beam birch blade bloom bluff bolt bone bow brace bridge brook briar cairn cape cedar chill chord cleft cliff cloud coast coral core cove crane crest croft cross crown curve dale dew dock dome dove draft drift drum dune dust echo edge elm ember end fall fault fawn fen fern field flare fleet flint flora ford forge fox frame frost gale gate gem glade glen glow gorge grain grove gust harbor haven hawk haze heath hedge helm hill hold hollow horn hub husk inlet iron isle ivy jar jest keel kelp knoll knot lake larch lark latch lea ledge lilac linen loch lodge loom lore marsh mast maze mead mesa mill mint mist moor moss mount muse nest node notch oak opal orbit ore owl palm pass patch path peak pearl pine pitch plain plume point pond porch post prime prism pulse quay quill raft rail rain range reach reed reef ridge rift rim ring rise road rock root rose roost rune rush sage salt sand seal seed shade shard shaw shell shore shrub silt slate slope smoke snag spar spark spire spoke spring spruce spur staff stage stake star steep stem still stone strand stream stump surge swale swift tarn teal thaw thorn tide timber trail trove trunk vale vault veil vine wade wake wall ward wash wave weld well wharf wheat wick wield wilt wind wing wood wren yard yew)
+
+random_name() {
+  local adj="${ADJECTIVES[$((RANDOM % ${#ADJECTIVES[@]}))]}"
+  local noun="${NOUNS[$((RANDOM % ${#NOUNS[@]}))]}"
+  echo "${adj}-${noun}"
+}
+
+NAME="$(random_name)"
+WORKTREE_PATH="$WORKTREES_DIR/$NAME"
+
+while [[ -d "$WORKTREE_PATH" ]]; do
+  NAME="$(random_name)"
+  WORKTREE_PATH="$WORKTREES_DIR/$NAME"
+done
+
+mkdir -p "$WORKTREES_DIR"
+git -C "$ROOT_DIR" worktree add -b "$NAME" "$WORKTREE_PATH" HEAD
+
+if [[ -f "$ROOT_DIR/.env" ]]; then
+  cp "$ROOT_DIR/.env" "$WORKTREE_PATH/.env"
+  echo "Copied .env to worktree"
+fi
+
+echo "Worktree ready at $WORKTREE_PATH"
+cd "$WORKTREE_PATH"


### PR DESCRIPTION
## Summary
- Adds `scripts/worktree.sh` that creates a git worktree under `.worktrees/` with a random two-word name (e.g. `wild-reef`), copies `.env` into it, and `cd`s into the worktree
- Source the script (`. ./scripts/worktree.sh`) so the `cd` takes effect in your shell

## Test plan
- [ ] Run `. ./scripts/worktree.sh` and verify a worktree is created with a random name
- [ ] Verify `.env` is copied into the new worktree
- [ ] Verify the shell's working directory changes to the new worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)