### PR TITLE
Animate sidebar folder caret rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2026-05-28
 
+- Animate the sidebar folder caret so it rotates smoothly between collapsed (pointing right) and expanded (pointing down) instead of swapping icons instantly. The caret rotation is now the only animated transition on sidebar rows — the hover background highlight and the icon/label opacity changes apply instantly.
 - Update the app icon across all platforms (macOS `.icns`, Windows `.ico`, Linux/Store PNGs, and Android/iOS launcher assets) and sync the marketing website favicon to match.
 - Show an arrow caret on folder hover in the sidebar, replacing the folder icon, so expand/collapse intent is clearer. Icons and labels now fade in/out with opacity rather than color transitions for a cleaner visual hierarchy.
 

--- a/apps/desktop/src/components/sidebar/file-tree-node.tsx
+++ b/apps/desktop/src/components/sidebar/file-tree-node.tsx
@@ -1,6 +1,6 @@
 import { memo, useEffect, useRef, type MouseEvent } from "react";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { ArrowDown01Icon, ArrowRight01Icon, File02Icon } from "@hugeicons/core-free-icons";
+import { ArrowRight01Icon, File02Icon } from "@hugeicons/core-free-icons";
 import { useIsActive, useResolvedDocumentTitle } from "@/hooks/use-tabs";
 import { getFileStem } from "@/lib/paths";
 import type { DirEntry } from "@/types/fs";
@@ -166,32 +166,33 @@ export const FileTreeNode = memo(function FileTreeNode({
       onMouseDown={(e) => e.preventDefault()}
       onClick={handleClick}
       onContextMenu={handleContextMenu}
-      className={`group ${entry.is_dir ? "group/folder " : ""}flex h-[32px] w-full items-center gap-1.5 overflow-hidden rounded-lg pr-2 text-left text-[13px] leading-[1.15] text-[var(--fg-base)] transition-colors hover:transition-none ${bgClassName}`}
+      className={`group ${entry.is_dir ? "group/folder " : ""}flex h-[32px] w-full items-center gap-1.5 overflow-hidden rounded-lg pr-2 text-left text-[13px] leading-[1.15] text-[var(--fg-base)] ${bgClassName}`}
       style={{ paddingLeft: depth === 0 ? 10 : depth * 12 + 6 }}
     >
       <span className="relative flex w-5 shrink-0 items-center justify-center">
         {entry.is_dir ? (
           <>
-            <span className="flex items-center justify-center opacity-60 transition-opacity group-hover:opacity-100 group-hover/folder:opacity-0 group-hover:transition-none">
+            <span className="flex items-center justify-center opacity-60 group-hover:opacity-100 group-hover/folder:opacity-0">
               <FolderIcon isExpanded={isExpanded} />
             </span>
-            <span className="absolute inset-0 flex items-center justify-center opacity-0 transition-opacity group-hover/folder:opacity-100 group-hover:transition-none">
+            <span className="absolute inset-0 flex items-center justify-center opacity-0 group-hover/folder:opacity-100">
               <HugeiconsIcon
-                icon={isExpanded ? ArrowDown01Icon : ArrowRight01Icon}
+                icon={ArrowRight01Icon}
                 size={16}
                 color="currentColor"
                 strokeWidth={2}
+                className={`transition-transform duration-200 ease-out ${isExpanded ? "rotate-90" : ""}`}
               />
             </span>
           </>
         ) : (
-          <span className="opacity-60 transition-opacity group-hover:opacity-100 group-hover:transition-none">
+          <span className="opacity-60 group-hover:opacity-100">
             <FileIcon />
           </span>
         )}
       </span>
       <span
-        className={`min-w-0 overflow-hidden text-ellipsis whitespace-nowrap transition-opacity ${isHighlighted ? "opacity-100" : "opacity-60 group-hover:opacity-100 group-hover:transition-none"}`}
+        className={`min-w-0 overflow-hidden text-ellipsis whitespace-nowrap ${isHighlighted ? "opacity-100" : "opacity-60 group-hover:opacity-100"}`}
       >
         {displayName}
       </span>


### PR DESCRIPTION
## Summary

Animates the sidebar folder caret's rotation and makes it the only animated transition on sidebar rows.

- Replace the instant collapsed/expanded chevron icon swap (`ArrowRight01Icon` ↔ `ArrowDown01Icon`) with a **single** `ArrowRight01Icon` that rotates 90° when expanded, via `transition-transform duration-200 ease-out`. The chevron now tweens smoothly between pointing-right (collapsed) and pointing-down (expanded) instead of snapping.
- Make that rotation the **only** animation on sidebar rows. Removed the row hover-background color fade (`transition-colors`) and the icon/label opacity fades (`transition-opacity`). Their hover, selected, and active states still apply — just instantly.

## Why a single rotating icon

Keeping one stable `<svg>` element across toggles means React doesn't remount it, so the CSS transition reliably fires. The rotation lives on the icon; nothing else transitions.

## Notes

- Tailwind v4's `transition-transform` compiles to `transition-property: transform, translate, scale, rotate`, so it animates the standalone `rotate` property that `rotate-90` sets — verified the rotation actually tweens rather than snaps.
- Only the static hover/opacity utility classes were kept; every `transition-*` except the caret's `transition-transform` was removed.

## Test plan

- `vp check` — passes, 0 errors (2 pre-existing warnings live in `e2e/` files, untouched here).
- Manual: hover a folder → caret appears instantly; click to expand/collapse → caret rotates smoothly; hover background highlight and icon/label brightening are instant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)