### PR TITLE
Polish sidebar hover foreground

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2026-05-26
 
 - Add 1rem top padding to rendered editor Markdown headings through a shared heading line class, covering both ATX and Setext heading syntax while preserving the existing hanging ATX hash behavior.
+- Make sidebar icons and labels promote to the full theme foreground color on hover, selection, and active file states so they read white in dark mode and dark in light mode instead of staying gray.
 
 ## 2026-05-25
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -7,6 +7,7 @@
 ## Done
 
 - Markdown heading top padding: [`SPECs/heading-top-padding-spec.md`](SPECs/heading-top-padding-spec.md) — inject a shared editor heading class and use it to add 1rem top padding to Markdown headings.
+- Sidebar hover and active foreground polish — make sidebar icons and labels use full foreground color on hover, selection, and active states.
 - Empty list caret visibility: [`SPECs/empty-list-caret-spec.md`](SPECs/empty-list-caret-spec.md) — keep the caret visible at the body column on empty bullet and task-list items whose source marker is hidden by the list-prefix renderer.
 - List selection and TODO checkbox regression: [`SPECs/list-selection-todo-checkbox-regression-spec.md`](SPECs/list-selection-todo-checkbox-regression-spec.md) — replace list-prefix replace widgets with point widgets to stop selection/caret snaps, and render TODO checkboxes as a single non-native span so drag-selection and nested alignment work.
 - Mermaid canvas widget: [`SPECs/mermaid-canvas-widget-spec.md`](SPECs/mermaid-canvas-widget-spec.md) — render mermaid blocks in a fixed-height canvas-style frame with pan, zoom, reset-to-fit, and an edit-code toggle.

--- a/apps/desktop/src/components/sidebar/file-browser.tsx
+++ b/apps/desktop/src/components/sidebar/file-browser.tsx
@@ -25,16 +25,16 @@ export function FileBrowser() {
         <button
           type="button"
           onClick={() => openCommandPalette()}
-          className="relative flex w-full items-center rounded-lg border border-transparent bg-[var(--surface-input)] pl-[34px] pr-3 text-[13px] text-[var(--text-muted)] h-[var(--chrome-control-height)]"
+          className="relative flex w-full items-center rounded-lg border border-transparent bg-[var(--surface-input)] pl-[34px] pr-3 text-[13px] text-[var(--text-muted)] transition-colors hover:text-[var(--fg-base)] h-[var(--chrome-control-height)]"
         >
           <span
             aria-hidden="true"
-            className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--fg-base)] opacity-[0.54]"
+            className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-current"
           >
             <HugeiconsIcon icon={Search01Icon} size={16} color="currentColor" strokeWidth={2} />
           </span>
           Search
-          <kbd className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 text-[11px] text-[var(--text-muted)]">
+          <kbd className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 text-[11px] text-current">
             ⌘<span className="ml-0.5">P</span>
           </kbd>
         </button>

--- a/apps/desktop/src/components/sidebar/file-tree-node.tsx
+++ b/apps/desktop/src/components/sidebar/file-tree-node.tsx
@@ -63,11 +63,10 @@ export const FileTreeNode = memo(function FileTreeNode({
     input.select();
   }, [isRenaming]);
 
-  const toneClassName = entry.is_dir
-    ? "text-[var(--text-muted)]"
-    : isActive
-      ? "text-[var(--text-secondary)]"
-      : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]";
+  const isHighlighted = isActive || isSelected;
+  const toneClassName = isHighlighted
+    ? "text-[var(--fg-base)]"
+    : "text-[var(--text-muted)] hover:text-[var(--fg-base)]";
 
   function handleClick(event: MouseEvent<HTMLElement>) {
     if (isRenaming) return;
@@ -103,7 +102,7 @@ export const FileTreeNode = memo(function FileTreeNode({
         style={{ paddingLeft: depth === 0 ? 10 : depth * 12 + 6 }}
       >
         <span
-          className="flex w-5 shrink-0 items-center justify-center text-[var(--fg-base)] opacity-[0.54]"
+          className="flex w-5 shrink-0 items-center justify-center text-current"
           aria-hidden="true"
         >
           {entry.is_dir ? <FolderIcon isExpanded={isExpanded} /> : <FileIcon />}
@@ -146,10 +145,10 @@ export const FileTreeNode = memo(function FileTreeNode({
       onMouseDown={(e) => e.preventDefault()}
       onClick={handleClick}
       onContextMenu={handleContextMenu}
-      className={`flex h-[32px] w-full items-center gap-1.5 overflow-hidden rounded-lg pr-2 text-left text-[13px] leading-[1.15] ${toneClassName} ${bgClassName}`}
+      className={`flex h-[32px] w-full items-center gap-1.5 overflow-hidden rounded-lg pr-2 text-left text-[13px] leading-[1.15] transition-colors ${toneClassName} ${bgClassName}`}
       style={{ paddingLeft: depth === 0 ? 10 : depth * 12 + 6 }}
     >
-      <span className="flex w-5 shrink-0 items-center justify-center text-[var(--fg-base)] opacity-[0.54]">
+      <span className="flex w-5 shrink-0 items-center justify-center text-current">
         {entry.is_dir ? <FolderIcon isExpanded={isExpanded} /> : <FileIcon />}
       </span>
       <span className="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap">{displayName}</span>

--- a/apps/desktop/src/components/sidebar/sidebar-toggle-button.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar-toggle-button.tsx
@@ -11,7 +11,7 @@ export function SidebarToggleButton() {
       onClick={toggleSidebar}
       aria-label={isSidebarVisible ? "Hide sidebar" : "Show sidebar"}
       title={isSidebarVisible ? "Hide sidebar" : "Show sidebar"}
-      className="flex h-7 w-7 items-center justify-center rounded-md text-[var(--text-icon-muted)] transition-colors hover:bg-[var(--surface-subtle)] hover:text-[var(--text-secondary)]"
+      className="flex h-7 w-7 items-center justify-center rounded-md text-[var(--text-icon-muted)] transition-colors hover:bg-[var(--surface-subtle)] hover:text-[var(--fg-base)]"
     >
       <HugeiconsIcon icon={SidebarLeftIcon} size={18} color="currentColor" strokeWidth={2} />
     </button>

--- a/apps/desktop/src/components/sidebar/workspace-switcher.tsx
+++ b/apps/desktop/src/components/sidebar/workspace-switcher.tsx
@@ -82,10 +82,10 @@ export function WorkspaceSwitcher() {
       type="button"
       onClick={() => void showMenu()}
       aria-label="Switch workspace"
-      className="flex h-[32px] w-full items-center gap-1.5 overflow-hidden rounded-lg pl-[10px] pr-2 text-left text-[13px] leading-[1.15] text-[var(--text-muted)] transition-colors hover:bg-[var(--surface-subtle)] hover:text-[var(--text-secondary)]"
+      className="flex h-[32px] w-full items-center gap-1.5 overflow-hidden rounded-lg pl-[10px] pr-2 text-left text-[13px] leading-[1.15] text-[var(--text-muted)] transition-colors hover:bg-[var(--surface-subtle)] hover:text-[var(--fg-base)]"
     >
       <span
-        className="flex w-5 shrink-0 items-center justify-center text-[var(--text-icon-muted)]"
+        className="flex w-5 shrink-0 items-center justify-center text-current"
         aria-hidden="true"
       >
         <svg width="16" height="16" viewBox="0 0 16 16" fill="none" strokeLinejoin="round">


### PR DESCRIPTION
Summary:
- Promote sidebar tree text/icons to the full theme foreground on hover, selection, and active file states
- Make search, workspace switcher, and sidebar toggle hover states use the same full foreground treatment
- Update TODOs and changelog

Validation:
- vp check (passes with 2 unrelated existing e2e lint warnings)
- vp test (23 files, 397 tests)