### PR TITLE
Fix editor scroll jumping on every keystroke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-05-07
+
+- Fix the editor scroll jumping on every keystroke after the Cmd+F polish landed. The custom `EditorView.scrollHandler` was firing for any scroll-into-view (including CodeMirror's default cursor tracking on typing) and unconditionally re-positioning the cursor at the safe-zone top. Now gated by a `searchScrollIntent` `StateField` that only flips on for transactions tagged `select.search` (find next/previous, jump-to-match) or `input.replace` (replace next/all), and the handler only nudges the scroll when the match's line is actually outside the safe zone — typing and ordinary cursor moves fall through to CodeMirror's default scroll, and stepping between already-visible matches no longer jumps.
+
 ## 2026-05-06
 
 - Polish in-document find (Cmd+F): the active match now scrolls into a clear zone away from the editor's top/bottom fade mask and progressive blur — `search()` is configured with a custom `scrollToMatch` that uses `EditorView.scrollIntoView` with a `yMargin` derived from `EDITOR_SAFE_SCROLL_MARGIN`. Add `Cmd+G` / `Cmd+Shift+G` for next/previous match (handled at `Prec.highest` in the editor keymap and in the find/replace inputs' `onKeyDown`). Add an IDE-style match overview rail along the right edge of the editor pane: thin marks (one per match, accent-colored for the active match) render outside the masked scroll area, click to jump. The query is mirrored into `editor-search-store` so the overview can subscribe without prop-drilling. See `SPECs/cmd-f-spec.md`.

--- a/apps/desktop/src/components/editor-area/use-prosemark-editor.ts
+++ b/apps/desktop/src/components/editor-area/use-prosemark-editor.ts
@@ -6,6 +6,7 @@ import {
   EditorState,
   Extension,
   Prec,
+  StateField,
   Transaction,
   type StateCommand,
 } from "@codemirror/state";
@@ -89,6 +90,20 @@ function findOuterScroller(view: EditorView): HTMLElement | null {
   }
   return null;
 }
+
+// True when the latest transaction was a search/replace navigation
+// (`select.search` from findNext/findPrevious/jumpToMatch, or
+// `input.replace` from replaceNext/replaceAll). The custom scrollHandler
+// reads this to scope the safe-zone scroll to search nav only — without
+// it, ordinary typing would also be repositioned and cause a jump on
+// every keystroke that triggered CodeMirror's cursor tracking.
+const searchScrollIntent = StateField.define<boolean>({
+  create: () => false,
+  update: (value, tr) => {
+    if (!tr.selection && !tr.docChanged) return value;
+    return tr.isUserEvent("select.search") || tr.isUserEvent("input.replace");
+  },
+});
 
 function resolveScrollContainer(root: HTMLElement, getScrollContainer?: () => HTMLElement | null) {
   return getScrollContainer?.() ?? findScrollContainer(root);
@@ -416,15 +431,23 @@ function createEditorExtensions(
     drawSelection(),
     prosemarkBaseThemeSetup(),
     search({ literal: true, createPanel: invisibleSearchPanel }),
-    // Take over scrollIntoView entirely so search/replace navigation lands
-    // matches in the clear zone of the *outer* scroll container — the
-    // EditorScrollContainer wraps the editor with an overflow-y-auto div
-    // covered by a fade mask + 120px progressive blur, but CodeMirror's
-    // built-in scrollIntoView walks ancestors generically and the geometry
-    // doesn't always land the match where we want it. We position the
-    // match at the top of the safe zone so users keep their reading
-    // context (vs. centering, which jumps).
+    // Tracks whether the latest transaction was search/replace navigation
+    // (`@codemirror/search` tags those with userEvents `select.search` for
+    // find-next/previous + `jumpToMatch`, and `input.replace` for replace-
+    // next/all). The scrollHandler below reads this to know whether to
+    // apply our safe-zone scroll, instead of running on every cursor move.
+    searchScrollIntent,
+    // Override scrollIntoView only for search/replace navigation so matches
+    // land in the clear zone of the *outer* scroll container (the
+    // EditorScrollContainer is wrapped by a fade mask + 120px progressive
+    // blur, and CodeMirror's default scroll walks ancestors generically and
+    // doesn't always land the match where we want it). Only nudges the
+    // scroll when the match is outside the safe zone — if it's already
+    // visible we don't move so stepping between nearby matches doesn't
+    // jump. For typing and ordinary cursor moves we return false and let
+    // CodeMirror's default scroll behavior run.
     EditorView.scrollHandler.of((view, range) => {
+      if (!view.state.field(searchScrollIntent, false)) return false;
       const scroller = findOuterScroller(view);
       if (!scroller) return false;
       // Use lineBlockAt + documentTop (CodeMirror's layout model) rather
@@ -432,10 +455,23 @@ function createEditorExtensions(
       // match is outside the currently-rendered viewport, which silently
       // fell back to the default scroll and ignored our fade margin.
       const block = view.lineBlockAt(range.head);
-      const matchScreenY = view.documentTop + block.top;
+      const matchTop = view.documentTop + block.top;
+      const matchBottom = view.documentTop + block.bottom;
       const scrollerRect = scroller.getBoundingClientRect();
-      const desiredScreenY = scrollerRect.top + scroller.clientTop + EDITOR_SAFE_SCROLL_MARGIN;
-      const delta = matchScreenY - desiredScreenY;
+      const contentTop = scrollerRect.top + scroller.clientTop;
+      const safeTop = contentTop + EDITOR_SAFE_SCROLL_MARGIN;
+      const safeBottom = contentTop + scroller.clientHeight - EDITOR_SAFE_SCROLL_MARGIN;
+      // Top edge wins if the line is taller than the safe zone, so the
+      // match (anchored at the line's top) stays visible instead of being
+      // pushed above the fade by a bottom-align scroll.
+      let delta = 0;
+      if (matchTop < safeTop) {
+        delta = matchTop - safeTop;
+      } else if (matchBottom > safeBottom && block.height <= safeBottom - safeTop) {
+        delta = matchBottom - safeBottom;
+      } else {
+        return true;
+      }
       const max = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
       const next = Math.max(0, Math.min(scroller.scrollTop + delta, max));
       if (Math.abs(scroller.scrollTop - next) < 1) return true;


### PR DESCRIPTION
## Summary
- The Cmd+F polish in #26 added an `EditorView.scrollHandler` that fired for any scroll-into-view (including CodeMirror's default cursor tracking on typing) and unconditionally re-positioned the target at the safe-zone top, so the editor jumped on every keystroke that triggered cursor tracking.
- Gate the handler on a new `searchScrollIntent` `StateField` that only flips on for transactions tagged `select.search` (find next/previous, jump-to-match) or `input.replace` (`replaceNext`/`replaceAll`). Other transactions fall through to CodeMirror's default scroll.
- Only nudge the scroll when the match's line is actually outside the safe zone — stepping between already-visible matches no longer jumps. Top-edge alignment wins for lines taller than the safe zone so the match anchor stays visible.

## Test plan
- [ ] Type a long paragraph mid-document — viewport stays put, no per-keystroke jump.
- [ ] Cmd+F, search a term, press Cmd+G / Cmd+Shift+G — out-of-view matches scroll into the safe zone (clear of the top/bottom fade and progressive blur).
- [ ] Click marks on the right-edge match overview rail (`jumpToMatch`) — same behavior.
- [ ] Open Replace, click Replace / Replace All — next match scrolls into the safe zone when out of view.
- [ ] Step through several matches that are all already on screen — viewport doesn't move.
- [ ] Move the caret with arrow keys and clicks near the edges — default cursor tracking still works (no safe-zone forcing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)