### PR TITLE
Track website download clicks

### DIFF
--- a/apps/website/src/App.tsx
+++ b/apps/website/src/App.tsx
@@ -46,7 +46,12 @@ export function App() {
         <h1 className="headline">Fast and lightweight app for your workspace's markdown files</h1>
 
         <div className="cta">
-          <a className="download" href={__WRITER_DMG_URL__}>
+          <a
+            className="download"
+            href={__WRITER_DMG_URL__}
+            data-umami-event="Download macOS app"
+            data-umami-event-version={__WRITER_VERSION__}
+          >
             <AppleGlyph size={14} />
             <span>Download for MacOS</span>
           </a>


### PR DESCRIPTION
## Summary
- Add Umami event tracking to the macOS download CTA.
- Include the current app version as event metadata.

## Validation
- vp check src/App.tsx