### PR TITLE
Update website analytics and Cloudflare deployment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ All docs except CLAUDE.md, AGENTS.md, TODOS.md, and CHANGELOG.md live in `./docs
 **Infra**
 
 - [docs/releasing.md](./docs/releasing.md) — how to cut a signed, notarized macOS release
+- [docs/website-deploy.md](./docs/website-deploy.md) — how to deploy the marketing website to Cloudflare Workers
 
 **Cross-cutting**
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -2,7 +2,7 @@
 
 ## In Progress
 
-- Landing page redesign: [`SPECs/landing-page-redesign-spec.md`](SPECs/landing-page-redesign-spec.md) — Figma "Writer Computer" frame implemented under `apps/website/` (single-page React + Vite, dark, SF Pro, single orange accent). Remaining: real screenshots into `apps/website/public/screenshots/`, GitHub Pages deploy workflow, custom-domain decision, copy review. Supersedes `SPECs/landing-page-spec.md`.
+- Landing page redesign: [`SPECs/landing-page-redesign-spec.md`](SPECs/landing-page-redesign-spec.md) — Figma "Writer Computer" frame implemented under `apps/website/` (single-page React + Vite, dark, SF Pro, single orange accent). Remaining: real screenshots into `apps/website/public/screenshots/`, custom-domain decision, copy review. Supersedes `SPECs/landing-page-spec.md`.
 
 ## Up Next
 

--- a/apps/website/index.html
+++ b/apps/website/index.html
@@ -18,6 +18,11 @@
   </head>
   <body>
     <div id="root"></div>
+    <script
+      defer
+      src="https://umami.highpath.studio/script.js"
+      data-website-id="7b3faf71-9025-4378-b7dd-4562a9ab55d9"
+    ></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/apps/website/src/styles.css
+++ b/apps/website/src/styles.css
@@ -303,7 +303,6 @@ a {
     width: auto;
     margin: 0;
     padding: 20px 20px 20px;
-    height: auto;
   }
 
   .site-header {

--- a/apps/website/src/styles.css
+++ b/apps/website/src/styles.css
@@ -148,7 +148,6 @@ a {
   height: 100vh;
   display: flex;
   flex-direction: column;
-  overflow-y: auto;
 }
 
 .headline {

--- a/docs/website-deploy.md
+++ b/docs/website-deploy.md
@@ -1,0 +1,42 @@
+# Website Deploy
+
+The marketing website lives in `apps/website/` and deploys to the existing Cloudflare Worker service `writer-website`.
+
+## Configuration
+
+- Worker config: `wrangler.jsonc`
+- Worker name: `writer-website`
+- Static assets directory: `apps/website/dist`
+- Production URL: `https://writter.computer`
+- Worker preview URL: `https://writer-website.soluthemes.workers.dev`
+
+The Worker name in Cloudflare must match `name` in `wrangler.jsonc` so local deploys update the intended service.
+
+## Deploy Locally
+
+Deploys are run manually from a local machine using Wrangler CLI. From the repository root:
+
+```sh
+vp install
+(cd apps/website && vp build)
+vp dlx wrangler deploy --config wrangler.jsonc
+```
+
+Wrangler must be logged into the Cloudflare account that owns `writer-website`:
+
+```sh
+vp dlx wrangler login
+```
+
+Verify the deployment:
+
+```sh
+curl -I https://writter.computer
+```
+
+## Notes
+
+- Do not use GitHub Pages for this website.
+- Do not rely on Cloudflare Git Builds for this website unless this document is updated first.
+- Keep `wrangler.jsonc` at the repository root so local Wrangler deploys use the same Worker settings.
+- Run `vp check` before deploying source changes when practical.

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,8 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "writer-website",
+  "compatibility_date": "2026-04-30",
+  "assets": {
+    "directory": "apps/website/dist",
+  },
+}


### PR DESCRIPTION
## Summary
- Add Umami analytics to the website entry HTML.
- Add Cloudflare Worker configuration for local Wrangler deployments.
- Document the website deployment flow and update task/router references.

## Validation
- vp check
- vp build (apps/website)
- Deployed to Cloudflare Worker writer-website