### PR TITLE
Fix Obsidian-style wikilink parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2026-05-02
 
+- Fix Obsidian-style wikilinks with aliases, escaped table pipes, and heading or block fragments so Sandbox vault links open the intended notes.
 - Unify the default theme accent to `#FF6A00` across light and dark modes.
 - Style task list checkboxes with the accent color and use a Hugeicons checkmark for the checked state.
 - Fix tables getting horizontally squeezed when a single cell holds a long word; columns now lay out at their natural widths and the table scrolls instead.

--- a/SPECs/Agent/worksheet-obsidian-wikilink-parsing.md
+++ b/SPECs/Agent/worksheet-obsidian-wikilink-parsing.md
@@ -1,0 +1,43 @@
+# Worksheet: Obsidian Wikilink Parsing
+
+## Task
+
+- TODO: Obsidian-style wikilink parsing, linked to `SPECs/obsidian-wikilink-parsing-spec.md`.
+- Worktree was clean before starting.
+
+## Reviewed
+
+- `apps/desktop/src/lib/wiki-links.ts`
+- `apps/desktop/src/components/editor-area/wiki-link-extension.ts`
+- `apps/desktop/src/components/editor-area/use-prosemark-editor.ts`
+- `apps/desktop/src-tauri/src/commands/search.rs`
+- `~/j/tmp/Sandbox` Obsidian sandbox vault links
+- `docs/workflows/agent-loop.md`
+
+## Findings
+
+- Writer parsed everything inside `[[...]]` as the file target, so piped aliases polluted lookup and folded display text.
+- Fragment links such as `[[Format your notes#^376b9d|second option]]` also polluted lookup.
+- Same-file fragment links had no way to resolve because the resolver did not receive the current file path.
+- Backend fuzzy search normalized query spaces to hyphens only, so exact stem lookup missed Sandbox files whose names contain spaces.
+
+## Plan
+
+- Add a pure wiki-link parser that splits destination, fragment, and display alias.
+- Feed the current file path into wiki-link click resolution for same-file fragments.
+- Keep fragment scrolling and embed rendering out of scope.
+- Make fuzzy search tolerant of both space and hyphen query variants.
+- Add targeted frontend and Rust tests, then run validation.
+
+## Results
+
+- Implemented parser and resolver support for Obsidian aliases, table-escaped pipes, note fragments, and same-file fragment links.
+- Updated folded wiki-link display to show alias text when present.
+- Made backend fuzzy search match both space-separated and hyphen-separated query variants so note names with spaces resolve.
+- Validation:
+  - `vp test apps/desktop/tests/wiki-links.test.ts` passed.
+  - `vp check` passed with two existing E2E JavaScript warnings.
+  - `vp test` passed.
+  - `cargo test` passed.
+  - `cargo clippy` passed with existing warnings outside this task.
+  - `cargo fmt --check` passed.

--- a/SPECs/obsidian-wikilink-parsing-spec.md
+++ b/SPECs/obsidian-wikilink-parsing-spec.md
@@ -1,0 +1,27 @@
+# Obsidian Wikilink Parsing Spec
+
+## Summary
+
+Writer's wiki-link resolver treated all text inside `[[...]]` as a filename. Obsidian vaults commonly use aliases, escaped table pipes, and heading or block fragments, so links like `[[No prior experience|I have no prior experience]]` failed by trying to open a note named `No prior experience|I have no prior experience`.
+
+## Goals
+
+- Parse Obsidian-style wiki-link aliases and resolve only the destination note name.
+- Display the alias text when a link has one.
+- Ignore heading and block fragments for file lookup so fragment-bearing links still open the right file.
+- Resolve same-file fragment links to the current document.
+- Support table-escaped piped links such as `[[Format your notes\|Formatting]]`.
+
+## Non-Goals
+
+- Scrolling to heading or block fragments. `SPECs/heading-anchor-links-spec.md` owns anchor scrolling.
+- Inline rendering for `![[...]]` embeds. `SPECs/obsidian-image-embed-spec.md` owns embed rendering.
+- Rewriting existing markdown syntax on save.
+
+## Acceptance Criteria
+
+- Clicking `[[No prior experience|I have no prior experience]]` opens `No prior experience.md` and displays `I have no prior experience`.
+- Clicking `[[Format your notes#^376b9d|second option]]` opens `Format your notes.md`.
+- Clicking `[[#^0f681f|with great power comes great responsibility]]` stays on the current file.
+- `[[Format your notes\|Formatting]]` behaves as a piped link for table compatibility.
+- Duplicate stems remain unresolved unless the link is path-qualified.

--- a/TODOS.md
+++ b/TODOS.md
@@ -46,7 +46,7 @@ Previously-triaged work organized by phase. Pull into `Up Next` as capacity open
 
 ## Done
 
-- Obsidian-style wikilink parsing: [`SPECs/obsidian-wikilink-parsing-spec.md`](SPECs/obsidian-wikilink-parsing-spec.md) — aliases, escaped table pipes, note fragments, and same-file fragment links now resolve like Obsidian. (`635deb1`)
+- Obsidian-style wikilink parsing: [`SPECs/obsidian-wikilink-parsing-spec.md`](SPECs/obsidian-wikilink-parsing-spec.md) — aliases, escaped table pipes, note fragments, and same-file fragment links now resolve like Obsidian. (`cf3d753`)
 - Sidebar toggle tab chrome shift: [`SPECs/sidebar-toggle-tab-chrome-shift-spec.md`](SPECs/sidebar-toggle-tab-chrome-shift-spec.md)
 - Rename bundled Codex theme preset to Writer.
 - Recent workspaces Dock menu: [`SPECs/recent-workspaces-dock-menu-spec.md`](SPECs/recent-workspaces-dock-menu-spec.md) — right-clicking the macOS Dock icon now shows existing recent workspaces above the default Dock menu items; choosing one opens a new workspace window or focuses an existing one.

--- a/TODOS.md
+++ b/TODOS.md
@@ -46,6 +46,7 @@ Previously-triaged work organized by phase. Pull into `Up Next` as capacity open
 
 ## Done
 
+- Obsidian-style wikilink parsing: [`SPECs/obsidian-wikilink-parsing-spec.md`](SPECs/obsidian-wikilink-parsing-spec.md) — aliases, escaped table pipes, note fragments, and same-file fragment links now resolve like Obsidian. (`635deb1`)
 - Sidebar toggle tab chrome shift: [`SPECs/sidebar-toggle-tab-chrome-shift-spec.md`](SPECs/sidebar-toggle-tab-chrome-shift-spec.md)
 - Rename bundled Codex theme preset to Writer.
 - Recent workspaces Dock menu: [`SPECs/recent-workspaces-dock-menu-spec.md`](SPECs/recent-workspaces-dock-menu-spec.md) — right-clicking the macOS Dock icon now shows existing recent workspaces above the default Dock menu items; choosing one opens a new workspace window or focuses an existing one.

--- a/apps/desktop/src-tauri/src/commands/search.rs
+++ b/apps/desktop/src-tauri/src/commands/search.rs
@@ -89,13 +89,25 @@ fn fuzzy_search_from(
         return Ok(Vec::new());
     }
 
-    let needle = query.to_lowercase().replace(' ', "-");
+    let normalized_query = query.to_lowercase();
+    let mut needles = Vec::from([normalized_query.clone()]);
+    let hyphen_query = normalized_query.replace(' ', "-");
+    if !needles.contains(&hyphen_query) {
+        needles.push(hyphen_query);
+    }
+    let space_query = normalized_query.replace('-', " ");
+    if !needles.contains(&space_query) {
+        needles.push(space_query);
+    }
 
     let mut results: Vec<SearchResult> = index
         .iter()
         .filter_map(|file| {
             let haystack = file.relative_path.to_lowercase();
-            let byte_start = haystack.find(&needle)?;
+            let (byte_start, needle) = needles
+                .iter()
+                .filter_map(|needle| haystack.find(needle).map(|start| (start, needle)))
+                .min_by_key(|(start, _)| *start)?;
 
             let char_start = haystack[..byte_start].chars().count();
             let char_len = needle.chars().count();
@@ -290,6 +302,18 @@ mod tests {
         let results = fuzzy_search_impl("readme", &index, 50);
         assert!(!results.is_empty());
         assert_eq!(results[0].filename, "readme.md");
+    }
+
+    #[test]
+    fn test_fuzzy_search_matches_space_separated_names() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("No prior experience.md"), "# Note").unwrap();
+        let (index, _dirs) = index_workspace_test(dir.path());
+
+        let results = fuzzy_search_impl("No prior experience", &index, 50);
+
+        assert!(!results.is_empty());
+        assert_eq!(results[0].filename, "No prior experience.md");
     }
 
     #[test]

--- a/apps/desktop/src/components/editor-area/use-prosemark-editor.ts
+++ b/apps/desktop/src/components/editor-area/use-prosemark-editor.ts
@@ -421,7 +421,7 @@ function createEditorExtensions(
     htmlBlockDecorations(),
     mermaidDecorations(),
     imageSrcResolver(getFilePath),
-    wikiLinkExtension(isDisposed),
+    wikiLinkExtension(getFilePath, isDisposed),
     markdownFormatting,
 
     EditorView.updateListener.of((update) => {

--- a/apps/desktop/src/components/editor-area/wiki-link-extension.ts
+++ b/apps/desktop/src/components/editor-area/wiki-link-extension.ts
@@ -18,7 +18,7 @@ import * as tauri from "@/lib/tauri";
 import { getFileStem } from "@/lib/paths";
 import { getWorkspaceRoot } from "@/hooks/workspace-api";
 import * as editorApi from "@/hooks/editor-api";
-import { canonicalWikiTarget, resolveWikiLink } from "@/lib/wiki-links";
+import { canonicalWikiTarget, parseWikiLink, resolveWikiLink } from "@/lib/wiki-links";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -84,7 +84,7 @@ class WikiLinkWidget extends WidgetType {
   toDOM(): HTMLElement {
     const span = document.createElement("span");
     span.className = "cm-wiki-link";
-    span.textContent = this.target;
+    span.textContent = parseWikiLink(this.target).displayText;
     return span;
   }
 
@@ -195,7 +195,7 @@ async function wikiLinkCompletions(context: CompletionContext): Promise<Completi
 // Click handling
 // ---------------------------------------------------------------------------
 
-function wikiLinkClickHandler(isDisposed: () => boolean): Extension {
+function wikiLinkClickHandler(getFilePath: () => string, isDisposed: () => boolean): Extension {
   return Prec.highest(
     EditorView.domEventHandlers({
       mousedown(event, view) {
@@ -215,7 +215,13 @@ function wikiLinkClickHandler(isDisposed: () => boolean): Extension {
         const workspaceRoot = getWorkspaceRoot();
         if (!workspaceRoot) return true;
 
-        void resolveWikiLink(rawTarget, workspaceRoot, tauri.fuzzySearch, tauri.fileExists)
+        void resolveWikiLink(
+          rawTarget,
+          workspaceRoot,
+          tauri.fuzzySearch,
+          tauri.fileExists,
+          getFilePath(),
+        )
           .then((result) => {
             if (isDisposed()) return;
             if (result.kind === "internal") {
@@ -280,10 +286,13 @@ const wikiLinkTheme = EditorView.baseTheme({
 // Public extension
 // ---------------------------------------------------------------------------
 
-export function wikiLinkExtension(isDisposed: () => boolean): Extension[] {
+export function wikiLinkExtension(
+  getFilePath: () => string,
+  isDisposed: () => boolean,
+): Extension[] {
   return [
     wikiLinkDecorations,
-    wikiLinkClickHandler(isDisposed),
+    wikiLinkClickHandler(getFilePath, isDisposed),
     wikiLinkTheme,
     autocompletion({
       override: [wikiLinkCompletions],

--- a/apps/desktop/src/lib/wiki-links.ts
+++ b/apps/desktop/src/lib/wiki-links.ts
@@ -1,7 +1,63 @@
-import { getFileStem } from "./paths";
+import { getFileStem, normalizePath } from "./paths";
 import type { SearchResult } from "@/types/fs";
 
 export type WikiLinkTarget = { kind: "internal"; path: string } | { kind: "unresolved" };
+export interface ParsedWikiLink {
+  raw: string;
+  target: string;
+  path: string;
+  fragment: string | null;
+  alias: string | null;
+  displayText: string;
+}
+
+function unescapeWikiText(text: string): string {
+  return text.replace(/\\\|/g, "|").trim();
+}
+
+function splitAlias(raw: string): { target: string; alias: string | null } {
+  const separator = raw.indexOf("|");
+  if (separator === -1) {
+    return { target: raw, alias: null };
+  }
+
+  const escapedSeparator = separator > 0 && raw[separator - 1] === "\\";
+  const targetEnd = escapedSeparator ? separator - 1 : separator;
+
+  return {
+    target: raw.slice(0, targetEnd),
+    alias: unescapeWikiText(raw.slice(separator + 1)),
+  };
+}
+
+function splitFragment(target: string): { path: string; fragment: string | null } {
+  const hashIndex = target.indexOf("#");
+  if (hashIndex === -1) {
+    return { path: target, fragment: null };
+  }
+
+  return {
+    path: target.slice(0, hashIndex),
+    fragment: target.slice(hashIndex + 1),
+  };
+}
+
+export function parseWikiLink(raw: string): ParsedWikiLink {
+  const { target, alias } = splitAlias(raw.trim());
+  const normalizedTarget = unescapeWikiText(target);
+  const { path, fragment } = splitFragment(normalizedTarget);
+  const normalizedPath = normalizeWikiTarget(path);
+  const fallbackDisplay = normalizedPath || (fragment ? `#${fragment}` : normalizedTarget);
+
+  return {
+    raw,
+    target: normalizedTarget,
+    path: normalizedPath,
+    fragment,
+    alias: alias || null,
+    displayText: alias || fallbackDisplay,
+  };
+}
 
 /**
  * Normalize a raw wiki-link target string for resolution:
@@ -9,6 +65,7 @@ export type WikiLinkTarget = { kind: "internal"; path: string } | { kind: "unres
  */
 export function normalizeWikiTarget(raw: string): string {
   let target = raw.trim().replace(/\\/g, "/");
+  target = target.replace(/^\/+/, "");
   const lower = target.toLowerCase();
   if (lower.endsWith(".md")) {
     target = target.slice(0, -3);
@@ -30,14 +87,21 @@ export async function resolveWikiLink(
   workspaceRoot: string,
   fuzzySearch: (query: string, limit?: number) => Promise<SearchResult[]>,
   fileExists: (path: string) => Promise<boolean>,
+  currentFilePath?: string | null,
 ): Promise<WikiLinkTarget> {
-  const target = normalizeWikiTarget(raw);
+  const link = parseWikiLink(raw);
+  const target = link.path;
+  if (!target && link.fragment && currentFilePath) {
+    return { kind: "internal", path: currentFilePath };
+  }
   if (!target) return { kind: "unresolved" };
 
   if (target.includes("/")) {
-    const fullPath = `${workspaceRoot}/${target}.md`;
-    if (await fileExists(fullPath)) {
-      return { kind: "internal", path: fullPath };
+    const basePath = normalizePath(`${workspaceRoot.replace(/\/$/, "")}/${target}`);
+    for (const fullPath of [`${basePath}.md`, `${basePath}.markdown`]) {
+      if (await fileExists(fullPath)) {
+        return { kind: "internal", path: fullPath };
+      }
     }
     return { kind: "unresolved" };
   }

--- a/apps/desktop/tests/wiki-links.test.ts
+++ b/apps/desktop/tests/wiki-links.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test, vi } from "vite-plus/test";
-import { normalizeWikiTarget, resolveWikiLink, canonicalWikiTarget } from "../src/lib/wiki-links";
+import {
+  canonicalWikiTarget,
+  normalizeWikiTarget,
+  parseWikiLink,
+  resolveWikiLink,
+} from "../src/lib/wiki-links";
 import type { SearchResult } from "../src/types/fs";
 
 // ---------------------------------------------------------------------------
@@ -38,6 +43,47 @@ describe("normalizeWikiTarget", () => {
 
   test("returns empty string for whitespace-only input", () => {
     expect(normalizeWikiTarget("   ")).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseWikiLink
+// ---------------------------------------------------------------------------
+
+describe("parseWikiLink", () => {
+  test("splits Obsidian aliases from targets", () => {
+    expect(parseWikiLink("No prior experience|I have no prior experience")).toMatchObject({
+      path: "No prior experience",
+      fragment: null,
+      alias: "I have no prior experience",
+      displayText: "I have no prior experience",
+    });
+  });
+
+  test("keeps heading and block fragments out of the file path", () => {
+    expect(parseWikiLink("Format your notes#^376b9d|second option")).toMatchObject({
+      path: "Format your notes",
+      fragment: "^376b9d",
+      alias: "second option",
+      displayText: "second option",
+    });
+  });
+
+  test("supports same-file fragment links", () => {
+    expect(parseWikiLink("#^0f681f|with great power comes great responsibility")).toMatchObject({
+      path: "",
+      fragment: "^0f681f",
+      alias: "with great power comes great responsibility",
+      displayText: "with great power comes great responsibility",
+    });
+  });
+
+  test("treats table-escaped pipes as Obsidian alias separators", () => {
+    expect(parseWikiLink("Format your notes\\|Formatting")).toMatchObject({
+      path: "Format your notes",
+      alias: "Formatting",
+      displayText: "Formatting",
+    });
   });
 });
 
@@ -156,6 +202,89 @@ describe("resolveWikiLink", () => {
     const fileExists = vi.fn();
 
     const result = await resolveWikiLink("Missing", "/vault", fuzzySearch, fileExists);
+    expect(result).toEqual({ kind: "unresolved" });
+  });
+
+  test("resolves piped links by target instead of alias text", async () => {
+    const fuzzySearch = vi.fn().mockResolvedValue([
+      makeResult({
+        path: "/vault/Adventurer/No prior experience.md",
+        relative_path: "Adventurer/No prior experience.md",
+      }),
+    ]);
+    const fileExists = vi.fn();
+
+    const result = await resolveWikiLink(
+      "No prior experience|I have no prior experience",
+      "/vault",
+      fuzzySearch,
+      fileExists,
+    );
+
+    expect(result).toEqual({
+      kind: "internal",
+      path: "/vault/Adventurer/No prior experience.md",
+    });
+  });
+
+  test("resolves fragments against the target file", async () => {
+    const fuzzySearch = vi.fn().mockResolvedValue([
+      makeResult({
+        path: "/vault/Formatting/Format your notes.md",
+        relative_path: "Formatting/Format your notes.md",
+      }),
+    ]);
+    const fileExists = vi.fn();
+
+    const result = await resolveWikiLink(
+      "Format your notes#^376b9d|second option",
+      "/vault",
+      fuzzySearch,
+      fileExists,
+    );
+
+    expect(result).toEqual({
+      kind: "internal",
+      path: "/vault/Formatting/Format your notes.md",
+    });
+  });
+
+  test("resolves same-file fragment links to the current file", async () => {
+    const fuzzySearch = vi.fn();
+    const fileExists = vi.fn();
+
+    const result = await resolveWikiLink(
+      "#^0f681f|with great power comes great responsibility",
+      "/vault",
+      fuzzySearch,
+      fileExists,
+      "/vault/Vault is just a local folder.md",
+    );
+
+    expect(result).toEqual({
+      kind: "internal",
+      path: "/vault/Vault is just a local folder.md",
+    });
+    expect(fuzzySearch).not.toHaveBeenCalled();
+  });
+
+  test("keeps duplicate stems unresolved unless the path is qualified", async () => {
+    const fuzzySearch = vi.fn().mockResolvedValue([
+      makeResult({
+        path: "/vault/Formatting/Callout.md",
+        filename: "Callout.md",
+        relative_path: "Formatting/Callout.md",
+      }),
+      makeResult({
+        path: "/vault/Other/Callout.md",
+        filename: "Callout.md",
+        relative_path: "Other/Callout.md",
+      }),
+    ]);
+    const fileExists = vi.fn().mockResolvedValue(false);
+
+    const result = await resolveWikiLink("Callout", "/vault", fuzzySearch, fileExists);
+
     expect(result).toEqual({ kind: "unresolved" });
   });
 });


### PR DESCRIPTION
## Summary
- Parse Obsidian wikilink aliases, escaped table pipes, note fragments, and same-file fragment links.
- Display alias text in folded wikilinks while resolving the destination note.
- Make fuzzy file search match space-separated note names as well as hyphen variants.

## Validation
- vp test apps/desktop/tests/wiki-links.test.ts
- vp test
- cargo test
- cargo fmt --check
- vp check (passes with existing E2E JS warnings)
- cargo clippy (passes with existing warnings outside this change)

## Notes
- Opened against the current default branch from feature/fix-wikilinks.
