### PR TITLE
Adjust website download button

### DIFF
--- a/apps/website/src/App.tsx
+++ b/apps/website/src/App.tsx
@@ -54,7 +54,7 @@ export function App() {
             data-umami-event="Download macOS app"
             data-umami-event-version={__WRITER_VERSION__}
           >
-            <AppleGlyph size={14} />
+            <AppleGlyph size={20} />
             <span>Download for MacOS</span>
           </a>
           <span className="alpha-pill">Alpha</span>

--- a/apps/website/src/styles.css
+++ b/apps/website/src/styles.css
@@ -172,7 +172,6 @@ a {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  width: 186px;
   height: 40px;
   padding: 0 12px;
   border-radius: var(--radius);


### PR DESCRIPTION
## Summary
- Increase the macOS download icon size.
- Let the download button size to its content instead of a fixed width.

## Validation
- vp check src/App.tsx src/styles.css