### PR TITLE
Default new document content to heading

### DIFF
--- a/apps/desktop/src-tauri/src/commands/fs.rs
+++ b/apps/desktop/src-tauri/src/commands/fs.rs
@@ -307,10 +307,11 @@ pub fn create_file_impl(path: &str) -> Result<FileContent, AppError> {
     if let Some(parent) = file_path.parent() {
         fs::create_dir_all(parent)?;
     }
-    fs::write(&file_path, "")?;
+    let default_content = "# ";
+    fs::write(&file_path, default_content)?;
     Ok(FileContent {
         path: path.to_string(),
-        content: String::new(),
+        content: default_content.to_string(),
         modified_at: modified_time(&file_path),
     })
 }


### PR DESCRIPTION
## Summary
- New documents now start with `# ` instead of being empty, so the user can immediately type a heading title.

## Test plan
- [ ] Create a new file from the sidebar context menu and verify it opens with `# ` as content
- [ ] Create a new file from the command palette and verify the same

🤖 Generated with [Claude Code](https://claude.com/claude-code)