### PR TITLE
Pin focus on section-rail clicks to stop huge editor selection

### DIFF
--- a/apps/desktop/src/components/editor-area/section-rail.tsx
+++ b/apps/desktop/src/components/editor-area/section-rail.tsx
@@ -136,6 +136,7 @@ export function SectionRail({ filePath, view, scrollContainerRef }: SectionRailP
                 className="section-rail-tick block cursor-default border-0 bg-transparent p-0"
                 style={tickStyle}
                 title={heading.text}
+                onMouseDown={(event) => event.preventDefault()}
                 onClick={() => handleTickClick(heading)}
                 onContextMenu={(event) => handleContextMenu(event, heading)}
               />
@@ -177,6 +178,7 @@ export function SectionRail({ filePath, view, scrollContainerRef }: SectionRailP
                         letterSpacing: "-0.01em",
                         lineHeight: 1.5,
                       }}
+                      onMouseDown={(event) => event.preventDefault()}
                       onClick={() => handleTickClick(heading)}
                       onContextMenu={(event) => handleContextMenu(event, heading)}
                     >


### PR DESCRIPTION
## Summary
- Clicking a tick or popover row in the section rail moved focus out of CodeMirror; the next click in the editor then extended the selection from the previous anchor to the click point, producing a huge range.
- Added `onMouseDown={(event) => event.preventDefault()}` to both buttons in `section-rail.tsx`, matching the focus-pinning pattern already used on the editor-tab nav buttons.

## Test plan
- [ ] Open a doc with several headings; click a heading in the section-rail popover, then click in the editor — caret lands where clicked, no range selection.
- [ ] Click a tick (rail closed state), then click in the editor — same expectation.
- [ ] Right-click on a heading still opens the context menu and "Copy heading link" works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)