### PR TITLE
Search-scroll fix: review follow-ups

### DIFF
--- a/SPECs/cmd-f-spec.md
+++ b/SPECs/cmd-f-spec.md
@@ -42,6 +42,7 @@ CodeMirror's default `findNext` / `findPrevious` (`@codemirror/search`) scrolls 
 - "Clear zone" = the visible region not obscured by either the mask gradient transition or the 120px progressive-blur overlay. Treat the safe top inset and safe bottom inset as a single source of truth — derive both from the constants already in `editor-scroll-container.tsx` (`FADE_DISTANCE`, mask stops) rather than hard-coding numbers in the search code.
 - The scroll adjustment must not flicker or fight CodeMirror's own `scrollIntoView`. Prefer a single `EditorView.scrollIntoView` dispatch with `y: "center"` (or an explicit margin equal to the top/bottom safe insets), instead of letting CodeMirror's default scroll run and then correcting afterwards.
 - Apply the same logic when the overlay is first opened with an existing selection that is the first match.
+- If the active match is already inside the clear zone, do **not** scroll. Stepping between adjacent visible matches (Enter, Cmd+G, rail-click) updates the selection only — re-anchoring a visible match to the safe-zone top would feel like a jump for no reason.
 
 ### Scrollbar match overview
 

--- a/apps/desktop/src/components/editor-area/use-prosemark-editor.ts
+++ b/apps/desktop/src/components/editor-area/use-prosemark-editor.ts
@@ -97,12 +97,14 @@ function findOuterScroller(view: EditorView): HTMLElement | null {
 // reads this to scope the safe-zone scroll to search nav only — without
 // it, ordinary typing would also be repositioned and cause a jump on
 // every keystroke that triggered CodeMirror's cursor tracking.
+//
+// Recomputed on every transaction (no early return) so the flag never
+// latches `true` across an effect-only transaction that follows a search
+// nav — otherwise a later non-search `scrollIntoView` would inherit the
+// stale `true` and silently re-anchor.
 const searchScrollIntent = StateField.define<boolean>({
   create: () => false,
-  update: (value, tr) => {
-    if (!tr.selection && !tr.docChanged) return value;
-    return tr.isUserEvent("select.search") || tr.isUserEvent("input.replace");
-  },
+  update: (_value, tr) => tr.isUserEvent("select.search") || tr.isUserEvent("input.replace"),
 });
 
 function resolveScrollContainer(root: HTMLElement, getScrollContainer?: () => HTMLElement | null) {
@@ -447,7 +449,7 @@ function createEditorExtensions(
     // jump. For typing and ordinary cursor moves we return false and let
     // CodeMirror's default scroll behavior run.
     EditorView.scrollHandler.of((view, range) => {
-      if (!view.state.field(searchScrollIntent, false)) return false;
+      if (!view.state.field(searchScrollIntent)) return false;
       const scroller = findOuterScroller(view);
       if (!scroller) return false;
       // Use lineBlockAt + documentTop (CodeMirror's layout model) rather

--- a/docs/codemirror.md
+++ b/docs/codemirror.md
@@ -42,3 +42,30 @@ When the scrollable element is an ancestor:
 - Account for `clientTop` if the ancestor has a border (Writer's container has a 12px transparent border-top to give the mask gradient room).
 
 Reference: `EditorView.scrollHandler.of((view, range) => …)` in `apps/desktop/src/components/editor-area/use-prosemark-editor.ts`.
+
+## Scope `scrollHandler` to the scroll targets you actually want to override
+
+`EditorView.scrollHandler.of(...)` runs for **every** scroll target the view processes — including CodeMirror's default cursor tracking on typing. A handler that unconditionally rewrites geometry will jolt the viewport on every keystroke.
+
+Gate the handler on a `StateField` of intent that reads the current transaction's user-event tags, then `return false` for transactions you don't own so CodeMirror's default scroll runs unimpeded:
+
+```ts
+const searchScrollIntent = StateField.define<boolean>({
+  create: () => false,
+  update: (_value, tr) => tr.isUserEvent("select.search") || tr.isUserEvent("input.replace"),
+});
+
+EditorView.scrollHandler.of((view, range) => {
+  if (!view.state.field(searchScrollIntent)) return false; // typing, cursor moves, etc.
+  // …safe-zone scroll math…
+});
+```
+
+Two subtleties:
+
+- **Recompute on every transaction.** Don't early-return to "preserve" the previous value across effect-only transactions — the flag would latch `true` after a search nav and a later unrelated `scrollIntoView` effect would inherit it.
+- **`isUserEvent` is prefix-matching with `.` separators.** `isUserEvent("select.search")` matches both `"select.search"` and `"select.search.matches"`. Likewise `"input.replace"` covers `"input.replace.all"`. One check per family is enough.
+
+User events emitted by `@codemirror/search` (v6.x): `findNext` / `findPrevious` / `jumpToMatch` → `select.search`; `replaceNext` → `input.replace`; `replaceAll` → `input.replace.all`. Typing emits `input.type`, paste emits `input.paste`, plain cursor moves emit `select` — none match the gate.
+
+Return values: `false` falls through to CodeMirror's default scroll; `true` means handled (no further scrolling). Use `true` (not `false`) when the match is already inside the safe zone and you want to suppress any scroll, otherwise the default handler will run and undo your no-op.


### PR DESCRIPTION
## Summary
Follow-ups on top of #31 that didn't make it into the squash:

- Simplify `searchScrollIntent` to recompute on every transaction so the flag can't latch `true` across a follow-on effect-only transaction (where a later non-search `scrollIntoView` would otherwise inherit a stale `true` and silently re-anchor).
- Drop the dead `, false` default arg on the `state.field()` lookup — the field is always installed.
- Document the `scrollHandler`-scoping pattern in `docs/codemirror.md` (gate via a `StateField` of intent, prefix-matching of `isUserEvent`, return-value semantics).
- Note in `SPECs/cmd-f-spec.md` that already-visible matches no longer re-scroll on step.

## Test plan
- [ ] Type a long paragraph mid-document — viewport stays put, no per-keystroke jump (regression check from #31).
- [ ] Cmd+F + Cmd+G / Cmd+Shift+G — out-of-view matches scroll into the safe zone, in-view matches do not.
- [ ] Trigger an effect-only transaction (e.g. theme toggle, search-query update) immediately after a `findNext` — next non-search `scrollIntoView` (e.g. arrow-key cursor move out of viewport) uses default scroll, not safe-zone.
- [ ] `replaceNext` / `replaceAll` — next match still scrolls into safe zone when out of view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)