### PR TITLE
Improve table and checkbox rendering

### DIFF
--- a/apps/desktop/src/components/editor-area/prosemark-theme.css
+++ b/apps/desktop/src/components/editor-area/prosemark-theme.css
@@ -99,6 +99,44 @@
   display: none;
 }
 
+/* Task checkboxes — replace native checkbox with hugeicon-style rounded square */
+@keyframes checkbox-pop {
+  0% {
+    transform: scale(0.85);
+  }
+  50% {
+    transform: scale(1.1);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+.cm-editor .cm-checkbox {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 18px;
+  height: 18px;
+  border: 1.5px solid var(--text-muted);
+  border-radius: 5px;
+  cursor: pointer;
+  vertical-align: -3px;
+  margin-right: 2px;
+  transition:
+    background-color 0.15s,
+    border-color 0.15s;
+}
+
+.cm-editor .cm-checkbox:checked {
+  background-color: var(--accent);
+  border-color: var(--accent);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='white' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M8 12.5L10.5 15L16 9'/%3E%3C/svg%3E");
+  background-size: 20px 20px;
+  background-position: center;
+  background-repeat: no-repeat;
+  animation: checkbox-pop 0.2s ease-out;
+}
+
 /* Wiki-link autocomplete tooltip uses the UI font, not the editor font */
 .cm-editor .cm-tooltip.cm-tooltip-autocomplete > ul,
 .cm-editor .cm-tooltip.cm-tooltip-autocomplete > ul > li {

--- a/apps/desktop/src/components/editor-area/table-decorations.ts
+++ b/apps/desktop/src/components/editor-area/table-decorations.ts
@@ -112,16 +112,17 @@ const tableFoldExtension = foldableSyntaxFacet.of({
 const tableTheme = EditorView.baseTheme({
   ".cm-table-widget": {
     padding: "0.25em 0",
+    overflowX: "auto",
   },
   ".cm-table-widget table": {
     borderCollapse: "collapse",
-    width: "100%",
     fontFamily: "'SF Mono', Menlo, Monaco, Consolas, monospace",
     fontSize: "0.9em",
   },
   ".cm-table-widget th, .cm-table-widget td": {
     border: "1px solid var(--border-color, #3e3e42)",
     padding: "0.4em 0.8em",
+    minWidth: "10em",
   },
   ".cm-table-widget th": {
     fontWeight: "600",


### PR DESCRIPTION
## Summary

- **Table overflow**: Remove `width: 100%` from table widgets so columns size naturally, add `overflow-x: auto` for horizontal scrolling on wide tables, and set a `min-width` on cells to prevent narrow-column word breaks
- **Checkbox styling**: Replace native checkbox appearance with accent-colored rounded squares, a hugeicon-derived checkmark SVG, and a pop animation on check

## Test plan

- [ ] Open a markdown file with a wide table (many columns or long cell content) — columns should no longer squeeze with mid-word wrapping
- [ ] Open a markdown file with task list items — checkboxes should use the accent color when checked, with a bounce animation
- [ ] Verify narrow tables that fit within the editor width render without a scrollbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)