### PR TITLE
Add recent workspaces Dock menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix the tab chrome snapping when toggling the sidebar. The tabs now render from the app layout as a root-level overlay whose left edge transitions between the expanded sidebar edge and the collapsed safe inset, instead of switching sidebar-dependent padding inside the moving editor area. See `SPECs/sidebar-toggle-tab-chrome-shift-spec.md`.
 - Rename the bundled Codex theme preset to Writer. The preset values are unchanged; only the default preset label and bundled theme folder changed.
+- Show recent workspaces in the macOS Dock icon context menu. The menu is built from Writer's existing recent workspace list, omits missing folders, and reuses the multi-window open path so selecting an already-open workspace focuses that window instead of duplicating it. See `SPECs/recent-workspaces-dock-menu-spec.md`.
 - Prepare the repository for a fresh private GitHub repo: remove internal triage artifacts and screenshots, replace starter READMEs with Writer-specific docs, and point release/updater metadata at `joelbqz/writer-computer`.
 
 ## 2026-04-28

--- a/SPECs/Agent/worksheet-recent-workspaces-dock-menu.md
+++ b/SPECs/Agent/worksheet-recent-workspaces-dock-menu.md
@@ -1,0 +1,48 @@
+# Worksheet: Recent Workspaces Dock Menu
+
+## Task
+
+- TODO: Recent workspaces Dock menu
+- Spec: `SPECs/recent-workspaces-dock-menu-spec.md`
+
+## Reviewed
+
+- `TODOS.md`
+- `SPECs/multi-window-spec.md`
+- `docs/workflows/agent-loop.md`
+- `apps/desktop/src-tauri/src/lib.rs`
+- `apps/desktop/src-tauri/src/commands/workspace.rs`
+- `apps/desktop/src-tauri/src/state.rs`
+- `apps/desktop/src-tauri/Cargo.toml`
+- Tauri 2.9 docs for macOS menu/window-menu APIs; no first-class Dock menu setter found.
+
+## Plan
+
+- Add a macOS-only `dock_menu` Rust module.
+- Register `applicationDockMenu:` and a workspace action method on the existing AppKit delegate class.
+- Build menu contents from `load_recent_workspaces`, filtering missing folders.
+- Store the workspace path on each menu item and dispatch selection to `open_new_workspace_window`.
+- Update docs/changelog and run Rust/frontend validation.
+
+## Notes
+
+- Worktree was clean at start.
+- The screenshot is the macOS Dock icon context menu; this is not the in-app menu bar or sidebar menu.
+
+## Implementation
+
+- Added `apps/desktop/src-tauri/src/dock_menu.rs` behind `cfg(target_os = "macos")`.
+- Registered AppKit delegate methods for `applicationDockMenu:` and recent-workspace item actions.
+- Recent menu items use folder names, store the full path as `representedObject`, and call `open_new_workspace_window` on selection.
+- Hardened the shared new-window path to reject deleted workspace folders and treat pending-open windows as already opening a workspace, preventing duplicate windows from rapid repeat opens.
+- Added unit coverage for filtering missing recent workspace directories, title fallback, and pending-open duplicate detection.
+
+## Validation
+
+- `vp install` was required before frontend validation because dependencies were missing in this worktree.
+- `vp check` passed after install with pre-existing warnings in settings/e2e files.
+- `vp test` passed: 17 files / 257 tests.
+- `cargo fmt --check` passed.
+- Implementation review found and fixed stale-path and pending-window duplicate races.
+- `cargo test` passed: 90 tests.
+- `cargo clippy` passed with pre-existing warnings in unrelated files.

--- a/SPECs/recent-workspaces-dock-menu-spec.md
+++ b/SPECs/recent-workspaces-dock-menu-spec.md
@@ -1,0 +1,34 @@
+# Recent Workspaces Dock Menu Spec
+
+## Status
+
+Shipped 2026-04-30.
+
+## Summary
+
+Show Writer's existing recent workspace list in the macOS Dock icon context menu so a user can reopen or focus a workspace without first switching to an app window.
+
+## Goals
+
+- Add recent workspace menu items above macOS' built-in Dock menu items.
+- Reuse the existing `recent_workspaces.json` list and workspace-opening path.
+- Selecting an already-open workspace focuses its window instead of duplicating it.
+- Keep the feature macOS-only; other platforms are unchanged.
+
+## Non-Goals
+
+- Redesign the in-app workspace switcher.
+- Add Windows jump-list or Linux launcher integrations.
+- Add user-configurable recent workspace limits.
+
+## UX Decisions
+
+- Show up to the existing persisted recent-workspace limit.
+- Display each workspace by its folder name.
+- Omit missing folders from the Dock menu rather than showing disabled stale entries.
+
+## Acceptance Criteria
+
+- Right-clicking the Writer Dock icon shows recent workspaces before the default Options / Hide / Quit items.
+- Clicking a recent workspace opens it in a new Writer window, or focuses the existing window for that workspace.
+- Existing recent workspace IPC and sidebar behavior continue to work.

--- a/TODOS.md
+++ b/TODOS.md
@@ -48,6 +48,7 @@ Previously-triaged work organized by phase. Pull into `Up Next` as capacity open
 
 - Sidebar toggle tab chrome shift: [`SPECs/sidebar-toggle-tab-chrome-shift-spec.md`](SPECs/sidebar-toggle-tab-chrome-shift-spec.md)
 - Rename bundled Codex theme preset to Writer.
+- Recent workspaces Dock menu: [`SPECs/recent-workspaces-dock-menu-spec.md`](SPECs/recent-workspaces-dock-menu-spec.md) — right-clicking the macOS Dock icon now shows existing recent workspaces above the default Dock menu items; choosing one opens a new workspace window or focuses an existing one.
 - Editor search lifecycle refactor: [`SPECs/editor-search-lifecycle-spec.md`](SPECs/editor-search-lifecycle-spec.md) — closes CodeMirror and React search state together, clears stale editor views on close/unmount, and updates CodeMirror from input events instead of a query-sync render effect.
 
 - Theming system: [`SPECs/theming-system-spec.md`](SPECs/theming-system-spec.md) — CSS-var-driven primaries (accent, bg, fg, fonts, translucency, contrast) per light/dark mode with derived overlays. Supersedes `body-theming-spec.md`.

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -863,6 +863,7 @@ dependencies = [
  "ignore",
  "image",
  "notify",
+ "objc2",
  "parking_lot",
  "regex-lite",
  "serde",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -38,6 +38,9 @@ tauri-plugin-updater = "2"
 tauri-plugin-single-instance = "2"
 tauri-plugin-webdriver = { version = "0.2", optional = true }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6.4"
+
 [features]
 # Embeds a W3C WebDriver server in the app for local E2E testing with
 # `tauri-webdriver` + WebdriverIO. Never enable this for release builds.

--- a/apps/desktop/src-tauri/src/dock_menu.rs
+++ b/apps/desktop/src-tauri/src/dock_menu.rs
@@ -1,0 +1,273 @@
+//! macOS Dock icon context menu integration.
+//!
+//! Tauri exposes the normal application menu, but not AppKit's
+//! `applicationDockMenu:` hook. Registering that selector on Tauri's existing
+//! app delegate lets Writer add recent workspaces above macOS' built-in Dock
+//! menu items without taking over the rest of the native menu behavior.
+
+use crate::commands::workspace::load_recent_workspaces;
+use objc2::ffi::class_addMethod;
+use objc2::runtime::{AnyClass, AnyObject, Imp, Sel};
+use objc2::{class, msg_send, sel};
+use std::ffi::CStr;
+use std::os::raw::c_char;
+use std::path::Path;
+use std::ptr;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::OnceLock;
+
+const NS_UTF8_STRING_ENCODING: usize = 4;
+const DOCK_MENU_SIGNATURE: &[u8] = b"@@:@\0";
+const MENU_ACTION_SIGNATURE: &[u8] = b"v@:@\0";
+
+static APP_HANDLE: OnceLock<tauri::AppHandle> = OnceLock::new();
+static METHODS_REGISTERED: AtomicBool = AtomicBool::new(false);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RecentWorkspaceMenuItem {
+    title: String,
+    path: String,
+}
+
+pub(crate) fn install(app: &tauri::AppHandle) {
+    let _ = APP_HANDLE.set(app.clone());
+    if METHODS_REGISTERED.load(Ordering::Acquire) {
+        return;
+    }
+
+    let registered = unsafe { register_delegate_methods() };
+    if registered {
+        METHODS_REGISTERED.store(true, Ordering::Release);
+    }
+}
+
+unsafe fn register_delegate_methods() -> bool {
+    let app: *mut AnyObject = unsafe { msg_send![class!(NSApplication), sharedApplication] };
+    if app.is_null() {
+        eprintln!("failed to install Dock menu: NSApplication unavailable");
+        return false;
+    }
+
+    let delegate: *mut AnyObject = unsafe { msg_send![app, delegate] };
+    if delegate.is_null() {
+        eprintln!("failed to install Dock menu: NSApplication delegate unavailable");
+        return false;
+    }
+
+    let delegate_class: *mut AnyClass = unsafe { msg_send![delegate, class] };
+    if delegate_class.is_null() {
+        eprintln!("failed to install Dock menu: delegate class unavailable");
+        return false;
+    }
+
+    let dock_menu_imp: Imp = unsafe {
+        std::mem::transmute::<
+            unsafe extern "C-unwind" fn(*mut AnyObject, Sel, *mut AnyObject) -> *mut AnyObject,
+            Imp,
+        >(application_dock_menu)
+    };
+    let action_imp: Imp = unsafe {
+        std::mem::transmute::<unsafe extern "C-unwind" fn(*mut AnyObject, Sel, *mut AnyObject), Imp>(
+            open_recent_workspace,
+        )
+    };
+
+    let action_method_added = unsafe {
+        class_addMethod(
+            delegate_class,
+            sel!(writerOpenRecentWorkspace:),
+            action_imp,
+            MENU_ACTION_SIGNATURE.as_ptr().cast(),
+        )
+        .as_bool()
+    };
+    if !action_method_added {
+        eprintln!("failed to install Dock menu: action selector could not be added");
+        return false;
+    }
+
+    let dock_method_added = unsafe {
+        class_addMethod(
+            delegate_class,
+            sel!(applicationDockMenu:),
+            dock_menu_imp,
+            DOCK_MENU_SIGNATURE.as_ptr().cast(),
+        )
+        .as_bool()
+    };
+    if !dock_method_added {
+        eprintln!("failed to install Dock menu: applicationDockMenu selector could not be added");
+        return false;
+    }
+
+    true
+}
+
+unsafe extern "C-unwind" fn application_dock_menu(
+    delegate: *mut AnyObject,
+    _cmd: Sel,
+    _sender: *mut AnyObject,
+) -> *mut AnyObject {
+    let Some(app) = APP_HANDLE.get() else {
+        return ptr::null_mut();
+    };
+
+    let recents = load_recent_workspaces(app).unwrap_or_default();
+    let items = recent_workspace_menu_items(&recents);
+    if items.is_empty() {
+        return ptr::null_mut();
+    }
+
+    let menu: *mut AnyObject = unsafe { msg_send![class!(NSMenu), new] };
+    if menu.is_null() {
+        return ptr::null_mut();
+    }
+
+    for item in &items {
+        unsafe { add_workspace_menu_item(menu, delegate, item) };
+    }
+
+    let _: *mut AnyObject = unsafe { msg_send![menu, autorelease] };
+    menu
+}
+
+unsafe fn add_workspace_menu_item(
+    menu: *mut AnyObject,
+    target: *mut AnyObject,
+    item: &RecentWorkspaceMenuItem,
+) {
+    let title = unsafe { ns_string(&item.title) };
+    let path = unsafe { ns_string(&item.path) };
+    let key_equivalent = unsafe { ns_string("") };
+    if title.is_null() || path.is_null() || key_equivalent.is_null() {
+        return;
+    }
+
+    let menu_item: *mut AnyObject = unsafe { msg_send![class!(NSMenuItem), alloc] };
+    if menu_item.is_null() {
+        return;
+    }
+    let menu_item: *mut AnyObject = unsafe {
+        msg_send![menu_item, initWithTitle: title, action: sel!(writerOpenRecentWorkspace:), keyEquivalent: key_equivalent]
+    };
+    if menu_item.is_null() {
+        return;
+    }
+
+    unsafe {
+        let _: () = msg_send![menu_item, setTarget: target];
+        let _: () = msg_send![menu_item, setRepresentedObject: path];
+        let _: () = msg_send![menu_item, setToolTip: path];
+        let _: () = msg_send![menu, addItem: menu_item];
+        let _: *mut AnyObject = msg_send![menu_item, autorelease];
+    }
+}
+
+unsafe extern "C-unwind" fn open_recent_workspace(
+    _delegate: *mut AnyObject,
+    _cmd: Sel,
+    sender: *mut AnyObject,
+) {
+    if sender.is_null() {
+        return;
+    }
+
+    let path_object: *mut AnyObject = unsafe { msg_send![sender, representedObject] };
+    let Some(path) = (unsafe { ns_string_to_string(path_object) }) else {
+        return;
+    };
+
+    let Some(app) = APP_HANDLE.get() else {
+        return;
+    };
+
+    if let Err(err) = crate::open_new_workspace_window(app, path, None) {
+        eprintln!("failed to open workspace from Dock menu: {err:?}");
+    }
+}
+
+fn recent_workspace_menu_items(recents: &[String]) -> Vec<RecentWorkspaceMenuItem> {
+    recents
+        .iter()
+        .filter(|path| Path::new(path).is_dir())
+        .map(|path| RecentWorkspaceMenuItem {
+            title: workspace_title(path),
+            path: path.clone(),
+        })
+        .collect()
+}
+
+fn workspace_title(path: &str) -> String {
+    Path::new(path)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .unwrap_or(path)
+        .to_string()
+}
+
+unsafe fn ns_string(value: &str) -> *mut AnyObject {
+    let string: *mut AnyObject = unsafe { msg_send![class!(NSString), alloc] };
+    if string.is_null() {
+        return ptr::null_mut();
+    }
+    let string: *mut AnyObject = unsafe {
+        msg_send![
+            string,
+            initWithBytes: value.as_ptr(),
+            length: value.len(),
+            encoding: NS_UTF8_STRING_ENCODING
+        ]
+    };
+    if string.is_null() {
+        return ptr::null_mut();
+    }
+    let _: *mut AnyObject = unsafe { msg_send![string, autorelease] };
+    string
+}
+
+unsafe fn ns_string_to_string(value: *mut AnyObject) -> Option<String> {
+    if value.is_null() {
+        return None;
+    }
+    let bytes: *const c_char = unsafe { msg_send![value, UTF8String] };
+    if bytes.is_null() {
+        return None;
+    }
+    unsafe { CStr::from_ptr(bytes) }
+        .to_str()
+        .ok()
+        .map(|s| s.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn recent_workspace_items_filter_missing_directories() {
+        let dir = tempdir().unwrap();
+        let existing = dir.path().join("Existing Workspace");
+        std::fs::create_dir(&existing).unwrap();
+        let missing = dir.path().join("Missing Workspace");
+
+        let items = recent_workspace_menu_items(&[
+            existing.to_string_lossy().to_string(),
+            missing.to_string_lossy().to_string(),
+        ]);
+
+        assert_eq!(
+            items,
+            vec![RecentWorkspaceMenuItem {
+                title: "Existing Workspace".to_string(),
+                path: existing.to_string_lossy().to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn workspace_title_falls_back_to_full_path() {
+        assert_eq!(workspace_title("/"), "/");
+    }
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,5 +1,7 @@
 mod commands;
 mod config;
+#[cfg(target_os = "macos")]
+mod dock_menu;
 mod error;
 mod ignore;
 pub mod open_target;
@@ -80,6 +82,9 @@ pub(crate) fn open_new_workspace_window(
     file: Option<String>,
 ) -> Result<(), AppError> {
     let workspace = PathBuf::from(&workspace_path);
+    if !workspace.exists() || !workspace.is_dir() {
+        return Err(AppError::NotFound(workspace_path));
+    }
 
     if let Some(existing_label) = app.state::<AppState>().find_by_workspace(&workspace) {
         if let Some(window) = app.get_webview_window(&existing_label) {
@@ -367,6 +372,8 @@ pub fn run() {
                 app.handle()
                     .plugin(tauri_plugin_updater::Builder::new().build())?;
                 install_app_menu(app.handle(), config_dir)?;
+                #[cfg(target_os = "macos")]
+                dock_menu::install(app.handle());
 
                 // Kick off the launch check once the window is ready to show
                 // any follow-up dialogs on top of a visible app.

--- a/apps/desktop/src-tauri/src/state.rs
+++ b/apps/desktop/src-tauri/src/state.rs
@@ -88,6 +88,13 @@ impl WorkspaceState {
     pub fn pop_pending_open(&self) -> Option<PendingOpenPayload> {
         self.pending_open.lock().pop_front()
     }
+
+    pub fn has_pending_workspace(&self, path: &Path) -> bool {
+        self.pending_open
+            .lock()
+            .iter()
+            .any(|payload| Path::new(&payload.workspace) == path)
+    }
 }
 
 /// Process-wide registry of per-window `WorkspaceState`, keyed by Tauri
@@ -137,9 +144,11 @@ impl AppState {
         self.windows.write().remove(label)
     }
 
-    /// Find an existing window already hosting `path`. Used to focus
-    /// rather than duplicate when the user opens a workspace that's
-    /// already open in another window.
+    /// Find an existing window already hosting or opening `path`. Used to
+    /// focus rather than duplicate when the user opens a workspace that's
+    /// already open in another window. Pending opens are included so two
+    /// quick requests for the same workspace do not race before the new
+    /// window hydrates and publishes `workspace_root`.
     pub fn find_by_workspace(&self, path: &Path) -> Option<String> {
         let map = self.windows.read();
         for (label, state) in map.iter() {
@@ -148,6 +157,11 @@ impl AppState {
                 if root == path {
                     return Some(label.clone());
                 }
+            }
+            drop(guard);
+
+            if state.has_pending_workspace(path) {
+                return Some(label.clone());
             }
         }
         None
@@ -188,4 +202,24 @@ pub fn rebuild_dirs_from_index(files: &[IndexedFile], root: &Path) -> HashSet<Pa
         register_ancestors(&mut dirs, &file.path, root);
     }
     dirs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn find_by_workspace_matches_pending_open() {
+        let app_state = AppState::new();
+        let window_state = app_state.get_or_create("pending-window");
+        window_state.push_pending_open(PendingOpenPayload {
+            workspace: "/tmp/workspace".to_string(),
+            file: None,
+        });
+
+        assert_eq!(
+            app_state.find_by_workspace(Path::new("/tmp/workspace")),
+            Some("pending-window".to_string())
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Adds a macOS Dock icon context menu populated from Writer's existing recent workspaces.
- Reuses the multi-window open path so choosing an open workspace focuses its window and rapid repeat opens don't duplicate pending windows.
- Documents the feature in the spec, worksheet, TODOs, and changelog.

## Validation
- cargo test
- cargo fmt --check
- cargo clippy (passes with existing unrelated warnings)
- vp check (passes with existing unrelated warnings)
- vp test