### PR TITLE
Make code styles follow editor font size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add 1rem top padding to rendered editor Markdown headings through a shared heading line class, covering both ATX and Setext heading syntax while preserving the existing hanging ATX hash behavior.
 - Make sidebar icons and labels promote to the full theme foreground color on hover, selection, and active file states so they read white in dark mode and dark in light mode instead of staying gray.
+- Make fenced Markdown code blocks follow the editor font-size setting while keeping their monospace code font.
 
 ## 2026-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Add 1rem top padding to rendered editor Markdown headings through a shared heading line class, covering both ATX and Setext heading syntax while preserving the existing hanging ATX hash behavior.
 - Make sidebar icons and labels promote to the full theme foreground color on hover, selection, and active file states so they read white in dark mode and dark in light mode instead of staying gray.
-- Make fenced Markdown code blocks follow the editor font-size setting while keeping their monospace code font.
+- Make fenced Markdown code blocks and inline code follow the editor font-size setting while keeping their monospace code font.
 
 ## 2026-05-25
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -8,6 +8,7 @@
 
 - Markdown heading top padding: [`SPECs/heading-top-padding-spec.md`](SPECs/heading-top-padding-spec.md) — inject a shared editor heading class and use it to add 1rem top padding to Markdown headings.
 - Sidebar hover and active foreground polish — make sidebar icons and labels use full foreground color on hover, selection, and active states.
+- Code block editor font size — make fenced Markdown code blocks follow the editor font-size setting.
 - Empty list caret visibility: [`SPECs/empty-list-caret-spec.md`](SPECs/empty-list-caret-spec.md) — keep the caret visible at the body column on empty bullet and task-list items whose source marker is hidden by the list-prefix renderer.
 - List selection and TODO checkbox regression: [`SPECs/list-selection-todo-checkbox-regression-spec.md`](SPECs/list-selection-todo-checkbox-regression-spec.md) — replace list-prefix replace widgets with point widgets to stop selection/caret snaps, and render TODO checkboxes as a single non-native span so drag-selection and nested alignment work.
 - Mermaid canvas widget: [`SPECs/mermaid-canvas-widget-spec.md`](SPECs/mermaid-canvas-widget-spec.md) — render mermaid blocks in a fixed-height canvas-style frame with pan, zoom, reset-to-fit, and an edit-code toggle.

--- a/TODOS.md
+++ b/TODOS.md
@@ -8,7 +8,7 @@
 
 - Markdown heading top padding: [`SPECs/heading-top-padding-spec.md`](SPECs/heading-top-padding-spec.md) — inject a shared editor heading class and use it to add 1rem top padding to Markdown headings.
 - Sidebar hover and active foreground polish — make sidebar icons and labels use full foreground color on hover, selection, and active states.
-- Code block editor font size — make fenced Markdown code blocks follow the editor font-size setting.
+- Code block editor font size — make fenced Markdown code blocks and inline code follow the editor font-size setting.
 - Empty list caret visibility: [`SPECs/empty-list-caret-spec.md`](SPECs/empty-list-caret-spec.md) — keep the caret visible at the body column on empty bullet and task-list items whose source marker is hidden by the list-prefix renderer.
 - List selection and TODO checkbox regression: [`SPECs/list-selection-todo-checkbox-regression-spec.md`](SPECs/list-selection-todo-checkbox-regression-spec.md) — replace list-prefix replace widgets with point widgets to stop selection/caret snaps, and render TODO checkboxes as a single non-native span so drag-selection and nested alignment work.
 - Mermaid canvas widget: [`SPECs/mermaid-canvas-widget-spec.md`](SPECs/mermaid-canvas-widget-spec.md) — render mermaid blocks in a fixed-height canvas-style frame with pan, zoom, reset-to-fit, and an edit-code toggle.

--- a/apps/desktop/src/lib/prosemark-core/codeFenceExtension.ts
+++ b/apps/desktop/src/lib/prosemark-core/codeFenceExtension.ts
@@ -9,6 +9,7 @@ import { FRONTMATTER_LANGUAGE_LABEL, isFrontmatterNode } from "./markdown/frontm
 const fallbackMonospaceCodeFont =
   "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace";
 const codeFontFamily = `var(--pm-code-font, ${fallbackMonospaceCodeFont})`;
+const editorFontSize = "var(--writer-editor-font-size, 16px)";
 
 const codeBlockDecorations = (view: EditorView) => {
   const builder = new RangeSetBuilder<Decoration>();
@@ -147,12 +148,13 @@ export const codeBlockDecorationsExtension: Extension = ViewPlugin.fromClass(
   },
 );
 
-export const codeFenceTheme = EditorView.theme({
+const codeFenceThemeSpec = {
   ".cm-fenced-code-line": {
     display: "block",
     marginLeft: "6px",
     backgroundColor: "var(--pm-code-background-color)",
     fontFamily: codeFontFamily,
+    fontSize: editorFontSize,
     fontVariantLigatures: "none",
     fontFeatureSettings: '"calt" 0',
     fontKerning: "none",
@@ -198,4 +200,10 @@ export const codeFenceTheme = EditorView.theme({
     width: "16px",
     height: "16px",
   },
-});
+};
+
+export const codeFenceTheme = EditorView.theme(codeFenceThemeSpec);
+
+export const __testCodeFenceExtension = {
+  codeFenceThemeSpec,
+};

--- a/apps/desktop/src/lib/prosemark-core/syntaxHighlighting.ts
+++ b/apps/desktop/src/lib/prosemark-core/syntaxHighlighting.ts
@@ -7,6 +7,7 @@ import type { MarkdownConfig } from "@lezer/markdown";
 const fallbackMonospaceCodeFont =
   "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace";
 const codeFontFamily = `var(--pm-code-font, ${fallbackMonospaceCodeFont})`;
+const editorFontSize = "var(--writer-editor-font-size, 16px)";
 
 export const additionalMarkdownSyntaxTags: MarkdownConfig = {
   // Define new nodes with tags here
@@ -75,7 +76,7 @@ export const baseSyntaxHighlights = syntaxHighlighting(
   ]),
 );
 
-export const baseTheme = EditorView.theme({
+const baseThemeSpec = {
   ".cm-content": {
     fontFamily: "var(--font)",
     fontSize: "0.9rem",
@@ -156,10 +157,16 @@ export const baseTheme = EditorView.theme({
     fontKerning: "none",
     padding: "0.2rem",
     borderRadius: "0.4rem",
-    fontSize: "0.8rem",
+    fontSize: editorFontSize,
     backgroundColor: "var(--pm-code-background-color)",
   },
-});
+};
+
+export const baseTheme = EditorView.theme(baseThemeSpec);
+
+export const __testSyntaxHighlighting = {
+  baseThemeSpec,
+};
 
 export const generalSyntaxHighlights = syntaxHighlighting(
   HighlightStyle.define([

--- a/apps/desktop/tests/code-fence-extension.test.ts
+++ b/apps/desktop/tests/code-fence-extension.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from "vite-plus/test";
+import { __testCodeFenceExtension } from "../src/lib/prosemark-core/codeFenceExtension";
+
+describe("codeFenceTheme", () => {
+  test("fenced code lines follow the editor font size while keeping the code font", () => {
+    const fencedCodeLine = __testCodeFenceExtension.codeFenceThemeSpec[".cm-fenced-code-line"];
+
+    expect(fencedCodeLine.fontSize).toBe("var(--writer-editor-font-size, 16px)");
+    expect(fencedCodeLine.fontFamily).toContain("--pm-code-font");
+  });
+});

--- a/apps/desktop/tests/syntax-highlighting.test.ts
+++ b/apps/desktop/tests/syntax-highlighting.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from "vite-plus/test";
+import { __testSyntaxHighlighting } from "../src/lib/prosemark-core/syntaxHighlighting";
+
+describe("baseTheme", () => {
+  test("inline code follows the editor font size while keeping the code font", () => {
+    const inlineCode = __testSyntaxHighlighting.baseThemeSpec[".cm-inline-code"];
+
+    expect(inlineCode.fontSize).toBe("var(--writer-editor-font-size, 16px)");
+    expect(inlineCode.fontFamily).toContain("--pm-code-font");
+  });
+});


### PR DESCRIPTION
Summary:
- Bind fenced code block lines and inline code chips to the editor font-size CSS variable.
- Keep code blocks and inline code on the existing monospace code font.
- Add regression tests for both code styling contracts and update changelog/TODOs.

Conflict resolution:
- Rebased onto master after #67 and kept both changelog/TODO entries.

Tests:
- vp check (0 errors; existing E2E warnings remain)
- vp test