### PR TITLE
Fix links and images with spaced paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2026-05-26
 
+- Fix Markdown links/images and wiki-style links whose labels, aliases, folder names, filenames, or generated pasted-image asset paths contain spaces. Bare-space destinations such as `[Todo](Writer TODOs.md)` and `![image.png](Writer TODOs-assets/file.png)` now parse as full links/images, angle-bracket destinations like `<Writer TODOs.md>` normalize to the intended local path, percent-encoded paths still decode, and pasted images now wrap generated destinations with spaces in angle brackets.
 - Add 1rem top padding to rendered editor Markdown headings through a shared heading line class, covering both ATX and Setext heading syntax while preserving the existing hanging ATX hash behavior.
 - Make sidebar icons and labels promote to the full theme foreground color on hover, selection, and active file states so they read white in dark mode and dark in light mode instead of staying gray.
 - Make fenced Markdown code blocks and inline code follow the editor font-size setting while keeping their monospace code font.

--- a/SPECs/link-paths-with-spaces-spec.md
+++ b/SPECs/link-paths-with-spaces-spec.md
@@ -1,0 +1,34 @@
+# Link Paths With Spaces Spec
+
+## Summary
+
+Markdown links/images and existing wiki-style link resolution should work when spaces appear in link labels, image alt text, aliases, folder names, file names, note titles, and generated asset paths.
+
+## Goals
+
+- Parse standard Markdown links and images with local destinations that contain literal spaces.
+- Resolve angle-bracket destinations like `<Writer TODOs.md>` to the same local path as `Writer TODOs.md`.
+- Continue decoding percent-encoded local paths such as `Writer%20TODOs.md`.
+- Preserve spaces in wiki-link targets and aliases.
+- Generate valid pasted-image Markdown when the destination path contains spaces.
+
+## Non-Goals
+
+- Add a new Obsidian embed feature.
+- Migrate existing document text.
+- Change Rust IPC contracts.
+
+## Implementation Notes
+
+- Add a shared frontend destination normalizer for stripping angle brackets, unescaping Markdown path escapes, and percent-decoding path segments.
+- Add a small Lezer inline extension before the default Markdown `LinkEnd` parser so bare-space destinations produce normal `Link` and `Image` nodes.
+- Keep quoted Markdown titles separate from destination URLs.
+- Route rendered images, link navigation, context-menu link actions, and generic ProseMark URL extraction through the same normalization path.
+
+## Acceptance Criteria
+
+- `[Todo](Writer TODOs.md)` opens `Writer TODOs.md`.
+- `![image.png](Writer TODOs-assets/20260525-041412-e520.png)` renders the image.
+- `[Todo](<Writer TODOs.md>)` and `[Todo](Writer%20TODOs.md)` resolve to the same file.
+- `[[Folder With Spaces/My Note|Label With Spaces]]` resolves and displays correctly.
+- Pasting an image into a note whose generated asset directory has spaces inserts a valid Markdown image destination.

--- a/TODOS.md
+++ b/TODOS.md
@@ -9,6 +9,7 @@
 - Markdown heading top padding: [`SPECs/heading-top-padding-spec.md`](SPECs/heading-top-padding-spec.md) — inject a shared editor heading class and use it to add 1rem top padding to Markdown headings.
 - Sidebar hover and active foreground polish — make sidebar icons and labels use full foreground color on hover, selection, and active states.
 - Code block editor font size — make fenced Markdown code blocks and inline code follow the editor font-size setting.
+- Link and image paths with spaces: [`SPECs/link-paths-with-spaces-spec.md`](SPECs/link-paths-with-spaces-spec.md) — make Markdown links/images and existing wiki-style link resolution work when labels, aliases, folders, filenames, or generated asset paths contain spaces.
 - Empty list caret visibility: [`SPECs/empty-list-caret-spec.md`](SPECs/empty-list-caret-spec.md) — keep the caret visible at the body column on empty bullet and task-list items whose source marker is hidden by the list-prefix renderer.
 - List selection and TODO checkbox regression: [`SPECs/list-selection-todo-checkbox-regression-spec.md`](SPECs/list-selection-todo-checkbox-regression-spec.md) — replace list-prefix replace widgets with point widgets to stop selection/caret snaps, and render TODO checkboxes as a single non-native span so drag-selection and nested alignment work.
 - Mermaid canvas widget: [`SPECs/mermaid-canvas-widget-spec.md`](SPECs/mermaid-canvas-widget-spec.md) — render mermaid blocks in a fixed-height canvas-style frame with pan, zoom, reset-to-fit, and an edit-code toggle.

--- a/apps/desktop/src/components/editor-area/image-src-resolver.ts
+++ b/apps/desktop/src/components/editor-area/image-src-resolver.ts
@@ -1,9 +1,10 @@
 import { EditorView, ViewPlugin } from "@codemirror/view";
 import { convertFileSrc } from "@tauri-apps/api/core";
-import { getParentDir } from "@/lib/paths";
+import { decodeLinkPath, getParentDir, normalizeMarkdownDestination } from "@/lib/paths";
 
 function resolveImgSrc(img: HTMLImageElement, markdownDir: string) {
-  const src = img.getAttribute("src");
+  const rawSrc = img.getAttribute("src");
+  const src = rawSrc ? normalizeMarkdownDestination(rawSrc) : rawSrc;
   if (!src) return;
   if (
     src.startsWith("http://") ||
@@ -13,7 +14,8 @@ function resolveImgSrc(img: HTMLImageElement, markdownDir: string) {
     src.startsWith("blob:")
   )
     return;
-  const absolute = src.startsWith("/") ? src : `${markdownDir}/${src}`;
+  const localSrc = decodeLinkPath(src);
+  const absolute = localSrc.startsWith("/") ? localSrc : `${markdownDir}/${localSrc}`;
   img.src = convertFileSrc(absolute);
 }
 

--- a/apps/desktop/src/components/editor-area/use-prosemark-editor.ts
+++ b/apps/desktop/src/components/editor-area/use-prosemark-editor.ts
@@ -64,7 +64,12 @@ import { getWorkspaceRoot } from "@/hooks/workspace-api";
 import { buildSlugIndex, parseDocumentHeadings } from "@/hooks/use-document-headings";
 import type { DocumentHeading } from "@/hooks/use-document-headings";
 import { parseDocument, parseFrontmatter } from "@/lib/frontmatter";
-import { getFileName, resolveLinkTarget } from "@/lib/paths";
+import {
+  formatMarkdownDestination,
+  getFileName,
+  normalizeMarkdownDestination,
+  resolveLinkTarget,
+} from "@/lib/paths";
 import { consumePendingAnchor, setPendingAnchor } from "@/lib/pending-anchor";
 import { logTimeline, mark } from "@/lib/startup-metrics";
 import * as tauri from "@/lib/tauri";
@@ -199,7 +204,7 @@ async function handleImagePaste(
   const format = file.type.split("/")[1] || "png";
   const result = await tauri.saveClipboardImage(filePath, imageData, format);
   if (isDisposed()) return;
-  const imageMarkdown = `![${file.name}](${result.relative_path})`;
+  const imageMarkdown = `![${file.name}](${formatMarkdownDestination(result.relative_path)})`;
   const cursor = view.state.selection.main.head;
   view.dispatch({ changes: { from: cursor, insert: imageMarkdown } });
 }
@@ -258,7 +263,7 @@ function getLinkHref(view: EditorView, pos: number) {
 
       do {
         if (cursor.name === "URL") {
-          href = view.state.doc.sliceString(cursor.from, cursor.to);
+          href = normalizeMarkdownDestination(view.state.doc.sliceString(cursor.from, cursor.to));
           return false;
         }
       } while (cursor.nextSibling());
@@ -277,7 +282,7 @@ function getRawUrl(view: EditorView, pos: number) {
     enter(node) {
       if (node.name !== "URL") return;
       if (node.node.parent?.name === "Link") return false;
-      href = view.state.doc.sliceString(node.from, node.to);
+      href = normalizeMarkdownDestination(view.state.doc.sliceString(node.from, node.to));
       return false;
     },
   });

--- a/apps/desktop/src/lib/paths.ts
+++ b/apps/desktop/src/lib/paths.ts
@@ -7,6 +7,7 @@ export function getFileExtension(path: string): string {
 
 const WINDOWS_ABSOLUTE_PATH = /^[A-Za-z]:[\\/]/;
 const EXPLICIT_URL_SCHEME = /^[A-Za-z][A-Za-z\d+.-]*:/;
+const MARKDOWN_ESCAPABLE = new Set(`!"#$%&'()*+,-./:;<=>?@[\\]^_\`{|}~ \t`.split(""));
 
 export type LinkTarget =
   | { kind: "internal"; path: string; anchor?: string }
@@ -29,12 +30,45 @@ function extractAnchor(href: string): string | undefined {
   return anchor ? decodeLinkPath(anchor) : undefined;
 }
 
-function decodeLinkPath(path: string): string {
+export function decodeLinkPath(path: string): string {
   try {
     return decodeURIComponent(path);
   } catch {
     return path;
   }
+}
+
+function unescapeMarkdownDestination(path: string): string {
+  let result = "";
+  for (let index = 0; index < path.length; index++) {
+    const char = path[index]!;
+    const next = path[index + 1];
+    if (char === "\\" && next && MARKDOWN_ESCAPABLE.has(next)) {
+      result += next;
+      index++;
+      continue;
+    }
+    result += char;
+  }
+  return result;
+}
+
+export function normalizeMarkdownDestination(destination: string): string {
+  let normalized = destination.trim();
+  if (normalized.startsWith("<") && normalized.endsWith(">")) {
+    normalized = normalized.slice(1, -1).trim();
+  }
+  return unescapeMarkdownDestination(normalized);
+}
+
+export function normalizeLocalMarkdownDestination(destination: string): string {
+  return decodeLinkPath(normalizeMarkdownDestination(destination));
+}
+
+export function formatMarkdownDestination(destination: string): string {
+  if (!/[\s<>]/.test(destination)) return destination;
+  const escaped = destination.replace(/</g, "%3C").replace(/>/g, "%3E");
+  return `<${escaped}>`;
 }
 
 export function normalizePath(path: string): string {
@@ -93,7 +127,7 @@ export async function resolveLinkTarget(
   workspaceRoot?: string | null,
   fileExists?: FileExistsFn,
 ): Promise<LinkTarget | null> {
-  const trimmed = href.trim();
+  const trimmed = normalizeMarkdownDestination(href);
   if (!trimmed) return null;
   if (trimmed.startsWith("#")) {
     const anchor = extractAnchor(trimmed);
@@ -181,12 +215,11 @@ export function getParentDir(path: string): string {
 }
 
 export function resolveImagePath(imageSrc: string, markdownDir: string): string {
-  if (
-    imageSrc.startsWith("/") ||
-    imageSrc.startsWith("http://") ||
-    imageSrc.startsWith("https://")
-  ) {
-    return imageSrc;
+  const normalizedSrc = normalizeMarkdownDestination(imageSrc);
+  if (normalizedSrc.startsWith("http://") || normalizedSrc.startsWith("https://")) {
+    return normalizedSrc;
   }
-  return `${markdownDir.replace(/\/$/, "")}/${imageSrc}`;
+  const localSrc = decodeLinkPath(normalizedSrc);
+  if (localSrc.startsWith("/")) return localSrc;
+  return `${markdownDir.replace(/\/$/, "")}/${localSrc}`;
 }

--- a/apps/desktop/src/lib/prosemark-core/clickLink.ts
+++ b/apps/desktop/src/lib/prosemark-core/clickLink.ts
@@ -3,6 +3,7 @@ import { HighlightStyle, syntaxHighlighting, syntaxTree } from "@codemirror/lang
 import { eventHandlersWithClass, iterChildren } from "./utils";
 import { markdownTags } from "./markdown/tags";
 import { Facet } from "@codemirror/state";
+import { normalizeMarkdownDestination } from "@/lib/paths";
 
 function getUrlFromLink(view: EditorView, pos: number): string | undefined {
   const tree = syntaxTree(view.state);
@@ -17,7 +18,7 @@ function getUrlFromLink(view: EditorView, pos: number): string | undefined {
 
       iterChildren(node.node.cursor(), (cursor) => {
         if (cursor.name === "URL") {
-          url = view.state.doc.sliceString(cursor.from, cursor.to);
+          url = normalizeMarkdownDestination(view.state.doc.sliceString(cursor.from, cursor.to));
           return true;
         }
       });
@@ -70,7 +71,7 @@ const getRawUrl = (view: EditorView, pos: number): string | undefined => {
       if (node.name !== "URL") return;
       if (node.node.parent?.name === "Link") return;
 
-      url = view.state.doc.sliceString(node.from, node.to);
+      url = normalizeMarkdownDestination(view.state.doc.sliceString(node.from, node.to));
       return true;
     },
   });

--- a/apps/desktop/src/lib/prosemark-core/fold/image.ts
+++ b/apps/desktop/src/lib/prosemark-core/fold/image.ts
@@ -1,4 +1,5 @@
 import { Decoration, WidgetType } from "@codemirror/view";
+import { normalizeMarkdownDestination } from "@/lib/paths";
 import { foldableSyntaxFacet, selectAllDecorationsOnSelectExtension } from "./core";
 import { iterChildren } from "../utils";
 
@@ -40,7 +41,7 @@ export const imageExtension = [
       let imageUrl: string | undefined;
       iterChildren(node.node.cursor(), (node) => {
         if (node.name === "URL") {
-          imageUrl = state.doc.sliceString(node.from, node.to);
+          imageUrl = normalizeMarkdownDestination(state.doc.sliceString(node.from, node.to));
         }
 
         return undefined;

--- a/apps/desktop/src/lib/prosemark-core/markdown/index.ts
+++ b/apps/desktop/src/lib/prosemark-core/markdown/index.ts
@@ -4,6 +4,7 @@ import { additionalMarkdownSyntaxTags } from "../syntaxHighlighting";
 import { frontmatterMarkdownSyntaxExtension } from "./frontmatter";
 import { nestedLinkAsPlainText } from "./nestedLinkAsPlainText";
 import { mathMarkdownSyntaxExtension } from "./mathMarkdown";
+import { spaceDestinationLinksMarkdownSyntaxExtension } from "./spaceDestinationLinks";
 
 export { markdownTags } from "./tags";
 export {
@@ -16,10 +17,12 @@ export { escapeMarkdownSyntaxExtension } from "../hide";
 export { additionalMarkdownSyntaxTags } from "../syntaxHighlighting";
 export { emojiMarkdownSyntaxExtension, dashMarkdownSyntaxExtension } from "../fold";
 export { mathDelimiterTag, mathFormulaTag, mathMarkdownSyntaxExtension } from "./mathMarkdown";
+export { spaceDestinationLinksMarkdownSyntaxExtension } from "./spaceDestinationLinks";
 
 export const prosemarkMarkdownSyntaxExtensions = [
   additionalMarkdownSyntaxTags,
   frontmatterMarkdownSyntaxExtension,
+  spaceDestinationLinksMarkdownSyntaxExtension,
   nestedLinkAsPlainText,
   escapeMarkdownSyntaxExtension,
   emojiMarkdownSyntaxExtension,

--- a/apps/desktop/src/lib/prosemark-core/markdown/spaceDestinationLinks.ts
+++ b/apps/desktop/src/lib/prosemark-core/markdown/spaceDestinationLinks.ts
@@ -1,0 +1,188 @@
+import { InlineContext, type MarkdownConfig } from "@lezer/markdown";
+
+interface DestinationRange {
+  contentFrom: number;
+  contentTo: number;
+  closeParen: number;
+}
+
+interface TitleSplit {
+  urlFrom: number;
+  urlTo: number;
+  titleFrom?: number;
+  titleTo?: number;
+}
+
+function isInlineSpace(char: number): boolean {
+  return char === 32 || char === 9;
+}
+
+function trimInlineSpaceEnd(cx: InlineContext, from: number, to: number): number {
+  let end = to;
+  while (end > from && isInlineSpace(cx.char(end - 1))) end--;
+  return end;
+}
+
+function isEscaped(cx: InlineContext, pos: number): boolean {
+  let backslashes = 0;
+  for (let index = pos - 1; cx.char(index) === 92; index--) backslashes++;
+  return backslashes % 2 === 1;
+}
+
+function parseDestination(cx: InlineContext, openParen: number): DestinationRange | null {
+  if (cx.char(openParen) !== 40) return null;
+
+  const contentFrom = cx.skipSpace(openParen + 1);
+  let depth = 0;
+  let escaped = false;
+
+  for (let pos = contentFrom; pos < cx.end; pos++) {
+    const char = cx.char(pos);
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === 92) {
+      escaped = true;
+      continue;
+    }
+    if (char === 10) return null;
+    if (char === 40) {
+      depth++;
+      continue;
+    }
+    if (char === 41) {
+      if (depth === 0) {
+        return {
+          contentFrom,
+          contentTo: trimInlineSpaceEnd(cx, contentFrom, pos),
+          closeParen: pos,
+        };
+      }
+      depth--;
+    }
+  }
+
+  return null;
+}
+
+function findOpeningQuote(cx: InlineContext, from: number, to: number, quote: number) {
+  for (let pos = to - 2; pos >= from; pos--) {
+    if (cx.char(pos) === quote && !isEscaped(cx, pos)) return pos;
+  }
+  return -1;
+}
+
+function findOpeningParenTitle(cx: InlineContext, from: number, to: number) {
+  let depth = 0;
+  for (let pos = to - 1; pos >= from; pos--) {
+    const char = cx.char(pos);
+    if (isEscaped(cx, pos)) continue;
+    if (char === 41) {
+      depth++;
+      continue;
+    }
+    if (char === 40) {
+      depth--;
+      if (depth === 0) return pos;
+    }
+  }
+  return -1;
+}
+
+function splitTrailingTitle(cx: InlineContext, contentFrom: number, contentTo: number): TitleSplit {
+  if (contentTo <= contentFrom) return { urlFrom: contentFrom, urlTo: contentTo };
+
+  const last = cx.char(contentTo - 1);
+  if ((last === 34 || last === 39) && !isEscaped(cx, contentTo - 1)) {
+    const opening = findOpeningQuote(cx, contentFrom, contentTo, last);
+    if (opening > contentFrom && isInlineSpace(cx.char(opening - 1))) {
+      return {
+        urlFrom: contentFrom,
+        urlTo: trimInlineSpaceEnd(cx, contentFrom, opening - 1),
+        titleFrom: opening,
+        titleTo: contentTo,
+      };
+    }
+  }
+
+  if (last === 41 && !isEscaped(cx, contentTo - 1)) {
+    const opening = findOpeningParenTitle(cx, contentFrom, contentTo);
+    if (opening > contentFrom && isInlineSpace(cx.char(opening - 1))) {
+      return {
+        urlFrom: contentFrom,
+        urlTo: trimInlineSpaceEnd(cx, contentFrom, opening - 1),
+        titleFrom: opening,
+        titleTo: contentTo,
+      };
+    }
+  }
+
+  return { urlFrom: contentFrom, urlTo: contentTo };
+}
+
+function hasDestinationSpace(cx: InlineContext, from: number, to: number): boolean {
+  for (let pos = from; pos < to; pos++) {
+    const char = cx.char(pos);
+    if (isInlineSpace(char)) return true;
+  }
+  return false;
+}
+
+function getOpeningDelimiter(cx: InlineContext) {
+  const linkOpening = cx.findOpeningDelimiter(InlineContext.linkStart);
+  const imageOpening = cx.findOpeningDelimiter(InlineContext.imageStart);
+  const openings = [linkOpening, imageOpening].filter((value): value is number => value !== null);
+  if (openings.length === 0) return null;
+
+  const index = Math.max(...openings);
+  const delimiter = cx.getDelimiterAt(index);
+  if (!delimiter) return null;
+
+  return {
+    index,
+    from: delimiter.from,
+    to: delimiter.to,
+    nodeName: delimiter.type === InlineContext.imageStart ? "Image" : "Link",
+  };
+}
+
+export const spaceDestinationLinksMarkdownSyntaxExtension: MarkdownConfig = {
+  parseInline: [
+    {
+      name: "SpaceDestinationLinkEnd",
+      before: "LinkEnd",
+      parse(cx, next, closeBracket) {
+        if (next !== 93) return -1;
+
+        const opening = getOpeningDelimiter(cx);
+        if (!opening) return -1;
+
+        const openParen = closeBracket + 1;
+        if (cx.char(openParen) !== 40) return -1;
+
+        const destination = parseDestination(cx, openParen);
+        if (!destination) return -1;
+
+        const split = splitTrailingTitle(cx, destination.contentFrom, destination.contentTo);
+        if (!hasDestinationSpace(cx, split.urlFrom, split.urlTo)) return -1;
+
+        const content = cx.takeContent(opening.index);
+        content.unshift(cx.elt("LinkMark", opening.from, opening.to));
+        content.push(
+          cx.elt("LinkMark", closeBracket, closeBracket + 1),
+          cx.elt("LinkMark", openParen, openParen + 1),
+          cx.elt("URL", split.urlFrom, split.urlTo),
+        );
+        if (split.titleFrom !== undefined && split.titleTo !== undefined) {
+          content.push(cx.elt("LinkTitle", split.titleFrom, split.titleTo));
+        }
+        content.push(cx.elt("LinkMark", destination.closeParen, destination.closeParen + 1));
+
+        return cx.addElement(
+          cx.elt(opening.nodeName, opening.from, destination.closeParen + 1, content),
+        );
+      },
+    },
+  ],
+};

--- a/apps/desktop/tests/image-paste.test.ts
+++ b/apps/desktop/tests/image-paste.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, vi } from "vite-plus/test";
-import { getParentDir, resolveImagePath } from "../src/lib/paths";
+import { formatMarkdownDestination, getParentDir, resolveImagePath } from "../src/lib/paths";
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn(),
@@ -25,6 +25,24 @@ describe("resolveImagePath", () => {
   test("handles subdirectory paths", () => {
     expect(resolveImagePath("sub/dir/img.png", "/workspace/docs")).toBe(
       "/workspace/docs/sub/dir/img.png",
+    );
+  });
+
+  test("handles angle-bracket image paths with spaces", () => {
+    expect(resolveImagePath("<note assets/img file.png>", "/workspace/docs")).toBe(
+      "/workspace/docs/note assets/img file.png",
+    );
+  });
+
+  test("handles percent-encoded image paths with spaces", () => {
+    expect(resolveImagePath("note%20assets/img%20file.png", "/workspace/docs")).toBe(
+      "/workspace/docs/note assets/img file.png",
+    );
+  });
+
+  test("formats generated image destinations with spaces", () => {
+    expect(formatMarkdownDestination("My Note-assets/image.png")).toBe(
+      "<My Note-assets/image.png>",
     );
   });
 });

--- a/apps/desktop/tests/markdown-links.test.ts
+++ b/apps/desktop/tests/markdown-links.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "vite-plus/test";
+import { ensureSyntaxTree, syntaxTree } from "@codemirror/language";
+import { markdown } from "@codemirror/lang-markdown";
+import { EditorState } from "@codemirror/state";
+import { GFM } from "@lezer/markdown";
+import { prosemarkMarkdownSyntaxExtensions } from "../src/lib/prosemark-core/markdown";
+
+function makeState(doc: string): EditorState {
+  const state = EditorState.create({
+    doc,
+    extensions: [markdown({ extensions: [GFM, prosemarkMarkdownSyntaxExtensions] })],
+  });
+  ensureSyntaxTree(state, doc.length, 1000);
+  return state;
+}
+
+function nodeTexts(doc: string, nodeName: string): string[] {
+  const state = makeState(doc);
+  const texts: string[] = [];
+  syntaxTree(state).iterate({
+    enter(node) {
+      if (node.name === nodeName) texts.push(doc.slice(node.from, node.to));
+    },
+  });
+  return texts;
+}
+
+describe("markdown links with spaced destinations", () => {
+  test("parses bare-space markdown link destinations", () => {
+    const doc = "[Todo Label](Writer TODOs.md)";
+    expect(nodeTexts(doc, "Link")).toEqual([doc]);
+    expect(nodeTexts(doc, "URL")).toEqual(["Writer TODOs.md"]);
+  });
+
+  test("parses bare-space markdown image destinations", () => {
+    const doc = "![Image Label](Writer TODOs-assets/20260525 image.png)";
+    expect(nodeTexts(doc, "Image")).toEqual([doc]);
+    expect(nodeTexts(doc, "URL")).toEqual(["Writer TODOs-assets/20260525 image.png"]);
+  });
+
+  test("keeps quoted titles separate from spaced destinations", () => {
+    const doc = '[Todo](Writer TODOs.md "Readable Title")';
+    expect(nodeTexts(doc, "Link")).toEqual([doc]);
+    expect(nodeTexts(doc, "URL")).toEqual(["Writer TODOs.md"]);
+    expect(nodeTexts(doc, "LinkTitle")).toEqual(['"Readable Title"']);
+  });
+
+  test("leaves standard title parsing intact when the destination has no spaces", () => {
+    const doc = '[Todo](writer-todos.md "Readable Title")';
+    expect(nodeTexts(doc, "URL")).toEqual(["writer-todos.md"]);
+    expect(nodeTexts(doc, "LinkTitle")).toEqual(['"Readable Title"']);
+  });
+});

--- a/apps/desktop/tests/paths.test.ts
+++ b/apps/desktop/tests/paths.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, test } from "vite-plus/test";
 import {
+  formatMarkdownDestination,
   getFileExtension,
   getFileName,
   getFileStem,
   getRelativePath,
+  normalizeLocalMarkdownDestination,
+  normalizeMarkdownDestination,
   normalizePath,
   resolveLinkTarget,
 } from "../src/lib/paths";
@@ -83,6 +86,30 @@ describe("normalizePath", () => {
   });
 });
 
+describe("markdown destinations", () => {
+  test("strips angle brackets around destinations", () => {
+    expect(normalizeMarkdownDestination("<Writer TODOs.md>")).toBe("Writer TODOs.md");
+  });
+
+  test("unescapes markdown escaped spaces", () => {
+    expect(normalizeMarkdownDestination("Writer\\ TODOs.md")).toBe("Writer TODOs.md");
+  });
+
+  test("decodes local percent escapes after markdown normalization", () => {
+    expect(normalizeLocalMarkdownDestination("<Writer%20TODOs.md>")).toBe("Writer TODOs.md");
+  });
+
+  test("wraps generated destinations with spaces in angle brackets", () => {
+    expect(formatMarkdownDestination("Writer TODOs-assets/image.png")).toBe(
+      "<Writer TODOs-assets/image.png>",
+    );
+  });
+
+  test("leaves generated destinations without spaces unchanged", () => {
+    expect(formatMarkdownDestination("note-assets/image.png")).toBe("note-assets/image.png");
+  });
+});
+
 describe("resolveLinkTarget", () => {
   test("resolves relative markdown links inside the workspace", async () => {
     expect(await resolveLinkTarget("../ideas/next.md", "/vault/daily/today.md", "/vault")).toEqual({
@@ -103,6 +130,20 @@ describe("resolveLinkTarget", () => {
 
   test("decodes encoded local markdown paths", async () => {
     expect(await resolveLinkTarget("./My%20Guide.md", "/vault/docs/start.md", "/vault")).toEqual({
+      kind: "internal",
+      path: "/vault/docs/My Guide.md",
+    });
+  });
+
+  test("resolves angle-bracket local markdown paths with spaces", async () => {
+    expect(await resolveLinkTarget("<./My Guide.md>", "/vault/docs/start.md", "/vault")).toEqual({
+      kind: "internal",
+      path: "/vault/docs/My Guide.md",
+    });
+  });
+
+  test("resolves markdown-escaped spaces in local paths", async () => {
+    expect(await resolveLinkTarget("./My\\ Guide.md", "/vault/docs/start.md", "/vault")).toEqual({
       kind: "internal",
       path: "/vault/docs/My Guide.md",
     });

--- a/apps/desktop/tests/wiki-links.test.ts
+++ b/apps/desktop/tests/wiki-links.test.ts
@@ -144,6 +144,26 @@ describe("resolveWikiLink", () => {
     expect(fuzzySearch).not.toHaveBeenCalled();
   });
 
+  test("resolves workspace-relative paths with spaces and aliases with spaces", async () => {
+    const fuzzySearch = vi.fn();
+    const fileExists = vi.fn().mockResolvedValue(true);
+
+    const result = await resolveWikiLink(
+      "Project Notes/My Note|Label With Spaces",
+      "/vault",
+      fuzzySearch,
+      fileExists,
+    );
+
+    expect(result).toEqual({ kind: "internal", path: "/vault/Project Notes/My Note.md" });
+    expect(fileExists).toHaveBeenCalledWith("/vault/Project Notes/My Note.md");
+    expect(fuzzySearch).not.toHaveBeenCalled();
+    expect(parseWikiLink("Project Notes/My Note|Label With Spaces")).toMatchObject({
+      path: "Project Notes/My Note",
+      displayText: "Label With Spaces",
+    });
+  });
+
   test("returns unresolved for missing path target", async () => {
     const fuzzySearch = vi.fn();
     const fileExists = vi.fn().mockResolvedValue(false);


### PR DESCRIPTION
## Summary
- parse Markdown links/images whose local destinations contain spaces
- normalize angle-bracket, escaped, and percent-encoded local destinations across link/image consumers
- keep wiki-style links with spaced targets and aliases covered by tests

## Validation
- vp check (passes with existing unrelated E2E JS warnings)
- vp test
- cargo fmt --check
- cargo test
- cargo clippy (passes with existing Rust warnings)