### PR TITLE
Fix editor caret in dark mode and checkbox in prod builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 2026-05-03
 
 - Fix the caret rendering offset after using back/forward navigation between files by avoiding transition-scheduled history swaps and using CodeMirror's measured cursor drawing.
+- Fix the editor caret rendering as a black bar in dark mode by overriding `@codemirror/view`'s default `border-left: solid black` on `.cm-cursor` with the theme's `--text-primary` token at higher specificity.
+- Remove the scale "pop" animation that played when toggling a task checkbox.
+- Fix the task checkbox checkmark not appearing in production builds by allowing `data:` URIs in the Tauri `img-src` CSP directive (the inline SVG check icon was being blocked).
 
 ## 2026-05-02
 

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -30,7 +30,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' asset: https://asset.localhost https:; style-src 'self' 'unsafe-inline'",
+      "csp": "default-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' data: asset: https://asset.localhost https:; style-src 'self' 'unsafe-inline'",
       "assetProtocol": {
         "enable": true,
         "scope": ["**"]

--- a/apps/desktop/src/components/editor-area/prosemark-theme.css
+++ b/apps/desktop/src/components/editor-area/prosemark-theme.css
@@ -27,6 +27,14 @@
   --pm-syntax-invalid: oklch(75.93% 0.182 28.91);
 }
 
+/* @codemirror/view's base theme sets `.cm-cursor { border-left: 1.2px solid black }`,
+   which can win over prosemark's `border-left-color: var(--pm-cursor-color)` on
+   source order. Bump specificity here so the cursor stays readable in dark mode. */
+.cm-editor .cm-cursorLayer .cm-cursor,
+.cm-editor .cm-cursorLayer .cm-dropCursor {
+  border-left-color: var(--text-primary);
+}
+
 /* Editor layout — let parent handle scrolling */
 .cm-editor {
   height: auto;
@@ -100,18 +108,6 @@
 }
 
 /* Task checkboxes — replace native checkbox with hugeicon-style rounded square */
-@keyframes checkbox-pop {
-  0% {
-    transform: scale(0.85);
-  }
-  50% {
-    transform: scale(1.1);
-  }
-  100% {
-    transform: scale(1);
-  }
-}
-
 .cm-editor .cm-checkbox {
   appearance: none;
   -webkit-appearance: none;
@@ -134,7 +130,6 @@
   background-size: 20px 20px;
   background-position: center;
   background-repeat: no-repeat;
-  animation: checkbox-pop 0.2s ease-out;
 }
 
 /* Wiki-link autocomplete tooltip uses the UI font, not the editor font */


### PR DESCRIPTION
## Summary

Three small editor polish fixes:

- **Caret color in dark mode** — `@codemirror/view`'s base theme sets `.cm-cursor { border-left: 1.2px solid black }`, which won over prosemark's `border-left-color: var(--pm-cursor-color)` on source order. The caret rendered as a black bar on the dark background. Adds a higher-specificity `.cm-editor .cm-cursorLayer .cm-cursor` rule that pins the color to `var(--text-primary)`. Light mode already happened to look correct because the default black matched.
- **Checkbox pop animation** — drops the `checkbox-pop` keyframe and the `animation` declaration on `.cm-checkbox:checked`. The color/border transition is preserved.
- **Checkmark missing in prod builds** — Tauri's `img-src` CSP didn't include `data:`, so the inline SVG check icon used as the checked-state `background-image` was blocked in production (CSP isn't enforced in `tauri dev`, hence the dev/prod divergence). Adds `data:` to `img-src`. Allowing inline data URIs is standard for a desktop app — no remote attack surface, the SVGs are bundled with the app.

## Test plan

- [ ] In dark mode, the editor caret is white/light (not black).
- [ ] In light mode, the editor caret is still dark.
- [ ] Toggling a `- [ ]` task checkbox no longer plays a scale pop animation; the color transition still runs.
- [ ] Run `tauri build`, install/launch the bundled `.app`, toggle a task checkbox, and confirm the white checkmark renders inside the orange box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)