### PR TITLE
Add sidebar file-label setting and file rename action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 2026-05-28
 
 - Animate the sidebar folder caret so it rotates smoothly between collapsed (pointing right) and expanded (pointing down) instead of swapping icons instantly. The caret rotation is now the only animated transition on sidebar rows — the hover background highlight and the icon/label opacity changes apply instantly.
+- Add a "Sidebar File Label" appearance setting that chooses whether sidebar file entries show the document title (frontmatter `title:` or leading `# ` heading, falling back to the filename) or always the filename. Defaults to title, preserving current behavior.
+- Add a "Rename..." action to the sidebar file context menu, so files can be renamed from the sidebar like folders already could. It opens the existing inline rename field, which always edits the filename (not the displayed title), regardless of the Sidebar File Label setting.
 - Update the app icon across all platforms (macOS `.icns`, Windows `.ico`, Linux/Store PNGs, and Android/iOS launcher assets) and sync the marketing website favicon to match.
 - Show an arrow caret on folder hover in the sidebar, replacing the folder icon, so expand/collapse intent is clearer. Icons and labels now fade in/out with opacity rather than color transitions for a cleaner visual hierarchy.
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -6,6 +6,7 @@
 
 ## Done
 
+- Sidebar file label setting — add an `appearance.sidebar-file-label` enum (`title` | `filename`, default `title`) and have the sidebar file tree render the filename stem or the title-fallback chain accordingly. Also expose a "Rename..." action in the file context menu (files reuse the inline-rename flow folders already had).
 - Desktop dev script — make the root `dev` script delegate to the desktop package's Tauri dev workflow and keep desktop build/preview scripts on Vite+ commands.
 - Dependency lock refresh: [`SPECs/Agent/worksheet-dependency-lock-refresh.md`](SPECs/Agent/worksheet-dependency-lock-refresh.md) — refresh compatible Rust and JavaScript dependency lockfiles, including the `vite-plus` toolchain update, root TypeScript config alignment, and package-audit fixes.
 - Default paragraph line height — make new and reset editor line-height settings use 1.8 instead of 1.6.

--- a/apps/desktop/shared/settings.schema.json
+++ b/apps/desktop/shared/settings.schema.json
@@ -54,6 +54,15 @@
       "default": true
     },
     {
+      "key": "appearance.sidebar-file-label",
+      "label": "Sidebar File Label",
+      "description": "Show the document title or the filename for files in the sidebar",
+      "category": "Appearance",
+      "type": "enum",
+      "options": ["title", "filename"],
+      "default": "title"
+    },
+    {
       "key": "appearance.editor-width",
       "label": "Editor Width",
       "description": "Editor content width mode",

--- a/apps/desktop/src/components/sidebar/file-context-menu.ts
+++ b/apps/desktop/src/components/sidebar/file-context-menu.ts
@@ -12,6 +12,7 @@ export type FileMenuActionId =
   | "copy-relative-path"
   | "copy-absolute-path"
   | "reveal"
+  | "rename"
   | "delete";
 
 export interface FileContextMenuHandlers {
@@ -21,6 +22,7 @@ export interface FileContextMenuHandlers {
   onCopyRelativePath: () => void;
   onCopyAbsolutePath: () => void;
   onReveal: () => void;
+  onRename: () => void;
   onDelete: () => void;
 }
 
@@ -66,6 +68,7 @@ export function buildFileMenuItemsSpec(
       action: handlers.onReveal,
     },
     { kind: "separator" },
+    { kind: "item", id: "rename", text: "Rename...", action: handlers.onRename },
     { kind: "item", id: "delete", text: "Delete", action: handlers.onDelete },
   ];
 }

--- a/apps/desktop/src/components/sidebar/file-tree-node.tsx
+++ b/apps/desktop/src/components/sidebar/file-tree-node.tsx
@@ -56,6 +56,10 @@ interface FileTreeNodeProps {
   onContextMenu?: (event: MouseEvent<HTMLElement>, entry: DirEntry) => void;
   onRenameSubmit?: (entry: DirEntry, nextStem: string) => void;
   onRenameCancel?: () => void;
+  /** Tree-wide label mode from `appearance.sidebar-file-label`. `"filename"`
+   *  shows the file stem; anything else (incl. `undefined` pre-hydration)
+   *  shows the document title, falling back to the stem. */
+  fileLabelMode?: string;
 }
 
 export const FileTreeNode = memo(function FileTreeNode({
@@ -70,12 +74,15 @@ export const FileTreeNode = memo(function FileTreeNode({
   onContextMenu,
   onRenameSubmit,
   onRenameCancel,
+  fileLabelMode,
 }: FileTreeNodeProps) {
   const isActive = useIsActive(entry.path);
   const editorTitle = useResolvedDocumentTitle(entry.is_dir ? null : entry.path);
   const displayName = entry.is_dir
     ? entry.name
-    : editorTitle || entry.title || getFileStem(entry.name);
+    : fileLabelMode === "filename"
+      ? getFileStem(entry.name)
+      : editorTitle || entry.title || getFileStem(entry.name);
   const inputRef = useRef<HTMLInputElement>(null);
 
   // Auto-focus and select the stem when entering rename mode.

--- a/apps/desktop/src/components/sidebar/file-tree.tsx
+++ b/apps/desktop/src/components/sidebar/file-tree.tsx
@@ -9,6 +9,7 @@ import {
   useToggleDirectory,
 } from "@/hooks/use-file-tree";
 import { useOpenFile } from "@/hooks/use-tabs";
+import { useSetting } from "@/hooks/use-settings";
 import {
   getOpenFile,
   getOpenFiles,
@@ -65,6 +66,7 @@ export function FileTree({ rootPath }: FileTreeProps) {
   const invalidatePath = useInvalidatePath();
   const rewriteExpandedDir = useRewriteExpandedDir();
   const workspaceRoot = useWorkspaceRoot();
+  const fileLabelMode = useSetting("appearance.sidebar-file-label");
   const [renamingPath, setRenamingPath] = useState<string | null>(null);
   const [selectedPaths, setSelectedPaths] = useState<Set<string>>(new Set());
   const [selectionAnchor, setSelectionAnchor] = useState<string | null>(null);
@@ -239,6 +241,9 @@ export function FileTree({ rootPath }: FileTreeProps) {
               `Failed to reveal: ${error instanceof Error ? error.message : String(error)}`,
             );
           });
+        },
+        onRename: () => {
+          setRenamingPath(entry.path);
         },
         onDelete: () => {
           void (async () => {
@@ -465,6 +470,7 @@ export function FileTree({ rootPath }: FileTreeProps) {
           onContextMenu={handleContextMenu}
           onRenameSubmit={handleRenameSubmit}
           onRenameCancel={handleRenameCancel}
+          fileLabelMode={fileLabelMode}
         />
       ))}
     </div>

--- a/apps/desktop/tests/file-context-menu.test.ts
+++ b/apps/desktop/tests/file-context-menu.test.ts
@@ -27,6 +27,7 @@ function makeHandlers(): FileContextMenuHandlers & { calls: string[] } {
     onCopyRelativePath: () => calls.push("copy-relative-path"),
     onCopyAbsolutePath: () => calls.push("copy-absolute-path"),
     onReveal: () => calls.push("reveal"),
+    onRename: () => calls.push("rename"),
     onDelete: () => calls.push("delete"),
   };
 }
@@ -112,6 +113,7 @@ describe("buildFileMenuItemsSpec", () => {
       "---",
       "reveal:Reveal in Finder",
       "---",
+      "rename:Rename...",
       "delete:Delete",
     ]);
   });
@@ -149,6 +151,7 @@ describe("buildFileMenuItemsSpec", () => {
       "copy-relative-path",
       "copy-absolute-path",
       "reveal",
+      "rename",
       "delete",
     ]);
   });


### PR DESCRIPTION
## Summary

Two related sidebar enhancements:

1. **Sidebar File Label setting** — a new `appearance.sidebar-file-label` enum (`title` | `filename`, default `title`) under Settings → Appearance. In `title` mode (current behavior) file rows show the document title — frontmatter `title:` or leading `# ` heading — falling back to the filename. In `filename` mode they always show the filename stem.
2. **Rename files from the sidebar** — adds a "Rename..." item to the file context menu, mirroring the folder menu. Files reuse the existing inline-rename flow, which always edits the filename (the stem) regardless of the label mode.

## Implementation notes

- The setting is declared once in `shared/settings.schema.json` — the single source of truth read by both Rust (`include_str!`) and the typed frontend `useSetting` — per the consolidation doc.
- The label mode is tree-wide state, so it's read once in `FileTree` and threaded to each `FileTreeNode` as a prop: one store subscription rather than one per node. The full label derivation stays co-located in the node.
- Renaming was already ~95% built (inline field, on-disk rename, open-tab path rewrite); only the file context menu lacked the entry folders already had.

## Testing

- `vp check` — 0 errors
- `vp test` — 436 passed (includes updated `file-context-menu.test.ts` asserting the new "Rename..." item)
- `cargo test` — 103 passed (confirms the Rust backend parses the new schema entry and builds defaults)

🤖 Generated with [Claude Code](https://claude.com/claude-code)