### PR TITLE
Fix caret rendering after back/forward history navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-05-03
+
+- Fix the caret rendering offset after using back/forward navigation between files by avoiding transition-scheduled history swaps and using CodeMirror's measured cursor drawing.
+
 ## 2026-05-02
 
 - Fix Obsidian-style wikilinks with aliases, escaped table pipes, and heading or block fragments so Sandbox vault links open the intended notes.

--- a/SPECs/Agent/worksheet-caret-history-navigation.md
+++ b/SPECs/Agent/worksheet-caret-history-navigation.md
@@ -1,0 +1,40 @@
+# Worksheet: Caret Position After History Navigation
+
+## Task
+
+TODO: Caret position after history navigation (`SPECs/caret-history-navigation-spec.md`).
+
+## Reviewed
+
+- `TODOS.md`
+- `CHANGELOG.md`
+- `docs/workflows/agent-loop.md`
+- `docs/react-guidelines.md`
+- `docs/zustand.md`
+- `apps/desktop/src/components/editor-area/use-prosemark-editor.ts`
+- `apps/desktop/src/components/editor-area/editor-tabs.tsx`
+- `apps/desktop/src/components/sidebar/file-tree-node.tsx`
+- `apps/desktop/src/stores/editor-store.ts`
+- `apps/desktop/src/components/editor-area/editor-pane.tsx`
+- Prior commit `75792ef` (`Fix caret misplacement when switching tabs`)
+
+## Plan
+
+- Preserve the in-place CodeMirror document swap.
+- Compare sidebar click handling against back/forward button handling.
+- Preserve CodeMirror focus during mouse-driven history-button navigation.
+- Remove React transition scheduling from toolbar history navigation so it commits with the same discrete priority as sidebar file selection.
+- Keep CodeMirror `drawSelection()` enabled so cursor painting comes from CodeMirror's measured coordinates rather than native contenteditable caret painting.
+- Update changelog and TODO state after validation.
+
+## Results
+
+- Reopened after user verification showed the focus-only fix was insufficient.
+- Root cause: history navigation takes the same-pane in-place document swap path, but the toolbar buttons were scheduling that swap through React transition priority. Sidebar file clicks call `openFile()` directly, and when the active tab is already a file they also reuse the same editor and swap the document in place. The scheduling difference left the live editor view vulnerable to stale caret/layout state during back/forward navigation.
+- Added `onMouseDown={(event) => event.preventDefault()}` to the Back and Forward toolbar buttons.
+- Changed Back and Forward button clicks to call `navigateBack()` / `navigateForward()` directly instead of inside `startTransition`.
+- Enabled CodeMirror `drawSelection()` for the editor.
+- Removed the earlier cursor-prefix normalization and delayed-refocus experiments; they were not the root cause.
+- Validation:
+  - `vp check` passed with two existing E2E JS warnings unrelated to this change.
+  - `vp test` passed.

--- a/SPECs/caret-history-navigation-spec.md
+++ b/SPECs/caret-history-navigation-spec.md
@@ -1,0 +1,24 @@
+# Caret Position After History Navigation
+
+## Problem
+
+Back/forward navigation swaps files inside the active CodeMirror view, like sidebar file clicks do when the active tab is already a file. The important difference was the toolbar history buttons: they wrapped `navigateBack()` / `navigateForward()` in `startTransition`, while sidebar file clicks call `openFile()` directly.
+
+That made history navigation run through React transition priority even though it is a discrete input action that changes the active document in a live editor view. The visible failure mode was the caret painting at the `.cm-content` left edge while the rendered line started after the editor side padding.
+
+## Goal
+
+When navigating back or forward between files in the same tab, the visible caret should stay aligned with the rendered document content.
+
+## Approach
+
+- Keep the existing in-place document swap so ProseMark decorations do not flash raw markdown.
+- Keep the sidebar-style `mousedown` focus guard on history buttons so mouse navigation does not blur CodeMirror before the swap.
+- Run back/forward navigation as a direct discrete action instead of wrapping it in `startTransition`; history changes should commit at input priority, matching sidebar file selection.
+- Enable CodeMirror's `drawSelection()` extension so the visible cursor is drawn by CodeMirror from measured editor coordinates instead of relying on the browser's native contenteditable caret.
+
+## Validation
+
+- `vp check`
+- `vp test`
+- Manual smoke: click A -> B from the sidebar, then use Back -> Forward toolbar buttons with headings near the saved cursor and verify the caret remains visually aligned.

--- a/TODOS.md
+++ b/TODOS.md
@@ -46,6 +46,7 @@ Previously-triaged work organized by phase. Pull into `Up Next` as capacity open
 
 ## Done
 
+- Caret position after history navigation: [`SPECs/caret-history-navigation-spec.md`](SPECs/caret-history-navigation-spec.md)
 - Obsidian-style wikilink parsing: [`SPECs/obsidian-wikilink-parsing-spec.md`](SPECs/obsidian-wikilink-parsing-spec.md) — aliases, escaped table pipes, note fragments, and same-file fragment links now resolve like Obsidian. (`cf3d753`)
 - Sidebar toggle tab chrome shift: [`SPECs/sidebar-toggle-tab-chrome-shift-spec.md`](SPECs/sidebar-toggle-tab-chrome-shift-spec.md)
 - Rename bundled Codex theme preset to Writer.

--- a/apps/desktop/src/components/editor-area/editor-tabs.tsx
+++ b/apps/desktop/src/components/editor-area/editor-tabs.tsx
@@ -160,7 +160,8 @@ export function EditorTabs() {
       <div className="flex shrink-0 items-center gap-0.5">
         <button
           type="button"
-          onClick={() => startTransition(() => void navigateBack())}
+          onMouseDown={(event) => event.preventDefault()}
+          onClick={() => void navigateBack()}
           disabled={!canNavigateBack}
           className="flex h-[var(--chrome-control-height)] w-7 items-center justify-center rounded-lg text-base text-[var(--text-icon-muted)] transition-colors enabled:hover:bg-[var(--surface-subtle)] enabled:hover:text-[var(--text-secondary)] disabled:opacity-30"
           title="Back"
@@ -170,7 +171,8 @@ export function EditorTabs() {
         </button>
         <button
           type="button"
-          onClick={() => startTransition(() => void navigateForward())}
+          onMouseDown={(event) => event.preventDefault()}
+          onClick={() => void navigateForward()}
           disabled={!canNavigateForward}
           className="flex h-[var(--chrome-control-height)] w-7 items-center justify-center rounded-lg text-base text-[var(--text-icon-muted)] transition-colors enabled:hover:bg-[var(--surface-subtle)] enabled:hover:text-[var(--text-secondary)] disabled:opacity-30"
           title="Forward"

--- a/apps/desktop/src/components/editor-area/use-prosemark-editor.ts
+++ b/apps/desktop/src/components/editor-area/use-prosemark-editor.ts
@@ -1,5 +1,5 @@
 import { useRef, useCallback, useEffect } from "react";
-import { EditorView, ViewPlugin, keymap } from "@codemirror/view";
+import { EditorView, ViewPlugin, drawSelection, keymap } from "@codemirror/view";
 import {
   Compartment,
   EditorSelection,
@@ -396,6 +396,7 @@ function createEditorExtensions(
     linkNavigationExtension(getFilePath, isDisposed),
     editorBodyContextMenuExtension(getFilePath, isDisposed),
     setupCompartment.of(prosemarkBasicSetup()),
+    drawSelection(),
     prosemarkBaseThemeSetup(),
     search({ literal: true, createPanel: invisibleSearchPanel }),
     Prec.highest(


### PR DESCRIPTION
## Summary
- Stop wrapping `navigateBack()` / `navigateForward()` in `startTransition` so history navigation commits at discrete input priority, matching sidebar file selection.
- Add `onMouseDown` preventDefault guard to the toolbar Back/Forward buttons so CodeMirror keeps focus through the swap.
- Enable CodeMirror `drawSelection()` so the cursor is painted from measured editor coordinates rather than the native contenteditable caret.

See [`SPECs/caret-history-navigation-spec.md`](SPECs/caret-history-navigation-spec.md) for problem analysis and approach.

## Test plan
- [x] `vp check`
- [x] `vp test`
- [ ] Manual smoke: open file A, then file B from the sidebar; use Back / Forward toolbar buttons and confirm the caret stays visually aligned with the rendered content (especially near headings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)