### PR TITLE
Add markdown heading top padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-05-26
+
+- Add 1rem top padding to rendered editor Markdown headings through a shared heading line class, covering both ATX and Setext heading syntax while preserving the existing hanging ATX hash behavior.
+
 ## 2026-05-25
 
 - Keep the blinking caret visible on empty bullet and TODO list items by anchoring the existing marker widget at the hidden prefix end, giving CodeMirror a body-column coordinate target without an extra empty-line widget.

--- a/SPECs/Agent/worksheet-heading-top-padding.md
+++ b/SPECs/Agent/worksheet-heading-top-padding.md
@@ -1,0 +1,45 @@
+# Agent Worksheet: Heading Top Padding
+
+## Task
+
+- Markdown heading top padding: inject a class into editor Markdown heading
+  lines and use it to add `1rem` top padding.
+- Spec: `SPECs/heading-top-padding-spec.md`
+
+## Reviewed
+
+- `TODOS.md` — noted existing unrelated in-progress reveal/sidebar task.
+- `docs/editor.md` — confirmed CodeMirror layout/decorations guidance.
+- `docs/react-guidelines.md` — no React component/store changes needed.
+- `docs/consolidation.md` — keep heading behavior centralized in the existing
+  heading decoration extension.
+- `apps/desktop/src/components/editor-area/heading-decorations.ts` — existing
+  ATX heading line/hash decoration and selection guard.
+- `apps/desktop/src/components/editor-area/prosemark-theme.css` — existing
+  heading hash CSS and editor line layout.
+- `apps/desktop/tests/heading-decorations.test.ts` — focused tests for heading
+  decoration behavior.
+
+## Plan
+
+- Reuse the existing `headingDecorations` extension as the single owner of
+  heading line classes.
+- Add a generic class to every heading line decoration.
+- Broaden line classification to include Setext headings, while keeping hash
+  movement/caret guards limited to ATX headings.
+- Add CSS top padding through the new generic class.
+- Validate with focused heading tests plus `vp check` and `vp test`.
+
+## Results
+
+- Added `cm-markdown-heading` to heading line decorations for ATX and Setext
+  headings.
+- Added `padding-top: 1rem` to the shared heading class.
+- Kept ATX hash decorations and selection no-go zones ATX-only.
+- Added tests for ATX/Setext heading classification and Setext no-go-zone
+  behavior.
+- Validation:
+  - `vp test run apps/desktop/tests/heading-decorations.test.ts` passed.
+  - `vp check` completed with existing unrelated warnings in
+    `apps/desktop/e2e`.
+  - `vp test` passed.

--- a/SPECs/heading-top-padding-spec.md
+++ b/SPECs/heading-top-padding-spec.md
@@ -1,0 +1,24 @@
+# Markdown Heading Top Padding Spec
+
+## Goal
+
+Give every rendered Markdown heading in the editor a small amount of top
+spacing so section breaks are easier to scan while preserving the existing
+hanging ATX hash behavior.
+
+## Design
+
+- Add a generic `cm-markdown-heading` line-decoration class to Markdown
+  heading lines.
+- Continue emitting the existing `cm-heading-line` and `cm-heading-line-N`
+  classes for compatibility with hanging hash positioning and level-specific
+  styling.
+- Treat ATX H1-H6 and Setext H1-H2 as Markdown headings for the line class.
+- Keep ATX hash decorations and selection no-go zones ATX-only.
+- Style `.cm-editor .cm-markdown-heading` with `padding-top: 1rem`.
+
+## Validation
+
+- Unit-test heading node classification for ATX and Setext heading names.
+- Unit-test that Setext headings do not create ATX hash no-go zones.
+- Run `vp check` and `vp test`.

--- a/TODOS.md
+++ b/TODOS.md
@@ -6,6 +6,7 @@
 
 ## Done
 
+- Markdown heading top padding: [`SPECs/heading-top-padding-spec.md`](SPECs/heading-top-padding-spec.md) — inject a shared editor heading class and use it to add 1rem top padding to Markdown headings.
 - Empty list caret visibility: [`SPECs/empty-list-caret-spec.md`](SPECs/empty-list-caret-spec.md) — keep the caret visible at the body column on empty bullet and task-list items whose source marker is hidden by the list-prefix renderer.
 - List selection and TODO checkbox regression: [`SPECs/list-selection-todo-checkbox-regression-spec.md`](SPECs/list-selection-todo-checkbox-regression-spec.md) — replace list-prefix replace widgets with point widgets to stop selection/caret snaps, and render TODO checkboxes as a single non-native span so drag-selection and nested alignment work.
 - Mermaid canvas widget: [`SPECs/mermaid-canvas-widget-spec.md`](SPECs/mermaid-canvas-widget-spec.md) — render mermaid blocks in a fixed-height canvas-style frame with pan, zoom, reset-to-fit, and an edit-code toggle.

--- a/apps/desktop/src/components/editor-area/heading-decorations.ts
+++ b/apps/desktop/src/components/editor-area/heading-decorations.ts
@@ -18,6 +18,7 @@ import { ensureSyntaxTree, syntaxTree } from "@codemirror/language";
 type SyntaxNode = ReturnType<typeof syntaxTree>["topNode"];
 
 const ATX_HEADING_RE = /^ATXHeading([1-6])$/;
+const SETEXT_HEADING_RE = /^SetextHeading([1-2])$/;
 
 // Max byte length of any heading no-go zone on a line: "###### " = 7 chars.
 // O(1) fast-path: a position more than this far from its line start cannot
@@ -31,8 +32,18 @@ const hashMark = Decoration.mark({ class: "cm-heading-hash" });
 const lineDecos: Record<number, Decoration> = {};
 for (let level = 1; level <= 6; level++) {
   lineDecos[level] = Decoration.line({
-    attributes: { class: `cm-heading-line cm-heading-line-${level}` },
+    attributes: { class: `cm-markdown-heading cm-heading-line cm-heading-line-${level}` },
   });
+}
+
+function getMarkdownHeadingLevel(name: string): number | null {
+  const atx = ATX_HEADING_RE.exec(name);
+  if (atx) return Number(atx[1]);
+
+  const setext = SETEXT_HEADING_RE.exec(name);
+  if (setext) return Number(setext[1]);
+
+  return null;
 }
 
 function findHeadingHashEnd(node: SyntaxNode): number | null {
@@ -123,12 +134,13 @@ function buildDecorations(view: EditorView): DecorationSet {
       from,
       to,
       enter(node) {
-        const m = ATX_HEADING_RE.exec(node.name);
-        if (!m) return undefined;
+        const level = getMarkdownHeadingLevel(node.name);
+        if (level === null) return undefined;
 
-        const level = Number(m[1]);
         const lineFrom = view.state.doc.lineAt(node.from).from;
         decos.push({ from: lineFrom, to: lineFrom, deco: lineDecos[level]! });
+
+        if (!ATX_HEADING_RE.test(node.name)) return false;
 
         const hashEnd = findHeadingHashEnd(node.node);
         if (hashEnd !== null) {
@@ -336,4 +348,5 @@ export const __test = {
   clampRangesToZones,
   couldBeInZone,
   anySelectionEndpointCouldBeInZone,
+  getMarkdownHeadingLevel,
 };

--- a/apps/desktop/src/components/editor-area/prosemark-theme.css
+++ b/apps/desktop/src/components/editor-area/prosemark-theme.css
@@ -236,6 +236,10 @@
    runtime-injected theme is loaded after this stylesheet, so !important
    pins the override and keeps the hash visible in the margin in both
    caret-on and caret-off states. See heading-hash-margin-spec.md. */
+.cm-editor .cm-markdown-heading {
+  padding-top: 1rem;
+}
+
 .cm-editor .cm-heading-line {
   position: relative;
 }

--- a/apps/desktop/tests/heading-decorations.test.ts
+++ b/apps/desktop/tests/heading-decorations.test.ts
@@ -5,7 +5,8 @@ import { GFM } from "@lezer/markdown";
 import { ensureSyntaxTree } from "@codemirror/language";
 import { headingDecorations, __test } from "../src/components/editor-area/heading-decorations";
 
-const { collectHeadingNoGoZones, clampRangesToZones, couldBeInZone } = __test;
+const { collectHeadingNoGoZones, clampRangesToZones, couldBeInZone, getMarkdownHeadingLevel } =
+  __test;
 
 function makeState(doc: string, selection?: EditorSelection): EditorState {
   const state = EditorState.create({
@@ -53,6 +54,29 @@ describe("collectHeadingNoGoZones", () => {
     const zones = collectHeadingNoGoZones(state);
     expect(zones).toHaveLength(1);
     expect(zones[0]?.from).toBe("#NotHeading\n".length);
+  });
+
+  test("does not create hash no-go zones for Setext headings", () => {
+    const state = makeState("Title\n=====\n\nSubtitle\n-----");
+    expect(collectHeadingNoGoZones(state)).toEqual([]);
+  });
+});
+
+describe("getMarkdownHeadingLevel", () => {
+  test("returns levels for ATX headings", () => {
+    expect(getMarkdownHeadingLevel("ATXHeading1")).toBe(1);
+    expect(getMarkdownHeadingLevel("ATXHeading6")).toBe(6);
+  });
+
+  test("returns levels for Setext headings", () => {
+    expect(getMarkdownHeadingLevel("SetextHeading1")).toBe(1);
+    expect(getMarkdownHeadingLevel("SetextHeading2")).toBe(2);
+  });
+
+  test("returns null for non-heading nodes", () => {
+    expect(getMarkdownHeadingLevel("Paragraph")).toBeNull();
+    expect(getMarkdownHeadingLevel("ATXHeading7")).toBeNull();
+    expect(getMarkdownHeadingLevel("SetextHeading3")).toBeNull();
   });
 });
 


### PR DESCRIPTION
Summary:
- Add a shared `cm-markdown-heading` line class for editor Markdown headings.
- Apply `padding-top: 1rem` through that class.
- Include Setext headings for heading line classing while keeping ATX hash/caret behavior ATX-only.

Validation:
- `vp test run apps/desktop/tests/heading-decorations.test.ts`
- `vp check` (passes with two existing unrelated e2e warnings)
- `vp test`