### PR TITLE
Change default editor line height to 1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2026-05-26
 
+- Change the default editor line height to 1.8 so new and reset paragraph spacing matches the app's typographic fallback.
 - Fix rendered table-cell links so clicking markdown links and Obsidian wiki links navigates instead of unfolding the table source. Table-cell wiki links now render aliases correctly, including table-escaped separators like `[[Format your notes\|Formatting]]`.
 - Render inline markdown inside folded table preview cells. Bold, italic, inline code, links, strikethrough, escaped pipes, and common HTML entities now display as rendered inline content in table headers and body cells, while inline HTML stays text-only and the unfolded source-editing path is unchanged.
 - Render unfolded markdown tables as codeblock-styled source lines in the main editor. Tables still fold to the rendered preview when the selection is outside them, but selecting into a table now keeps the markdown editable while giving it the same code surface treatment as fenced code.

--- a/TODOS.md
+++ b/TODOS.md
@@ -6,6 +6,7 @@
 
 ## Done
 
+- Default paragraph line height — make new and reset editor line-height settings use 1.8 instead of 1.6.
 - Table cell link regressions: [`SPECs/table-cell-link-regressions-spec.md`](SPECs/table-cell-link-regressions-spec.md) — keep rendered table-cell links clickable without unfolding the table, and render Obsidian wiki links with table-escaped aliases correctly.
 - Table cell markdown preview: [`SPECs/table-cell-markdown-preview-spec.md`](SPECs/table-cell-markdown-preview-spec.md) — render inline markdown inside folded table preview cells instead of showing the raw markdown delimiters.
 - Table unfold codeblock display: [`SPECs/table-unfold-codeblock-spec.md`](SPECs/table-unfold-codeblock-spec.md) — render touched table markdown as codeblock-styled source lines in the main editor instead of plain prose.

--- a/apps/desktop/shared/settings.schema.json
+++ b/apps/desktop/shared/settings.schema.json
@@ -17,7 +17,7 @@
       "description": "Line height multiplier for the editor",
       "category": "Editor",
       "type": "number",
-      "default": 1.6,
+      "default": 1.8,
       "cssVar": "--writer-editor-line-height"
     },
     {


### PR DESCRIPTION
## Summary
- Change the editor line-height setting default from 1.6 to 1.8
- Update changelog and task tracker
- Preserve existing saved line-height overrides

## Validation
- vp check
- vp test
- cargo test
- cargo clippy
- cargo fmt --check