### PR TITLE
Add Preferences menu entry and tighten CLI install label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-05-06
+
+- Add a `Preferences…` entry (`Cmd+,`) to the Writer application menu, opening the existing Settings tab in the focused window via a `menu:open-preferences` Tauri event. Rename the macOS-only CLI install item from `Shell Command: Install 'writer' Command in PATH` to `Install 'writer' Command Line Tool…` (and the uninstall counterpart) and group it next to Preferences. See `SPECs/install-cli-menu-placement-spec.md`.
+
 ## 2026-05-04
 
 - Update the app icon.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2026-05-06
 
-- Add a `Preferences…` entry (`Cmd+,`) to the Writer application menu, opening the existing Settings tab in the focused window via a `menu:open-preferences` Tauri event. Rename the macOS-only CLI install item from `Shell Command: Install 'writer' Command in PATH` to `Install 'writer' Command Line Tool…` (and the uninstall counterpart) and group it next to Preferences. See `SPECs/install-cli-menu-placement-spec.md`.
+- Add a `Preferences…` entry (`Cmd+,`) to the Writer application menu that opens the Settings tab in the focused window. Rename the macOS-only CLI install item to `Install 'writer' Command Line Tool…` (and the uninstall counterpart) and group it next to Preferences. See `SPECs/install-cli-menu-placement-spec.md`.
 
 ## 2026-05-04
 

--- a/SPECs/install-cli-menu-placement-spec.md
+++ b/SPECs/install-cli-menu-placement-spec.md
@@ -2,27 +2,31 @@
 
 ## Summary
 
-The "Install 'writer' Command in PATH" action lives directly inside the macOS **Writer** application menu — the most prominent menu position in the app. Almost no end user needs a shell command, so the item is noise for everyone who is not a CLI power user. Move it out of the app menu and into Preferences so it stays discoverable for the few who want it without confronting everyone else.
+The "Install 'writer' Command in PATH" action is the third item in the macOS **Writer** application menu, with a long jargon-heavy label that confuses users who do not need a CLI. We will keep the action in the app menu (where macOS users expect optional, app-wide setup items) and place a conventional **Preferences…** entry alongside it, so the menu reads like a standard macOS app menu rather than a one-off pile of items. Tightening the CLI item's label and grouping reduces the noise without hiding the feature from the power users who want it.
 
 ## Background
 
-The CLI install action is wired in `apps/desktop/src-tauri/src/lib.rs:160` and added to the `Writer` submenu at line 168. The label cycles between two strings defined at the top of the same file:
+The CLI install action is wired in `apps/desktop/src-tauri/src/lib.rs:160` and added to the `Writer` submenu at line 168. The label cycles between two strings defined at `lib.rs:28-30`:
 
 - `Shell Command: Install 'writer' Command in PATH`
 - `Shell Command: Uninstall 'writer' Command in PATH`
 
-The underlying Rust install/uninstall logic lives in `apps/desktop/src-tauri/src/commands/shell_install.rs` and is exposed via three Tauri IPC commands already registered in `lib.rs`: `cli_status`, `install_cli`, `uninstall_cli`. So the backend is already callable from the React frontend — the issue is purely placement.
+The underlying Rust install/uninstall logic lives in `apps/desktop/src-tauri/src/commands/shell_install.rs` and is exposed via three Tauri IPC commands already registered in `lib.rs`: `cli_status`, `install_cli`, `uninstall_cli`.
+
+Settings exists today as a tab opened by the `open-settings` command in the command palette (`apps/desktop/src/components/command-palette/index.tsx:152`) using the `useOpenSettingsTab` hook in `apps/desktop/src/hooks/use-tabs.ts:162`. There is no app-menu entry for it. The keyboard shortcut convention on macOS for Preferences is `⌘,`.
 
 For context on the CLI itself, see [`SPECs/writer-cli-spec.md`](./writer-cli-spec.md). The PATH-install menu item shipped alongside the `writer` open CLI (see `Done` in `TODOS.md`).
 
 ## Problem Statement
 
-The Writer menu is the first thing the user sees when they open the app menu. It currently looks roughly like this on macOS:
+The Writer app menu currently looks like this on macOS:
 
 ```
 Writer
   About Writer
+  ─────
   Check for Updates…
+  ─────
   Shell Command: Install 'writer' Command in PATH
   ─────
   Services
@@ -34,107 +38,119 @@ Writer
   Quit Writer
 ```
 
-For a markdown editor whose target audience explicitly includes non-developer writers, surfacing a long, jargon-laden "Shell Command…" string in this position:
+Two things go wrong here:
 
-- Confuses users who do not know what PATH means.
-- Implies that installing the CLI is a normal setup step.
-- Triggers a `sudo`-style admin authorization prompt if clicked, which is alarming when stumbled into.
-- Crowds the only menu where standard macOS items (Services, Hide, Quit) are expected to dominate.
-
-Users who actually want the CLI are exactly the users who will look for it — they read the docs, the website, or search Settings.
+1. **The CLI label is long, jargon-heavy, and prefixed with `Shell Command:`.** A non-developer writer reading down the menu sees `PATH` and stops. The current copy is doing the work of a tooltip rather than a menu item.
+2. **There is no Preferences entry.** macOS users instinctively reach for the app menu (or `⌘,`) for app-wide settings. We have a Preferences surface — a Settings tab — but it is currently only reachable from the command palette. That makes the CLI item feel even more out of place: it is the only "optional setup" item in a menu that has no normal-setup item to anchor it.
 
 ## Current Behavior
 
-- Defined at `apps/desktop/src-tauri/src/lib.rs:28-30` (label constants) and `lib.rs:160-168` (menu wiring).
-- Toggled via `run_cli_toggle` at `lib.rs:237`, which calls `install_cli` / `uninstall_cli`.
-- Menu label is refreshed by `refresh_cli_menu` at `lib.rs:224`, which reads `cli_status` on demand.
-- Visible on every launch, regardless of whether the user has ever interacted with the CLI.
+- App-menu wiring: `apps/desktop/src-tauri/src/lib.rs:160-168` (build), `lib.rs:213-218` (event handler), `lib.rs:224-234` (label refresh on state change).
+- `run_cli_toggle` at `lib.rs:237` calls `install_cli` / `uninstall_cli`.
+- Settings tab is opened only via the command palette's `open-settings` command, which calls `useOpenSettingsTab` (`apps/desktop/src/hooks/use-tabs.ts:162`).
+- No `⌘,` accelerator is registered anywhere in the app menu today.
 
 ## Proposed Change
 
-Remove the item from the **Writer** application menu and add a single CLI install/uninstall control to **Preferences** under a new `Shell` section.
+Keep the CLI install action in the Writer app menu. Add a conventional macOS Preferences entry to the same menu. Tighten the CLI label and grouping so the menu reads cleanly.
 
-### UX in Preferences
+### New menu structure
 
-- New category in `apps/desktop/shared/settings.schema.json`: `"Shell"`.
-- One "action" row inside it. Schema-wise this is a new `type: "action"` (or similar) entry, since the existing `boolean | number | string | enum | range | list | color` types are all value editors. The action row renders a single button.
-- Label: `Writer command-line tool`.
-- Description: `Adds a 'writer' command to /usr/local/bin so you can open the app from a terminal. Most people don't need this.`
-- Button text mirrors the current menu logic:
-  - When `cli_status.installed` is `false` → button reads `Install`.
-  - When `cli_status.installed` is `true` → button reads `Uninstall`, and a small status line below reads `Installed at /usr/local/bin/writer`.
-- Same dialogs as today on success and failure (kept verbatim from `run_cli_install` / `run_cli_uninstall` in `lib.rs:246-297`), because the messages are already correct.
+```
+Writer
+  About Writer
+  ─────
+  Check for Updates…
+  ─────
+  Preferences…                                   ⌘,
+  Install 'writer' Command Line Tool…
+  ─────
+  Services
+  ─────
+  Hide Writer
+  Hide Others
+  Show All
+  ─────
+  Quit Writer
+```
 
-The menu wiring is deleted entirely. We do not keep both surfaces — see Alternatives.
+Notes:
 
-### Why Preferences
+- **`Preferences…`** with the standard `⌘,` accelerator. Opens the existing Settings tab.
+- **`Install 'writer' Command Line Tool…`** — drops the `Shell Command:` prefix and the `in PATH` postfix. Trailing ellipsis indicates the action prompts the user (admin authorization). When the symlink already exists the label flips to `Uninstall 'writer' Command Line Tool…`, matching the existing toggle behavior.
+- Both items live in the same group between `Check for Updates…` and `Services`. This is the conventional macOS slot for app-level preferences and optional integrations, and it gives the CLI item company instead of leaving it as the only oddity.
 
-- Preferences is where macOS users expect "set up an optional integration" controls.
-- The Settings panel is already schema-driven (`apps/desktop/src/components/settings-panel/index.tsx`), so adding a section is a small, additive change rather than a fork in UI conventions.
-- A power user looking for the CLI will check `⌘,` first; placement there is more discoverable than buried in the app menu.
+### Wiring Preferences from Rust → React
+
+The menu handler cannot directly call the React-side `useOpenSettingsTab` hook. The cheapest way is to emit a Tauri event from the menu handler and listen for it in the frontend:
+
+- Add a new menu event id `preferences.open`.
+- In `app.on_menu_event` (`lib.rs:213`), match the new id and `app.emit("menu:open-preferences", ())` (or per-window equivalent so multi-window works).
+- In the React app shell (`apps/desktop/src/components/app-layout.tsx` or a new small hook `apps/desktop/src/hooks/use-menu-events.ts`), subscribe via `listen("menu:open-preferences", …)` and call `useOpenSettingsTab`.
+
+Per project guideline, the listener subscription lives in a custom hook, not inside a component's `useEffect`.
 
 ### Recommendation
 
-**Move to Preferences and remove from the app menu.** The other options are weaker (see below).
+**Keep the CLI item in the app menu, add Preferences alongside, retitle the CLI item.** This was the user's chosen direction; the alternatives below were considered and rejected.
 
 ## Alternatives Considered
 
-### A. Hide entirely; require terminal install via docs
+### A. Move the CLI install into Preferences and remove from menu
 
-Rejected. The current menu item works without the user having to copy-paste a `ln -s` command, and removing it without a replacement makes the CLI feel hidden / unsupported. Keeping a UI affordance is cheap.
+Earlier draft of this spec. Rejected: it makes the feature less discoverable for the audience that actually wants it (power users open the app menu first), and leaves the app menu with a non-standard shape (no Preferences entry). The user explicitly chose to keep both items in the app menu.
 
-### B. Keep in menu but rename / shorten
+### B. Hide the CLI item entirely; require terminal install via docs
 
-Rejected. Even with a tighter label like `Install Command Line Tool…`, the Writer menu is still the wrong home for an optional power-user setup action — every user sees it on first launch. Renaming reduces the noise but does not fix the placement.
+Rejected. The current menu item works without making the user copy-paste a `ln -s` invocation. Removing it without a replacement makes the CLI feel hidden / unsupported.
 
-### C. Gate behind an "Advanced mode" toggle
+### C. Keep the long original label
 
-Rejected for v1. We do not currently have an Advanced-mode concept and inventing one for a single action is over-engineering. If/when other power-user surfaces accumulate, revisit.
+Rejected. The label was the most-cited source of confusion ("Shell Command:", "PATH"). Tightening to `Install 'writer' Command Line Tool…` keeps the meaning intact while reading like a normal menu item.
 
-### D. Move it under Edit / Window / a new top-level menu
+### D. Put the CLI item under a dedicated "Tools" top-level menu
 
-Rejected. Edit and Window have well-defined macOS conventions and a "Tools" menu would be a one-item menu just for this. Preferences is the natural home.
+Rejected. A top-level menu with a single item is awkward and adds chrome before any second item lands.
 
-### E. Keep both menu and Preferences
+### E. Gate the CLI item behind an "Advanced mode" toggle
 
-Rejected. Two surfaces for the same action means we have to keep two refresh paths for the install state in sync. The menu refresh (`refresh_cli_menu` at `lib.rs:224`) already exists, but adding a second source of truth doubles the surface for bugs (e.g. user installs from Preferences, menu label is now stale) for no real win.
+Rejected for v1. We do not have an Advanced-mode concept and inventing one for a single action is over-engineering. Keep the door open for later if other power-user surfaces accumulate.
 
 ## Files Expected To Change
 
-Backend (Rust):
+Backend (Rust) — only `lib.rs`; install/uninstall primitives are unchanged:
 
-- `apps/desktop/src-tauri/src/lib.rs` — delete `CLI_MENU_INSTALL_LABEL` / `CLI_MENU_UNINSTALL_LABEL` constants, `CliMenuItem` struct, `cli_item` build, `refresh_cli_menu`, `run_cli_toggle`, `run_cli_install`, `run_cli_uninstall`, and the `cli.toggle` event arm. Keep the IPC commands themselves and the success/error dialog text — both move to the frontend invocation path or are reused by it.
-- The IPC commands `cli_status`, `install_cli`, `uninstall_cli` in `apps/desktop/src-tauri/src/commands/shell_install.rs` are unchanged.
+- `apps/desktop/src-tauri/src/lib.rs`:
+  - Update `CLI_MENU_INSTALL_LABEL` / `CLI_MENU_UNINSTALL_LABEL` to the new strings (`Install 'writer' Command Line Tool…` / `Uninstall 'writer' Command Line Tool…`).
+  - Add a new `Preferences…` menu item with `⌘,` accelerator and id `preferences.open`, inserted just before the CLI item in the `Writer` submenu builder (around `lib.rs:160-168`).
+  - Add an event arm in `app.on_menu_event` (`lib.rs:213`) that emits `menu:open-preferences` to the focused window.
+- `apps/desktop/src-tauri/src/commands/shell_install.rs` — unchanged.
 
 Frontend (React):
 
-- `apps/desktop/shared/settings.schema.json` — add a `Shell` section with one `action`-type entry for the CLI install/uninstall control. New entries do not need a `default` value because they are not stored, but schema validation in `apps/desktop/src-tauri/src/config.rs` may need a small allowance for the new type.
-- `apps/desktop/src/lib/settings-schema.ts` — extend the `SettingDef.type` union to include `"action"` (mirrors the Rust side).
-- `apps/desktop/src/components/settings-panel/setting-control.tsx` — add an `ActionControl` branch that calls a callback instead of writing a value.
-- `apps/desktop/src/components/settings-panel/index.tsx` — wire the action handler for the CLI key. The handler `invoke`s `cli_status`, then either `install_cli` or `uninstall_cli`, then re-reads `cli_status` to refresh the button label. A small `useCliInstallStatus()` hook in `apps/desktop/src/hooks/use-cli-install-status.ts` keeps the logic out of the component (per project guideline that side effects live in hooks).
-- Reuse the existing `tauri-plugin-dialog` to show the same success / failure dialogs. Or replace with inline status text under the row — see Open Questions.
+- `apps/desktop/src/hooks/use-menu-events.ts` (new) — subscribes to `menu:open-preferences` and calls `useOpenSettingsTab`. Per project rule, the `listen()` subscription lives in this hook, not inline in a component.
+- `apps/desktop/src/components/app-layout.tsx` — call the new hook once at the top level so the listener is mounted for the lifetime of the window.
 
 Tests:
 
-- Rust: `commands/shell_install.rs` already has unit tests for the symlink classification logic. Nothing to add or remove there since the install primitives are unchanged.
-- Frontend: existing settings-panel tests, if any, should still pass. Add a test that the action button invokes the correct IPC command based on `cli_status.installed`.
+- Rust: existing unit tests in `commands/shell_install.rs` continue to pass; no new Rust tests needed since menu-handler logic is a one-liner emit.
+- Frontend: add a test that the new hook opens the settings tab in response to a synthesized `menu:open-preferences` event.
 
 Docs:
 
-- `CHANGELOG.md` — note the move under user-visible changes when shipped.
-- The Writer CLI spec ([`SPECs/writer-cli-spec.md`](./writer-cli-spec.md)) does not need an update; it already lists "macOS PATH-install menu item" as shipped, and that menu item is being repositioned, not removed in capability.
+- `CHANGELOG.md` — note the relabel and the new Preferences menu entry under user-visible changes when shipped.
+- The Writer CLI spec ([`SPECs/writer-cli-spec.md`](./writer-cli-spec.md)) does not need an update; the menu item moves slot and gets a new label but its capability is unchanged.
 
 ## Open Questions
 
-- **Inline status vs dialog?** The current flow shows a system dialog ("The `writer` command is now installed at /usr/local/bin/writer …"). In Settings, an inline status line under the row may feel quieter and more native. Recommendation: keep the dialog on success the first time (so the user sees the install path and the example invocation) and rely on the live button label for subsequent state changes.
-- **What about Linux / Windows?** Today `shell_install` is `#[cfg(target_os = "macos")]`. The Settings row should be conditionally hidden on non-macOS so we do not show a control that does nothing. This matches the current menu, which is already macOS-only.
+- **Multi-window behavior:** the existing menu handler runs against `AppHandle` not a specific window. Confirm the `menu:open-preferences` event is routed to the focused window (e.g., `app.get_focused_window()` or `WebviewWindow::emit`) so Preferences opens in the correct workspace tab strip rather than every window at once.
+- **Linux / Windows:** today `shell_install` is `#[cfg(target_os = "macos")]`, so the Install CLI item is macOS-only. The new Preferences entry should appear on all desktop platforms; confirm the rest of the app menu builder is reused on non-macOS or whether platform-specific branches are needed.
 
 ## Acceptance Criteria
 
-- The `Shell Command: Install 'writer' Command in PATH` menu item no longer appears in the Writer application menu on macOS.
-- Preferences shows a `Shell` section with a single row that says `Writer command-line tool`, an explanatory line, and a button.
-- Clicking `Install` runs the same install flow as the old menu item, including the elevation prompt when needed.
-- Once installed, the button reads `Uninstall`, and clicking it removes the symlink.
-- The status line / button text reflects the actual install state on Preferences open and after each click — no stale label.
-- On Linux and Windows, the `Shell` section is not shown (or shows a one-liner explaining macOS-only support — TBD per Open Questions).
-- No regression in the existing CLI install/uninstall behavior; existing Rust unit tests in `shell_install.rs` continue to pass.
+- The Writer app menu on macOS contains, in order: `About Writer`, separator, `Check for Updates…`, separator, `Preferences…` (`⌘,`), `Install 'writer' Command Line Tool…`, separator, `Services`, …, `Quit Writer`.
+- `Preferences…` opens the existing Settings tab in the focused window. The keyboard shortcut `⌘,` does the same.
+- The CLI item's label is `Install 'writer' Command Line Tool…` when the symlink is missing, and `Uninstall 'writer' Command Line Tool…` when it is installed. Toggling continues to refresh the label correctly.
+- Clicking the CLI item runs the same install/uninstall flow as today, including the elevation prompt and success/error dialogs.
+- Existing Rust unit tests in `shell_install.rs` continue to pass.
+- No regression: the command-palette `open-settings` entry continues to work.

--- a/SPECs/install-cli-menu-placement-spec.md
+++ b/SPECs/install-cli-menu-placement-spec.md
@@ -1,0 +1,140 @@
+# Install CLI Menu Placement Spec
+
+## Summary
+
+The "Install 'writer' Command in PATH" action lives directly inside the macOS **Writer** application menu — the most prominent menu position in the app. Almost no end user needs a shell command, so the item is noise for everyone who is not a CLI power user. Move it out of the app menu and into Preferences so it stays discoverable for the few who want it without confronting everyone else.
+
+## Background
+
+The CLI install action is wired in `apps/desktop/src-tauri/src/lib.rs:160` and added to the `Writer` submenu at line 168. The label cycles between two strings defined at the top of the same file:
+
+- `Shell Command: Install 'writer' Command in PATH`
+- `Shell Command: Uninstall 'writer' Command in PATH`
+
+The underlying Rust install/uninstall logic lives in `apps/desktop/src-tauri/src/commands/shell_install.rs` and is exposed via three Tauri IPC commands already registered in `lib.rs`: `cli_status`, `install_cli`, `uninstall_cli`. So the backend is already callable from the React frontend — the issue is purely placement.
+
+For context on the CLI itself, see [`SPECs/writer-cli-spec.md`](./writer-cli-spec.md). The PATH-install menu item shipped alongside the `writer` open CLI (see `Done` in `TODOS.md`).
+
+## Problem Statement
+
+The Writer menu is the first thing the user sees when they open the app menu. It currently looks roughly like this on macOS:
+
+```
+Writer
+  About Writer
+  Check for Updates…
+  Shell Command: Install 'writer' Command in PATH
+  ─────
+  Services
+  ─────
+  Hide Writer
+  Hide Others
+  Show All
+  ─────
+  Quit Writer
+```
+
+For a markdown editor whose target audience explicitly includes non-developer writers, surfacing a long, jargon-laden "Shell Command…" string in this position:
+
+- Confuses users who do not know what PATH means.
+- Implies that installing the CLI is a normal setup step.
+- Triggers a `sudo`-style admin authorization prompt if clicked, which is alarming when stumbled into.
+- Crowds the only menu where standard macOS items (Services, Hide, Quit) are expected to dominate.
+
+Users who actually want the CLI are exactly the users who will look for it — they read the docs, the website, or search Settings.
+
+## Current Behavior
+
+- Defined at `apps/desktop/src-tauri/src/lib.rs:28-30` (label constants) and `lib.rs:160-168` (menu wiring).
+- Toggled via `run_cli_toggle` at `lib.rs:237`, which calls `install_cli` / `uninstall_cli`.
+- Menu label is refreshed by `refresh_cli_menu` at `lib.rs:224`, which reads `cli_status` on demand.
+- Visible on every launch, regardless of whether the user has ever interacted with the CLI.
+
+## Proposed Change
+
+Remove the item from the **Writer** application menu and add a single CLI install/uninstall control to **Preferences** under a new `Shell` section.
+
+### UX in Preferences
+
+- New category in `apps/desktop/shared/settings.schema.json`: `"Shell"`.
+- One "action" row inside it. Schema-wise this is a new `type: "action"` (or similar) entry, since the existing `boolean | number | string | enum | range | list | color` types are all value editors. The action row renders a single button.
+- Label: `Writer command-line tool`.
+- Description: `Adds a 'writer' command to /usr/local/bin so you can open the app from a terminal. Most people don't need this.`
+- Button text mirrors the current menu logic:
+  - When `cli_status.installed` is `false` → button reads `Install`.
+  - When `cli_status.installed` is `true` → button reads `Uninstall`, and a small status line below reads `Installed at /usr/local/bin/writer`.
+- Same dialogs as today on success and failure (kept verbatim from `run_cli_install` / `run_cli_uninstall` in `lib.rs:246-297`), because the messages are already correct.
+
+The menu wiring is deleted entirely. We do not keep both surfaces — see Alternatives.
+
+### Why Preferences
+
+- Preferences is where macOS users expect "set up an optional integration" controls.
+- The Settings panel is already schema-driven (`apps/desktop/src/components/settings-panel/index.tsx`), so adding a section is a small, additive change rather than a fork in UI conventions.
+- A power user looking for the CLI will check `⌘,` first; placement there is more discoverable than buried in the app menu.
+
+### Recommendation
+
+**Move to Preferences and remove from the app menu.** The other options are weaker (see below).
+
+## Alternatives Considered
+
+### A. Hide entirely; require terminal install via docs
+
+Rejected. The current menu item works without the user having to copy-paste a `ln -s` command, and removing it without a replacement makes the CLI feel hidden / unsupported. Keeping a UI affordance is cheap.
+
+### B. Keep in menu but rename / shorten
+
+Rejected. Even with a tighter label like `Install Command Line Tool…`, the Writer menu is still the wrong home for an optional power-user setup action — every user sees it on first launch. Renaming reduces the noise but does not fix the placement.
+
+### C. Gate behind an "Advanced mode" toggle
+
+Rejected for v1. We do not currently have an Advanced-mode concept and inventing one for a single action is over-engineering. If/when other power-user surfaces accumulate, revisit.
+
+### D. Move it under Edit / Window / a new top-level menu
+
+Rejected. Edit and Window have well-defined macOS conventions and a "Tools" menu would be a one-item menu just for this. Preferences is the natural home.
+
+### E. Keep both menu and Preferences
+
+Rejected. Two surfaces for the same action means we have to keep two refresh paths for the install state in sync. The menu refresh (`refresh_cli_menu` at `lib.rs:224`) already exists, but adding a second source of truth doubles the surface for bugs (e.g. user installs from Preferences, menu label is now stale) for no real win.
+
+## Files Expected To Change
+
+Backend (Rust):
+
+- `apps/desktop/src-tauri/src/lib.rs` — delete `CLI_MENU_INSTALL_LABEL` / `CLI_MENU_UNINSTALL_LABEL` constants, `CliMenuItem` struct, `cli_item` build, `refresh_cli_menu`, `run_cli_toggle`, `run_cli_install`, `run_cli_uninstall`, and the `cli.toggle` event arm. Keep the IPC commands themselves and the success/error dialog text — both move to the frontend invocation path or are reused by it.
+- The IPC commands `cli_status`, `install_cli`, `uninstall_cli` in `apps/desktop/src-tauri/src/commands/shell_install.rs` are unchanged.
+
+Frontend (React):
+
+- `apps/desktop/shared/settings.schema.json` — add a `Shell` section with one `action`-type entry for the CLI install/uninstall control. New entries do not need a `default` value because they are not stored, but schema validation in `apps/desktop/src-tauri/src/config.rs` may need a small allowance for the new type.
+- `apps/desktop/src/lib/settings-schema.ts` — extend the `SettingDef.type` union to include `"action"` (mirrors the Rust side).
+- `apps/desktop/src/components/settings-panel/setting-control.tsx` — add an `ActionControl` branch that calls a callback instead of writing a value.
+- `apps/desktop/src/components/settings-panel/index.tsx` — wire the action handler for the CLI key. The handler `invoke`s `cli_status`, then either `install_cli` or `uninstall_cli`, then re-reads `cli_status` to refresh the button label. A small `useCliInstallStatus()` hook in `apps/desktop/src/hooks/use-cli-install-status.ts` keeps the logic out of the component (per project guideline that side effects live in hooks).
+- Reuse the existing `tauri-plugin-dialog` to show the same success / failure dialogs. Or replace with inline status text under the row — see Open Questions.
+
+Tests:
+
+- Rust: `commands/shell_install.rs` already has unit tests for the symlink classification logic. Nothing to add or remove there since the install primitives are unchanged.
+- Frontend: existing settings-panel tests, if any, should still pass. Add a test that the action button invokes the correct IPC command based on `cli_status.installed`.
+
+Docs:
+
+- `CHANGELOG.md` — note the move under user-visible changes when shipped.
+- The Writer CLI spec ([`SPECs/writer-cli-spec.md`](./writer-cli-spec.md)) does not need an update; it already lists "macOS PATH-install menu item" as shipped, and that menu item is being repositioned, not removed in capability.
+
+## Open Questions
+
+- **Inline status vs dialog?** The current flow shows a system dialog ("The `writer` command is now installed at /usr/local/bin/writer …"). In Settings, an inline status line under the row may feel quieter and more native. Recommendation: keep the dialog on success the first time (so the user sees the install path and the example invocation) and rely on the live button label for subsequent state changes.
+- **What about Linux / Windows?** Today `shell_install` is `#[cfg(target_os = "macos")]`. The Settings row should be conditionally hidden on non-macOS so we do not show a control that does nothing. This matches the current menu, which is already macOS-only.
+
+## Acceptance Criteria
+
+- The `Shell Command: Install 'writer' Command in PATH` menu item no longer appears in the Writer application menu on macOS.
+- Preferences shows a `Shell` section with a single row that says `Writer command-line tool`, an explanatory line, and a button.
+- Clicking `Install` runs the same install flow as the old menu item, including the elevation prompt when needed.
+- Once installed, the button reads `Uninstall`, and clicking it removes the symlink.
+- The status line / button text reflects the actual install state on Preferences open and after each click — no stale label.
+- On Linux and Windows, the `Shell` section is not shown (or shows a one-liner explaining macOS-only support — TBD per Open Questions).
+- No regression in the existing CLI install/uninstall behavior; existing Rust unit tests in `shell_install.rs` continue to pass.

--- a/TODOS.md
+++ b/TODOS.md
@@ -6,7 +6,7 @@
 
 ## Up Next
 
-- Install CLI menu placement: [`SPECs/install-cli-menu-placement-spec.md`](SPECs/install-cli-menu-placement-spec.md) — move the `Install 'writer' Command in PATH` action out of the macOS Writer app menu and into Preferences under a new `Shell` section.
+- Install CLI menu placement: [`SPECs/install-cli-menu-placement-spec.md`](SPECs/install-cli-menu-placement-spec.md) — keep the CLI install action in the macOS Writer app menu, add a conventional `Preferences…` entry (`⌘,`) alongside it, and tighten the CLI item's label.
 
 ## Blockers At A Glance
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -6,8 +6,6 @@
 
 ## Up Next
 
-- Install CLI menu placement: [`SPECs/install-cli-menu-placement-spec.md`](SPECs/install-cli-menu-placement-spec.md) — keep the CLI install action in the macOS Writer app menu, add a conventional `Preferences…` entry (`⌘,`) alongside it, and tighten the CLI item's label.
-
 ## Blockers At A Glance
 
 - `workspace-snapshot` → `workspace-switch-hang` (shipped; blocker cleared — snapshot depends on the primitives that landed)

--- a/TODOS.md
+++ b/TODOS.md
@@ -6,6 +6,8 @@
 
 ## Up Next
 
+- Install CLI menu placement: [`SPECs/install-cli-menu-placement-spec.md`](SPECs/install-cli-menu-placement-spec.md) — move the `Install 'writer' Command in PATH` action out of the macOS Writer app menu and into Preferences under a new `Shell` section.
+
 ## Blockers At A Glance
 
 - `workspace-snapshot` → `workspace-switch-hang` (shipped; blocker cleared — snapshot depends on the primitives that landed)

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -25,9 +25,9 @@ use tauri::RunEvent;
 use tauri::{DragDropEvent, Emitter, Manager, WebviewWindow, WindowEvent};
 
 #[cfg(target_os = "macos")]
-const CLI_MENU_INSTALL_LABEL: &str = "Shell Command: Install 'writer' Command in PATH";
+const CLI_MENU_INSTALL_LABEL: &str = "Install 'writer' Command Line Tool…";
 #[cfg(target_os = "macos")]
-const CLI_MENU_UNINSTALL_LABEL: &str = "Shell Command: Uninstall 'writer' Command in PATH";
+const CLI_MENU_UNINSTALL_LABEL: &str = "Uninstall 'writer' Command Line Tool…";
 
 #[cfg(target_os = "macos")]
 struct CliMenuItem(MenuItem<tauri::Wry>);
@@ -156,6 +156,10 @@ fn install_app_menu(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let check_item = MenuItemBuilder::with_id("updater.check", "Check for Updates…").build(app)?;
 
+    let preferences_item = MenuItemBuilder::with_id("preferences.open", "Preferences…")
+        .accelerator("CmdOrCtrl+,")
+        .build(app)?;
+
     #[cfg(target_os = "macos")]
     let cli_item = MenuItemBuilder::with_id("cli.toggle", CLI_MENU_INSTALL_LABEL).build(app)?;
 
@@ -163,9 +167,11 @@ fn install_app_menu(
         let b = SubmenuBuilder::new(app, "Writer")
             .item(&PredefinedMenuItem::about(app, Some("About Writer"), None)?)
             .separator()
-            .item(&check_item);
+            .item(&check_item)
+            .separator()
+            .item(&preferences_item);
         #[cfg(target_os = "macos")]
-        let b = b.separator().item(&cli_item);
+        let b = b.item(&cli_item);
         b.separator()
             .item(&PredefinedMenuItem::services(app, None)?)
             .separator()
@@ -212,12 +218,32 @@ fn install_app_menu(
 
     app.on_menu_event(|app, event| match event.id().0.as_str() {
         "updater.check" => updater::start_check(app.clone(), true),
+        "preferences.open" => emit_to_focused_window(app, "menu:open-preferences"),
         #[cfg(target_os = "macos")]
         "cli.toggle" => run_cli_toggle(app.clone()),
         _ => {}
     });
 
     Ok(())
+}
+
+/// Send a fire-and-forget event to whichever webview window currently has
+/// focus, falling back to the first visible window if none report focus
+/// (e.g. focus changed mid-click). The native menu handler runs on the
+/// `AppHandle` and isn't tied to a window, so we resolve the target here.
+fn emit_to_focused_window(app: &tauri::AppHandle, event: &str) {
+    let target = app
+        .webview_windows()
+        .into_values()
+        .find(|w| w.is_focused().unwrap_or(false))
+        .or_else(|| {
+            app.webview_windows()
+                .into_values()
+                .find(|w| w.is_visible().unwrap_or(false))
+        });
+    if let Some(window) = target {
+        let _ = window.emit(event, ());
+    }
 }
 
 #[cfg(target_os = "macos")]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -227,22 +227,27 @@ fn install_app_menu(
     Ok(())
 }
 
-/// Send a fire-and-forget event to whichever webview window currently has
-/// focus, falling back to the first visible window if none report focus
-/// (e.g. focus changed mid-click). The native menu handler runs on the
-/// `AppHandle` and isn't tied to a window, so we resolve the target here.
+/// Send an event to whichever webview window currently has focus, scoped to
+/// that window so other windows don't react. The native menu handler runs on
+/// the `AppHandle` and isn't tied to a window, so we resolve the target here.
+///
+/// Fallback order if no window reports focus (focus race, platform error
+/// from `is_focused`): the main window if visible, else any visible window.
+/// `webview_windows()` returns a `HashMap` whose iteration order is
+/// non-deterministic, so the explicit main-window preference matters.
 fn emit_to_focused_window(app: &tauri::AppHandle, event: &str) {
-    let target = app
-        .webview_windows()
-        .into_values()
+    let windows = app.webview_windows();
+    let target = windows
+        .values()
         .find(|w| w.is_focused().unwrap_or(false))
         .or_else(|| {
-            app.webview_windows()
-                .into_values()
-                .find(|w| w.is_visible().unwrap_or(false))
-        });
+            windows
+                .get(MAIN_WINDOW_LABEL)
+                .filter(|w| w.is_visible().unwrap_or(false))
+        })
+        .or_else(|| windows.values().find(|w| w.is_visible().unwrap_or(false)));
     if let Some(window) = target {
-        let _ = window.emit(event, ());
+        let _ = app.emit_to(window.label(), event, ());
     }
 }
 

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -5,6 +5,7 @@ import { WindowTitle } from "./components/window-title";
 import { useWorkspace, useIsStartupResolved } from "./hooks/use-workspace";
 import { useFileWatcher } from "./hooks/use-file-watcher";
 import { useKeyboardShortcuts } from "./hooks/use-keyboard-shortcuts";
+import { useMenuEvents } from "./hooks/use-menu-events";
 import { useOpenDrop } from "./hooks/use-open-drop";
 import "./App.css";
 
@@ -14,6 +15,7 @@ function App() {
 
   useFileWatcher();
   useKeyboardShortcuts();
+  useMenuEvents();
   useOpenDrop();
 
   if (!isStartupResolved) {

--- a/apps/desktop/src/hooks/use-keyboard-shortcuts.ts
+++ b/apps/desktop/src/hooks/use-keyboard-shortcuts.ts
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { useUIStore } from "@/stores/ui-store";
-import { createSettingsTab, useEditorStore } from "@/stores/editor-store";
+import { useEditorStore } from "@/stores/editor-store";
 import { useWorkspaceStore } from "@/stores/workspace-store";
 import { toggleSidebar } from "@/hooks/use-sidebar";
 
@@ -29,7 +29,6 @@ export function useKeyboardShortcuts() {
         closeActiveTab,
         navigateBack,
         navigateForward,
-        openOrFocus,
       } = useEditorStore.getState();
 
       // Alt+Arrow: history navigation when no editable target is focused;
@@ -43,13 +42,6 @@ export function useKeyboardShortcuts() {
       if (e.altKey && !e.shiftKey && e.key === "ArrowRight" && !isEditableTargetFocused()) {
         e.preventDefault();
         void navigateForward();
-        return;
-      }
-
-      // Cmd+, — open or focus settings tab
-      if (mod && e.key === ",") {
-        e.preventDefault();
-        openOrFocus((tab) => tab.location.kind === "settings", createSettingsTab);
         return;
       }
 

--- a/apps/desktop/src/hooks/use-menu-events.ts
+++ b/apps/desktop/src/hooks/use-menu-events.ts
@@ -1,0 +1,16 @@
+import { useEffect } from "react";
+import { listen } from "@tauri-apps/api/event";
+import { useOpenSettingsTab } from "./use-tabs";
+
+export function useMenuEvents() {
+  const openSettingsTab = useOpenSettingsTab();
+
+  useEffect(() => {
+    const unlisten = listen("menu:open-preferences", () => {
+      openSettingsTab();
+    });
+    return () => {
+      void unlisten.then((fn) => fn());
+    };
+  }, [openSettingsTab]);
+}

--- a/apps/desktop/src/hooks/use-menu-events.ts
+++ b/apps/desktop/src/hooks/use-menu-events.ts
@@ -1,16 +1,33 @@
 import { useEffect } from "react";
 import { listen } from "@tauri-apps/api/event";
-import { useOpenSettingsTab } from "./use-tabs";
+import { createSettingsTab, useEditorStore } from "@/stores/editor-store";
+
+// Native menu items that drive in-app navigation emit a Tauri event from the
+// Rust menu handler. Add the (event-name → handler) pair here to subscribe;
+// the hook below registers each entry once for the window's lifetime.
+//
+// Handlers must read store state at call time (`useStore.getState()`) rather
+// than closing over hook callbacks, so the listener registration can stay
+// stable across renders.
+export const MENU_EVENT_HANDLERS: Record<string, () => void> = {
+  "menu:open-preferences": openPreferences,
+};
+
+function openPreferences() {
+  useEditorStore
+    .getState()
+    .openOrFocus((tab) => tab.location.kind === "settings", createSettingsTab);
+}
 
 export function useMenuEvents() {
-  const openSettingsTab = useOpenSettingsTab();
-
   useEffect(() => {
-    const unlisten = listen("menu:open-preferences", () => {
-      openSettingsTab();
-    });
+    const unlistens = Object.entries(MENU_EVENT_HANDLERS).map(([event, handler]) =>
+      listen(event, handler),
+    );
     return () => {
-      void unlisten.then((fn) => fn());
+      for (const p of unlistens) {
+        void p.then((fn) => fn());
+      }
     };
-  }, [openSettingsTab]);
+  }, []);
 }

--- a/apps/desktop/tests/menu-events.test.ts
+++ b/apps/desktop/tests/menu-events.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, test, vi } from "vite-plus/test";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(() => Promise.resolve(() => {})),
+}));
+
+vi.mock("@/lib/theme", () => ({
+  applyTheme: vi.fn(),
+  applyCssVarBindings: vi.fn(),
+}));
+
+import { MENU_EVENT_HANDLERS } from "../src/hooks/use-menu-events";
+import { useEditorStore } from "../src/stores/editor-store";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useEditorStore.setState({
+    openFiles: new Map(),
+    tabs: [],
+    activeTabId: null,
+    activeFilePath: null,
+  });
+});
+
+describe("menu-events", () => {
+  test("menu:open-preferences opens a settings tab", () => {
+    const handler = MENU_EVENT_HANDLERS["menu:open-preferences"];
+    expect(handler).toBeDefined();
+
+    handler!();
+
+    const tabs = useEditorStore.getState().tabs;
+    expect(tabs).toHaveLength(1);
+    expect(tabs[0]!.location.kind).toBe("settings");
+    expect(useEditorStore.getState().activeTabId).toBe(tabs[0]!.id);
+  });
+
+  test("menu:open-preferences focuses the existing settings tab instead of duplicating", () => {
+    const handler = MENU_EVENT_HANDLERS["menu:open-preferences"]!;
+
+    handler();
+    const firstId = useEditorStore.getState().activeTabId;
+    handler();
+    const secondId = useEditorStore.getState().activeTabId;
+
+    const settingsTabs = useEditorStore
+      .getState()
+      .tabs.filter((tab) => tab.location.kind === "settings");
+    expect(settingsTabs).toHaveLength(1);
+    expect(secondId).toBe(firstId);
+  });
+});

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -8,7 +8,6 @@ These shortcuts are handled by the global `useKeyboardShortcuts` hook and work r
 
 | Shortcut        | Action                        |
 | --------------- | ----------------------------- |
-| Cmd+,           | Open settings                 |
 | Cmd+P           | File search (command palette) |
 | Cmd+O           | Go to file                    |
 | Cmd+N           | Create new note               |
@@ -20,6 +19,14 @@ These shortcuts are handled by the global `useKeyboardShortcuts` hook and work r
 | Cmd+1 ... Cmd+9 | Jump to Nth tab               |
 | Alt+ArrowLeft   | Navigate back                 |
 | Alt+ArrowRight  | Navigate forward              |
+
+## Menu Accelerators
+
+These shortcuts are bound to the native app menu (Tauri menu accelerators) rather than the global JS handler.
+
+| Shortcut | Action                                                |
+| -------- | ----------------------------------------------------- |
+| Cmd+,    | Open Preferences (Settings tab) in the focused window |
 
 ## Editor Formatting
 


### PR DESCRIPTION
## Summary

- Add a `Preferences…` entry (`⌘,`) to the macOS Writer application menu, opening the existing Settings tab in the focused window via a new `menu:open-preferences` Tauri event.
- Rename the macOS-only CLI install item from `Shell Command: Install 'writer' Command in PATH` to `Install 'writer' Command Line Tool…` (and the uninstall counterpart) and group it next to Preferences so the app menu reads like a standard macOS app menu.
- Spec: `SPECs/install-cli-menu-placement-spec.md` (also added in this PR).

## Test plan

- [ ] On macOS, open the Writer app menu and confirm order: `About Writer`, `Check for Updates…`, `Preferences…` (`⌘,`), `Install 'writer' Command Line Tool…`, then standard `Services` / `Hide` / `Quit` block.
- [ ] Click `Preferences…` — Settings tab opens in the focused window.
- [ ] Press `⌘,` — Settings tab opens (native menu accelerator path).
- [ ] With multiple workspace windows open, clicking `Preferences…` opens Settings in the focused window only.
- [ ] Click `Install 'writer' Command Line Tool…` — install flow runs as before, including the elevation prompt and the success dialog. Label flips to `Uninstall 'writer' Command Line Tool…`.
- [ ] Click again — uninstall runs, label flips back.
- [ ] `cargo fmt --check`, `cargo clippy`, `cargo test` (91 passed locally).
- [ ] `vp check`, `vp test` (265 passed locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)