### PR TITLE
Fix cold-start target opens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-06-01
+
+- Fix cold starts from a concrete folder or markdown file target, including `writer <path>` and OS file/folder opens. Pending-open startup now treats the launch target as authoritative: it hydrates the requested workspace in target-only mode instead of restoring the last workspace or saved tab session, opens exactly the requested file when one was provided, and starts single-file launches with the sidebar closed for that startup.
+
 ## 2026-05-28
 
 - Animate the sidebar folder caret so it rotates smoothly between collapsed (pointing right) and expanded (pointing down) instead of swapping icons instantly. The caret rotation is now the only animated transition on sidebar rows — the hover background highlight and the icon/label opacity changes apply instantly.

--- a/SPECs/Agent/worksheet-cold-start-target-open.md
+++ b/SPECs/Agent/worksheet-cold-start-target-open.md
@@ -1,0 +1,61 @@
+# Worksheet: Cold-Start Target Open
+
+## Task
+
+TODO: `Cold-start target open` in `TODOS.md`.
+
+User request from Joel: if Writer cold-starts from the CLI or an OS file/folder open target, ignore the previous workspace/session and open only that target. Single-file launches must start with the sidebar closed. Prefer passing launch state from Rust to the webview before React renders.
+
+## Files and Docs Reviewed
+
+- `AGENTS.md`
+- `TODOS.md`
+- `docs/workflows/agent-loop.md`
+- `docs/react-guidelines.md`
+- `docs/zustand.md`
+- `docs/consolidation.md`
+- `docs/vite-plus.md`
+- `apps/desktop/src-tauri/src/lib.rs`
+- `apps/desktop/src-tauri/src/open_target.rs`
+- `apps/desktop/src-tauri/src/state.rs`
+- `apps/desktop/src-tauri/src/commands/startup.rs`
+- `apps/desktop/src-tauri/src/commands/workspace.rs`
+- `apps/desktop/src/hooks/use-open-drop.ts`
+- `apps/desktop/src/stores/workspace-store.ts`
+- `apps/desktop/src/stores/editor-store.ts`
+- `apps/desktop/src/stores/settings-store.ts`
+- `apps/desktop/tests/stores.test.ts`
+
+## Investigation
+
+- Cold-start targets are already canonicalized into `PendingOpenPayload` on the Rust side and returned by `get_startup_state`.
+- `get_startup_state` already prefers a pending-open workspace over the most recent workspace for bundle prefetch.
+- The bug is that the pending-open bundle still includes the workspace's saved session. The frontend restores that session first, then processes the target. File launches can therefore resurrect prior tabs, and folder launches reopen prior files.
+- Sidebar visibility is currently only a settings value. A file-launch override can be applied during startup hydration without persisting a settings change.
+
+## Plan
+
+- Add target-only restore-bundle mode in Rust. Pending-open startup uses it; ordinary restore and user workspace switches keep session restore.
+- Update frontend startup hydration so a pending-open bundle is hydrated with the pending payload and not processed a second time.
+- Override `appearance.sidebar-visible` to `false` in the startup settings snapshot for file launches only.
+- Add focused tests in `apps/desktop/tests/stores.test.ts` for file/folder target hydration and sidebar override.
+- Update `CHANGELOG.md`, move TODO to Done, run frontend and Rust validation, then commit and open a PR.
+
+## Implementation
+
+- Added `RestoreBundleMode` to the Rust workspace restore path. `restore_workspace` still restores sessions; `get_startup_state` uses `LaunchTarget` mode for pending opens, skipping session loading and prefetching the requested file when present.
+- Extended `workspace-store.restoreFromBundle` to accept an optional launch target. When provided, it ignores any session in the bundle and either opens exactly the target file or creates the launcher tab for a folder target.
+- Updated startup hydration to apply the file-launch sidebar override before settings reach React, and to avoid processing the same pending-open payload twice when the restore bundle already handled it.
+- Runtime pending opens with no current workspace now use the same target-only frontend hydration path.
+- Routed cold-start macOS `RunEvent::Opened` payloads into the empty main window instead of creating a secondary window, so dock/app drag opens also flow through `get_startup_state` pending-open hydration.
+- Added store tests for file target hydration, folder target hydration, and sidebar override behavior.
+
+## Validation
+
+- `corepack pnpm install --frozen-lockfile` — used because `vp` was not initially on PATH and dependencies were not installed in the worktree.
+- `./node_modules/.bin/vp test apps/desktop/tests/stores.test.ts` — passed, 51 tests.
+- `./node_modules/.bin/vp check` — passed with existing warnings in `apps/desktop/e2e/specs/smoke.spec.js` and `apps/desktop/e2e/wdio.conf.js`.
+- `./node_modules/.bin/vp test` — passed, 440 tests.
+- `cargo fmt --check` — passed after installing a minimal Rust toolchain and rustfmt.
+- `cargo test` — blocked by missing native Linux build dependency: `pkg-config` is absent, so `glib-sys` cannot run `pkg-config --libs --cflags glib-2.0 'glib-2.0 >= 2.70'`.
+- `cargo clippy` — blocked for the same missing `pkg-config` / `glib-sys` build step.

--- a/SPECs/cold-start-target-open-spec.md
+++ b/SPECs/cold-start-target-open-spec.md
@@ -1,0 +1,32 @@
+# Cold-Start Target Open
+
+## Summary
+
+When Writer is not running and is launched with a concrete file or folder target, that launch target should be authoritative. Startup must not restore the most recent workspace or any prior tab session. It should open only the requested folder or markdown file.
+
+## Entry Points
+
+- `writer <folder>`
+- `writer <file.md>`
+- OS file/folder open routed to the app during cold start, including drag-to-app/dock open events that seed the pending-open queue before the webview hydrates
+
+## Behavior
+
+- Folder launch opens that folder as the workspace and shows the launcher tab instead of restoring the folder's saved tab session.
+- File launch opens the file's parent folder as the workspace and opens exactly that file.
+- File launch starts with the sidebar closed, regardless of the persisted sidebar visibility setting for normal launches.
+- Launch target handling happens through the existing Rust pending-open payload returned by `get_startup_state`, before React renders the app shell.
+- Runtime opens while Writer is already running keep the existing multi-window behavior.
+
+## Implementation Notes
+
+- Keep `PendingOpenPayload` as the single launch-target shape shared by CLI, drag/drop, dock-open, Rust startup, and frontend startup.
+- When `get_startup_state` sees a pending-open payload, build the restore bundle for that workspace in target-only mode: read root entries and recents, prefetch the target file when present, and intentionally skip session restore.
+- The frontend should hydrate the workspace bundle with the pending-open payload so target launches do not flow through normal session restoration.
+- Cold-start OS open events with no matching workspace should seed the empty main window's pending-open queue instead of spawning a secondary window.
+
+## Validation
+
+- Unit tests cover target-only bundle hydration for folder and file launches.
+- Unit tests cover the single-file sidebar visibility override.
+- Existing frontend and Rust validation should continue to pass.

--- a/TODOS.md
+++ b/TODOS.md
@@ -6,6 +6,7 @@
 
 ## Done
 
+- Cold-start target open: [`SPECs/cold-start-target-open-spec.md`](SPECs/cold-start-target-open-spec.md) — when Writer starts from a CLI/dock/drop file or folder target, ignore the previous workspace/session and open only that target; file targets start with the sidebar closed.
 - Sidebar file label setting — add an `appearance.sidebar-file-label` enum (`title` | `filename`, default `title`) and have the sidebar file tree render the filename stem or the title-fallback chain accordingly. Also expose a "Rename..." action in the file context menu (files reuse the inline-rename flow folders already had).
 - Desktop dev script — make the root `dev` script delegate to the desktop package's Tauri dev workflow and keep desktop build/preview scripts on Vite+ commands.
 - Dependency lock refresh: [`SPECs/Agent/worksheet-dependency-lock-refresh.md`](SPECs/Agent/worksheet-dependency-lock-refresh.md) — refresh compatible Rust and JavaScript dependency lockfiles, including the `vite-plus` toolchain update, root TypeScript config alignment, and package-audit fixes.

--- a/apps/desktop/src-tauri/src/commands/startup.rs
+++ b/apps/desktop/src-tauri/src/commands/startup.rs
@@ -1,6 +1,6 @@
 use crate::commands::settings::config_value_to_json;
 use crate::commands::workspace::{
-    build_restore_bundle, load_recent_workspaces, RestoreWorkspaceResponse,
+    build_restore_bundle, load_recent_workspaces, RestoreBundleMode, RestoreWorkspaceResponse,
 };
 use crate::error::AppError;
 use crate::state::AppState;
@@ -18,12 +18,13 @@ pub struct StartupState {
     pub recent_workspaces: Vec<String>,
     pub pending_open: Option<PendingOpenPayload>,
     /// Prefetched workspace restore payload. Populated when there is a
-    /// `pending_open` (CLI / drag-drop cold start — bundle is built for that
-    /// workspace) or, failing that, when `window.restore-workspace` is enabled
-    /// and the most-recent recent workspace still exists on disk. When
-    /// present, the frontend hydrates its stores synchronously from this
-    /// bundle so React's first render already has full content — no second
-    /// IPC waterfall, no intermediate "empty shell" frame.
+    /// `pending_open` (CLI / drag-drop cold start — bundle is built in
+    /// target-only mode for that workspace and optional file) or, failing
+    /// that, when `window.restore-workspace` is enabled and the most-recent
+    /// recent workspace still exists on disk. When present, the frontend
+    /// hydrates its stores synchronously from this bundle so React's first
+    /// render already has full content — no second IPC waterfall, no
+    /// intermediate "empty shell" frame.
     pub restore_bundle: Option<RestoreWorkspaceResponse>,
 }
 
@@ -64,18 +65,24 @@ pub async fn get_startup_state(
     // Secondary windows opened via `open_workspace_in_new_window` follow the
     // pending-open branch via their pre-seeded queue.
     let restore_target = if let Some(payload) = &pending_open {
-        Some(payload.workspace.clone())
+        Some((
+            payload.workspace.clone(),
+            RestoreBundleMode::LaunchTarget {
+                file: payload.file.clone(),
+            },
+        ))
     } else if restore_enabled {
         recent_workspaces
             .first()
             .filter(|path| Path::new(path).is_dir())
             .cloned()
+            .map(|path| (path, RestoreBundleMode::RestoreSession))
     } else {
         None
     };
 
-    let restore_bundle = if let Some(path) = restore_target {
-        match build_restore_bundle(&app, &label, &path).await {
+    let restore_bundle = if let Some((path, mode)) = restore_target {
+        match build_restore_bundle(&app, &label, &path, mode).await {
             Ok(bundle) => Some(bundle),
             Err(err) => {
                 // Don't let a failed restore abort startup — settings still

--- a/apps/desktop/src-tauri/src/commands/workspace.rs
+++ b/apps/desktop/src-tauri/src/commands/workspace.rs
@@ -228,15 +228,23 @@ pub struct RestoreWorkspaceResponse {
     pub active_file: Option<FileContent>,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) enum RestoreBundleMode {
+    RestoreSession,
+    LaunchTarget { file: Option<String> },
+}
+
 /// Shared workspace-restore body used by both the `restore_workspace` IPC
 /// (user-initiated workspace switches) and `get_startup_state` (cold start).
 /// Prepares workspace state synchronously, then fans out directory, recents,
-/// and session reads in parallel via `spawn_blocking`, and finally prefetches
-/// the active tab's file content when the session has one.
+/// and optional session reads in parallel via `spawn_blocking`, and finally
+/// prefetches the active file content when either the session or launch target
+/// names one.
 pub(crate) async fn build_restore_bundle(
     app: &tauri::AppHandle,
     label: &str,
     path: &str,
+    mode: RestoreBundleMode,
 ) -> Result<RestoreWorkspaceResponse, AppError> {
     // Workspace state mutations (watcher, ignore matcher, indexing thread)
     // happen synchronously up front so the parallel reads below see
@@ -267,10 +275,14 @@ pub(crate) async fn build_restore_bundle(
             load_recent_workspaces(&app).unwrap_or_default()
         })
     };
-    let session_handle = {
+    let session_handle = if matches!(&mode, RestoreBundleMode::RestoreSession) {
         let app = app.clone();
         let root = canonical_root.clone();
-        tauri::async_runtime::spawn_blocking(move || load_session_impl(&app, &root))
+        Some(tauri::async_runtime::spawn_blocking(move || {
+            load_session_impl(&app, &root)
+        }))
+    } else {
+        None
     };
 
     let entries = entries_handle
@@ -279,14 +291,20 @@ pub(crate) async fn build_restore_bundle(
     let recent_workspaces = recents_handle
         .await
         .map_err(|e| AppError::Io(e.to_string()))?;
-    let session = session_handle
-        .await
-        .map_err(|e| AppError::Io(e.to_string()))??;
+    let session = if let Some(handle) = session_handle {
+        handle.await.map_err(|e| AppError::Io(e.to_string()))??
+    } else {
+        None
+    };
 
-    // If the session has an active tab, pre-fetch its content so the editor
-    // can mount with the file already loaded — saves another sequential IPC
-    // and the 40 ms `OPEN_FILE_GRACE_MS` wait on the frontend side.
-    let active_file = if let Some(active_path) = active_session_path(session.as_ref()) {
+    // If the restore mode names an active file, pre-fetch its content so the
+    // editor can mount with the file already loaded — saves another
+    // sequential IPC and the 40 ms `OPEN_FILE_GRACE_MS` wait on the frontend.
+    let active_path = match mode {
+        RestoreBundleMode::RestoreSession => active_session_path(session.as_ref()),
+        RestoreBundleMode::LaunchTarget { file } => file,
+    };
+    let active_file = if let Some(active_path) = active_path {
         tauri::async_runtime::spawn_blocking(move || read_file_impl(&active_path).ok())
             .await
             .map_err(|e| AppError::Io(e.to_string()))?
@@ -310,7 +328,7 @@ pub async fn restore_workspace(
     app: tauri::AppHandle,
 ) -> Result<RestoreWorkspaceResponse, AppError> {
     let label = webview.label().to_string();
-    build_restore_bundle(&app, &label, &path).await
+    build_restore_bundle(&app, &label, &path, RestoreBundleMode::RestoreSession).await
 }
 
 fn active_session_path(session: Option<&SessionData>) -> Option<String> {

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -44,6 +44,12 @@ fn queue_open_event(app: &tauri::AppHandle, label: &str, payload: PendingOpenPay
     let _ = app.emit_to(label, "open:from-drop", payload);
 }
 
+fn main_window_has_no_workspace(app: &tauri::AppHandle) -> bool {
+    app.state::<AppState>()
+        .get(MAIN_WINDOW_LABEL)
+        .is_some_and(|state| state.workspace_root.read().is_none())
+}
+
 /// Wire up per-window event handlers: drag-drop routes to the window's own
 /// pending-open queue, and the close/destroy event tears down the window's
 /// `WorkspaceState` (which drops the watcher, stopping FSEvents / inotify
@@ -487,6 +493,9 @@ pub fn run() {
                             match existing {
                                 Some(label) => {
                                     queue_open_event(_app, &label, payload);
+                                }
+                                None if main_window_has_no_workspace(_app) => {
+                                    queue_open_event(_app, MAIN_WINDOW_LABEL, payload);
                                 }
                                 None => {
                                     let _ = open_new_workspace_window(

--- a/apps/desktop/src/hooks/use-open-drop.ts
+++ b/apps/desktop/src/hooks/use-open-drop.ts
@@ -19,7 +19,9 @@ async function handleOpenPayload(payload: PendingOpenPayload) {
   }
 
   if (payload.workspace !== current) {
-    await useWorkspaceStore.getState().openWorkspace(payload.workspace);
+    const bundle = await tauri.restoreWorkspace(payload.workspace);
+    await useWorkspaceStore.getState().restoreFromBundle(bundle, payload);
+    return;
   }
   if (payload.file) {
     await useEditorStore.getState().openFile(payload.file);
@@ -77,6 +79,17 @@ export function createPendingOpenDrainer(
 
 const drainPendingOpens = createPendingOpenDrainer(tauri.takePendingOpen, queueOpenPayload);
 
+export function applyStartupLaunchOverrides(
+  settings: Record<string, unknown>,
+  pendingOpen: PendingOpenPayload | null,
+): Record<string, unknown> {
+  if (!pendingOpen?.file) return settings;
+  return {
+    ...settings,
+    "appearance.sidebar-visible": false,
+  };
+}
+
 // Guard against React 18 StrictMode double-mount
 let startupInitiated = false;
 let startupReady: Promise<void> = Promise.resolve();
@@ -95,18 +108,19 @@ async function resolveStartup() {
     const startup = await tauri.getStartupState();
     mark("ipc:get_startup_state:end");
 
+    pendingOpen = startup.pending_open;
+
     useSettingsStore.getState().hydrateFromBackend({
-      settings: startup.settings,
+      settings: applyStartupLaunchOverrides(startup.settings, pendingOpen),
     });
 
     useWorkspaceStore.setState({
       recentWorkspaces: startup.recent_workspaces,
     });
 
-    pendingOpen = startup.pending_open;
-
     if (startup.restore_bundle) {
-      await useWorkspaceStore.getState().restoreFromBundle(startup.restore_bundle);
+      await useWorkspaceStore.getState().restoreFromBundle(startup.restore_bundle, pendingOpen);
+      if (pendingOpen) pendingOpen = null;
     }
   } catch (error) {
     console.error("Failed to resolve startup state", error);

--- a/apps/desktop/src/lib/tauri.ts
+++ b/apps/desktop/src/lib/tauri.ts
@@ -182,11 +182,12 @@ export interface StartupState {
   settings: Record<string, unknown>;
   recent_workspaces: string[];
   pending_open: PendingOpenPayload | null;
-  /** Prefetched workspace restore payload. Populated when
-   *  `window.restore-workspace` is enabled, there's no pending open, and the
-   *  most-recent recent workspace still exists on disk. The frontend hydrates
-   *  its stores synchronously from this bundle before the first render, so
-   *  React mounts with full content instead of an empty shell. */
+  /** Prefetched workspace restore payload. Populated for pending-open cold
+   *  starts in target-only mode, or when `window.restore-workspace` is
+   *  enabled, there's no pending open, and the most-recent recent workspace
+   *  still exists on disk. The frontend hydrates its stores synchronously
+   *  from this bundle before the first render, so React mounts with full
+   *  content instead of an empty shell. */
   restore_bundle: RestoreWorkspaceResponse | null;
 }
 

--- a/apps/desktop/src/stores/workspace-store.ts
+++ b/apps/desktop/src/stores/workspace-store.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import type { DirEntry } from "@/types/fs";
-import type { RestoreWorkspaceResponse } from "@/lib/tauri";
+import type { PendingOpenPayload, RestoreWorkspaceResponse } from "@/lib/tauri";
 import * as tauri from "@/lib/tauri";
 import { saveSession, loadSession } from "@/lib/session";
 import { getEditorSessionSnapshot, useEditorStore } from "@/stores/editor-store";
@@ -16,7 +16,10 @@ interface WorkspaceState {
   openWorkspace: (path: string) => Promise<void>;
   /** Hydrate from a prefetched `RestoreWorkspaceResponse` (startup cold-path
    *  and user-initiated switches via the `restore_workspace` IPC). */
-  restoreFromBundle: (bundle: RestoreWorkspaceResponse) => Promise<void>;
+  restoreFromBundle: (
+    bundle: RestoreWorkspaceResponse,
+    launchTarget?: PendingOpenPayload | null,
+  ) => Promise<void>;
   closeWorkspace: () => void;
   setStartupResolved: () => void;
   refreshDirectory: (path: string) => Promise<void>;
@@ -94,7 +97,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     set({ root: null, directoryCache: new Map(), expandedDirs: new Set(), isIndexing: false });
   },
 
-  restoreFromBundle: async (bundle) => {
+  restoreFromBundle: async (bundle, launchTarget = null) => {
     // Clear editor state in case anything was hydrated by a parallel hook.
     useEditorStore.setState({
       openFiles: new Map(),
@@ -110,6 +113,25 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       expandedDirs: new Set(),
       recentWorkspaces: bundle.recent_workspaces,
     });
+
+    if (launchTarget) {
+      if (launchTarget.file) {
+        await useEditorStore.getState().restoreSession(
+          [
+            {
+              location: { kind: "file", path: launchTarget.file },
+              back: [],
+              forward: [],
+            },
+          ],
+          0,
+          bundle.active_file,
+        );
+      } else {
+        useEditorStore.getState().ensureLauncherTab();
+      }
+      return;
+    }
 
     if (bundle.session && bundle.session.tabs && bundle.session.tabs.length > 0) {
       // Fire-and-forget: `restoreSession` populates the active tab

--- a/apps/desktop/tests/stores.test.ts
+++ b/apps/desktop/tests/stores.test.ts
@@ -17,7 +17,7 @@ import { useUIStore } from "../src/stores/ui-store";
 import { useWorkspaceStore } from "../src/stores/workspace-store";
 import { toggleSidebar } from "../src/hooks/use-sidebar";
 import { toggleTheme } from "../src/hooks/use-theme";
-import { createPendingOpenDrainer } from "../src/hooks/use-open-drop";
+import { applyStartupLaunchOverrides, createPendingOpenDrainer } from "../src/hooks/use-open-drop";
 import { getEditorSessionSnapshot } from "../src/stores/editor-store";
 
 const mockedInvoke = vi.mocked(invoke);
@@ -78,6 +78,67 @@ describe("workspace-store", () => {
     expect(useEditorStore.getState().tabs).toEqual([
       { id: expect.any(String), location: { kind: "launcher" }, back: [], forward: [] },
     ]);
+  });
+
+  test("restoreFromBundle with a file launch target ignores saved session tabs", async () => {
+    const bundle = {
+      workspace: { root: "/ws", name: "ws", file_count: 0 },
+      entries: [],
+      recent_workspaces: ["/ws"],
+      session: {
+        tabs: [{ location: { kind: "file", path: "/ws/old.md" }, back: [], forward: [] }],
+        active_index: 0,
+      },
+      active_file: {
+        path: "/ws/target.md",
+        content: "---\ntitle: Target\n---\n\nBody",
+        modified_at: 1,
+      },
+    };
+
+    await useWorkspaceStore.getState().restoreFromBundle(bundle, {
+      workspace: "/ws",
+      file: "/ws/target.md",
+    });
+
+    const workspace = useWorkspaceStore.getState();
+    const editor = useEditorStore.getState();
+    expect(workspace.root).toBe("/ws");
+    expect(tabPaths()).toEqual(["/ws/target.md"]);
+    expect(editor.activeFilePath).toBe("/ws/target.md");
+    expect(editor.openFiles.get("/ws/target.md")?.title).toBe("Target");
+    expect(editor.openFiles.has("/ws/old.md")).toBe(false);
+    expect(mockedInvoke).not.toHaveBeenCalledWith("read_file", expect.anything());
+  });
+
+  test("restoreFromBundle with a folder launch target ignores saved session tabs", async () => {
+    const bundle = {
+      workspace: { root: "/ws", name: "ws", file_count: 0 },
+      entries: [],
+      recent_workspaces: ["/ws"],
+      session: {
+        tabs: [{ location: { kind: "file", path: "/ws/old.md" }, back: [], forward: [] }],
+        active_index: 0,
+      },
+      active_file: {
+        path: "/ws/old.md",
+        content: "Old",
+        modified_at: 1,
+      },
+    };
+
+    await useWorkspaceStore.getState().restoreFromBundle(bundle, {
+      workspace: "/ws",
+      file: null,
+    });
+
+    const editor = useEditorStore.getState();
+    expect(tabPaths()).toEqual([]);
+    expect(editor.tabs).toEqual([
+      { id: expect.any(String), location: { kind: "launcher" }, back: [], forward: [] },
+    ]);
+    expect(editor.activeFilePath).toBeNull();
+    expect(editor.openFiles.size).toBe(0);
   });
 
   test("toggleDirectory expands and collapses", async () => {
@@ -753,6 +814,35 @@ describe("workspace-store isStartupResolved", () => {
   test("setStartupResolved sets it to true", () => {
     useWorkspaceStore.getState().setStartupResolved();
     expect(useWorkspaceStore.getState().isStartupResolved).toBe(true);
+  });
+});
+
+describe("startup launch overrides", () => {
+  test("single-file launch starts with the sidebar hidden without mutating the source settings", () => {
+    const settings = {
+      "appearance.sidebar-visible": true,
+      "appearance.theme": "system",
+    };
+
+    const next = applyStartupLaunchOverrides(settings, {
+      workspace: "/ws",
+      file: "/ws/note.md",
+    });
+
+    expect(next).toEqual({
+      "appearance.sidebar-visible": false,
+      "appearance.theme": "system",
+    });
+    expect(settings["appearance.sidebar-visible"]).toBe(true);
+  });
+
+  test("folder launch keeps the persisted sidebar setting", () => {
+    const settings = {
+      "appearance.sidebar-visible": true,
+      "appearance.theme": "system",
+    };
+
+    expect(applyStartupLaunchOverrides(settings, { workspace: "/ws", file: null })).toBe(settings);
   });
 });
 


### PR DESCRIPTION
Summary:
- Treat cold-start pending-open payloads as authoritative launch targets instead of restoring the prior workspace/session.
- Add target-only restore bundle mode that skips saved session tabs and prefetches the requested file when present.
- Start single-file launches with the sidebar closed for that startup, and route cold-start macOS open events into the empty main window.
- Add spec, worksheet, changelog, and focused store coverage for file/folder launch targets.

Test plan:
- ./node_modules/.bin/vp check (passes with existing e2e JS warnings in apps/desktop/e2e/specs/smoke.spec.js and apps/desktop/e2e/wdio.conf.js)
- ./node_modules/.bin/vp test
- ./node_modules/.bin/vp test apps/desktop/tests/stores.test.ts
- cargo fmt --check
- cargo test (blocked: pkg-config is missing, so glib-sys cannot run pkg-config for glib-2.0 >= 2.70)
- cargo clippy (blocked by the same missing pkg-config / glib-sys build step)