### PR TITLE
Animate section-rail ticks with scaleX instead of width

### DIFF
--- a/apps/desktop/src/components/editor-area/section-rail.css
+++ b/apps/desktop/src/components/editor-area/section-rail.css
@@ -14,6 +14,11 @@
   pointer-events: none;
 }
 
+.section-rail-tick {
+  transform-origin: left center;
+  will-change: transform;
+}
+
 .section-rail-popover {
   transform-origin: left center;
   transform: translateY(-50%) translateX(4px) scale(1);

--- a/apps/desktop/src/components/editor-area/section-rail.tsx
+++ b/apps/desktop/src/components/editor-area/section-rail.tsx
@@ -13,6 +13,7 @@ import "./section-rail.css";
 
 const INACTIVE_WIDTH = 7;
 const ACTIVE_WIDTH = 14;
+const INACTIVE_TICK_SCALE = INACTIVE_WIDTH / ACTIVE_WIDTH;
 const TICK_HEIGHT = 1;
 const TICK_GAP = 6;
 const RAIL_LEFT = 12;
@@ -121,17 +122,18 @@ export function SectionRail({ filePath, view, scrollContainerRef }: SectionRailP
           {headings.map((heading, i) => {
             const isActive = i === activeIndex;
             const tickStyle: CSSProperties = {
-              width: isActive ? ACTIVE_WIDTH : INACTIVE_WIDTH,
+              width: ACTIVE_WIDTH,
               height: TICK_HEIGHT,
               background: "currentColor",
               opacity: isActive ? 1 : 0.35,
-              transition: isActive ? "none" : "width 300ms ease-in, opacity 300ms ease-in",
+              transform: isActive ? "scaleX(1)" : `scaleX(${INACTIVE_TICK_SCALE})`,
+              transition: isActive ? "none" : "transform 300ms ease-in, opacity 300ms ease-in",
             };
             return (
               <button
                 key={`${heading.line}-${i}`}
                 type="button"
-                className="block cursor-default border-0 bg-transparent p-0"
+                className="section-rail-tick block cursor-default border-0 bg-transparent p-0"
                 style={tickStyle}
                 title={heading.text}
                 onClick={() => handleTickClick(heading)}


### PR DESCRIPTION
## Summary
- Replace `width` animation on section-rail ticks with `transform: scaleX(...)` so the transition is composited instead of triggering layout/paint on every active-heading change during scroll.
- Tick boxes are a constant 14px with `transform-origin: left center`; inactive renders at `scaleX(7/14)` so the active tick still grows rightward from the same anchor.
- Add `will-change: transform` on `.section-rail-tick` — ticks transition repeatedly without a hover signal, so always-on compositor promotion is appropriate here.

Side effect: click hit area is now uniformly 14px wide (inactive ticks were 7px before). Minor UX improvement.

## Test plan
- [ ] Open a document with several headings; confirm the active tick still grows leftward-anchored (rightward expansion) as you scroll between sections.
- [ ] Confirm the inactive→active flip is instant and active→inactive eases over 300ms (transition asymmetry preserved).
- [ ] DevTools Performance/Layers: confirm the tick animation no longer triggers layout on each transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)