### PR TITLE
Auto-focus new files and land caret after the heading prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-05-02
+
+- Fix the editor not auto-focusing after creating a new file from the command palette. The dialog now closes before the file is opened so its focus trap and focus restoration finish before the editor mounts and calls `view.focus()`.
+- Land the caret after the `# ` heading prompt when a new file opens so the user can type the title immediately.
+
 ## 2026-05-01
 
 - Update the app icon.

--- a/apps/desktop/src/components/command-palette/index.tsx
+++ b/apps/desktop/src/components/command-palette/index.tsx
@@ -73,10 +73,10 @@ export function CommandPalette() {
   function handleCreate() {
     if (!createPath) return;
 
+    close();
     void (async () => {
       await tauri.createFile(createPath);
       await openFile(createPath);
-      close();
     })();
   }
 

--- a/apps/desktop/src/components/editor-area/use-prosemark-editor.ts
+++ b/apps/desktop/src/components/editor-area/use-prosemark-editor.ts
@@ -100,9 +100,15 @@ function focusOnRevealExtension(isDisposed: () => boolean): Extension {
 }
 
 function restoreCursorPosition(view: EditorView, cursorPos: number) {
-  if (cursorPos <= 0) return;
-  const pos = Math.min(cursorPos, view.state.doc.length);
-  view.dispatch({ selection: { anchor: pos } });
+  if (cursorPos > 0) {
+    const pos = Math.min(cursorPos, view.state.doc.length);
+    view.dispatch({ selection: { anchor: pos } });
+    return;
+  }
+  // New-file template from create_file_impl is "# "; land caret after it so the user can type the title immediately.
+  if (view.state.doc.toString() === "# ") {
+    view.dispatch({ selection: { anchor: 2 } });
+  }
 }
 
 function restoreScrollPosition(


### PR DESCRIPTION
## Summary
- Closes the command-palette dialog before opening a newly-created file so its focus trap and focus restoration finish before `ProseMarkEditor` mounts and calls `view.focus()`. Previously the editor never kept focus because the dialog stole it back on close.
- When a fresh file opens with the default `# ` template and no stored cursor, lands the caret at position 2 so the user can start typing the title immediately.

## Test plan
- [ ] In the dev app, open the command palette → "Create New File" → type a name → Enter. Editor should be focused; typing should append to `# ` without an extra click.
- [ ] Open an existing file and confirm cursor restoration still respects the stored position.
- [ ] Switch between tabs and confirm the existing focus-on-reveal behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)