### PR TITLE
Add virtual workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-06-01
+
+- Add CLI-managed virtual workspaces. `writer workspace new/list/open/add/remove/delete` now manages named collections of absolute file and folder references without copying, moving, renaming, or deleting the referenced files. Opening a virtual workspace shows a folder-style sidebar view that preserves nested folder structure, marks missing references as unavailable, and keeps virtual workspace remove/delete operations scoped to the workspace definition only. See `SPECs/virtual-workspaces-spec.md`.
+
 ## 2026-05-28
 
 - Animate the sidebar folder caret so it rotates smoothly between collapsed (pointing right) and expanded (pointing down) instead of swapping icons instantly. The caret rotation is now the only animated transition on sidebar rows — the hover background highlight and the icon/label opacity changes apply instantly.

--- a/SPECs/Agent/worksheet-virtual-workspaces.md
+++ b/SPECs/Agent/worksheet-virtual-workspaces.md
@@ -1,0 +1,69 @@
+# Worksheet: Virtual Workspaces
+
+## Task
+
+TODO: `Virtual workspaces` linked to `SPECs/virtual-workspaces-spec.md`.
+
+User request: implement named virtual file/folder collections exposed through `writer workspace ...`, with absolute-path references, folder nesting, graceful missing references, and safety semantics.
+
+## Git State
+
+Initial worktree status was clean on `feature/virtual-workspaces...origin/master`. An unrelated existing TODO item was already in `In Progress`; left intact.
+
+## Reviewed
+
+- `TODOS.md`
+- `docs/workflows/agent-loop.md`
+- `docs/consolidation.md`
+- `docs/vite-plus.md`
+- `SPECs/writer-cli-spec.md`
+- `apps/desktop/src-tauri/src/writer_cli.rs`
+- `apps/desktop/src-tauri/src/open_target.rs`
+- `apps/desktop/src-tauri/src/commands/workspace.rs`
+- `apps/desktop/src-tauri/src/commands/fs.rs`
+- `apps/desktop/src-tauri/src/commands/search.rs`
+- `apps/desktop/src-tauri/src/state.rs`
+- `apps/desktop/src/stores/workspace-store.ts`
+- `apps/desktop/src/components/sidebar/file-tree.tsx`
+- `apps/desktop/src/components/sidebar/file-tree-node.tsx`
+
+## Baseline Validation
+
+- `vp install` could not run because `vp` is not installed in this environment.
+- `cargo test writer_cli` and `cargo test open_target` both failed before tests ran because `pkg-config` is missing and `glib-sys` cannot build.
+
+## Plan
+
+1. Add a Rust virtual-workspace module that owns persistence, path validation, folder expansion, virtual URI parsing, and virtual index generation.
+2. Extend the dependency-free `writer` CLI parser with `workspace` subcommands and route mutations through the new module.
+3. Teach desktop startup/open paths to carry a virtual workspace URI through `PendingOpenPayload`.
+4. Teach workspace open, directory reads, and search indexing to branch on virtual workspace state.
+5. Mark virtual `DirEntry` values with `missing` and render missing entries read-only in the sidebar.
+6. Disable sidebar context menus for virtual workspaces so create/duplicate/rename/delete cannot mutate referenced files.
+7. Update changelog and move the TODO to Done after validation.
+
+## Notes
+
+- Sub-agent plan/implementation review from `agent-loop.md` is not available because the current tool policy allows spawning only when the user explicitly requests delegation.
+- Virtual workspace file watching across many referenced roots is intentionally deferred; the first pass is a safe read-only folder view plus normal file reads/writes for opened markdown files.
+- Installed missing Linux build dependencies (`pkg-config`, GLib, GTK3, WebKitGTK 4.1) so the Rust/Tauri crate can build and test in this worktree.
+- `vp` was not globally installed. Used Corepack to run `pnpm install --frozen-lockfile`, then ran the local `./node_modules/.bin/vp install`.
+
+## Implementation Summary
+
+- Added `virtual_workspace.rs` as the single Rust owner for virtual workspace persistence, absolute-path validation, CSV parsing, virtual URI handling, virtual directory reads, virtual search indexing, missing-reference reporting, and safety tests.
+- Extended the `writer` CLI with `workspace new/list/open/add/remove/delete`.
+- Taught desktop startup/open-window paths to route `writer-workspace://<name>` payloads through the normal pending-open flow.
+- Added virtual workspace state to per-window `WorkspaceState`, with virtual directory reads and search indexes built from stored references instead of a real workspace root.
+- Marked directory entries with `source_path` and `missing`, rendered missing entries as unavailable, and disabled filesystem-mutating sidebar/context-menu and command-palette creation paths while a virtual workspace is open.
+
+## Final Validation
+
+- `cargo test` — passed: 112 Rust tests.
+- `cargo fmt --check` — passed.
+- `cargo clippy` — passed with existing warnings in unrelated modules.
+- `./node_modules/.bin/vp install` — passed after Corepack/Pnpm dependency install.
+- `./node_modules/.bin/vp check` — passed with 0 errors and existing e2e lint warnings.
+- `./node_modules/.bin/vp test` — passed: 27 files, 436 tests.
+- `./node_modules/.bin/vp run build -r` — not accepted by this Vite+ version (`Task "build" not found`).
+- `./node_modules/.bin/vp run desktop#build` — passed; production desktop frontend build completed with existing chunk-size/dynamic-import warnings.

--- a/SPECs/virtual-workspaces-spec.md
+++ b/SPECs/virtual-workspaces-spec.md
@@ -1,0 +1,76 @@
+---
+title: Virtual Workspaces
+---
+
+# Virtual Workspaces
+
+## Summary
+
+Add named virtual workspaces managed through the `writer` CLI. A virtual workspace is a saved collection of absolute file and folder references from anywhere on the local filesystem. The workspace owns only the definition; it never copies, moves, renames, or deletes the referenced files.
+
+## Goals
+
+- Create, list, open, add to, remove from, and delete virtual workspaces through `writer workspace ...`.
+- Accept comma-separated absolute paths through `--files`.
+- Reject non-absolute paths with a clear error.
+- Store references as absolute canonical paths when the target exists.
+- Allow both file and folder references.
+- Preserve a referenced folder's nested structure in the virtual tree.
+- Keep workspace `remove` and `delete` purely metadata operations; referenced files and folders stay on disk.
+- Show missing direct references as unavailable instead of crashing.
+- Keep virtual workspaces read-only inside Writer: no rename, delete, duplicate, create-file, or create-folder actions from the virtual sidebar.
+
+## Non-Goals
+
+- No file rename support inside virtual workspaces.
+- No copying or materializing files into a temporary folder.
+- No symlink-based workspace mirror.
+- No cross-device file watching for every referenced folder in this pass.
+- No broad CLI refactor beyond the existing dependency-free parser.
+
+## Command Surface
+
+```bash
+writer workspace new <name> --files=<absolute-path-a>,<absolute-path-b>
+writer workspace list
+writer workspace open <name>
+writer workspace add <name> --files=<absolute-path-a>,<absolute-path-b>
+writer workspace remove <name> --files=<absolute-path-a>,<absolute-path-b>
+writer workspace delete <name>
+```
+
+`workspace open` launches Writer with a virtual workspace URI. The desktop backend resolves the URI, reads the saved definition, and presents a read-only folder tree over the referenced files and folders.
+
+## Persistence
+
+Virtual workspace definitions are stored in app data as `virtual_workspaces.json`. Tests and development can override the store location with `WRITER_VIRTUAL_WORKSPACES_FILE`.
+
+Each workspace stores:
+
+- `name`
+- `references[]`
+  - `path`: absolute path string
+  - `kind`: `file` or `folder`
+
+`kind` is captured when the reference is added so a later missing path can still be shown as the expected kind.
+
+## Folder View Rules
+
+- A referenced file appears at the virtual root under its filename.
+- A referenced folder appears at the virtual root under its folder name.
+- Children of a referenced folder preserve their nested relative paths.
+- Hidden paths are omitted from live folder expansion.
+- Markdown files are shown; directories are shown so nested structure can be traversed.
+- Direct references that later disappear remain visible with `missing: true`.
+
+Root display-name collisions are rejected when creating or adding references. This keeps the virtual tree unambiguous without inventing synthetic display names.
+
+## Safety
+
+Virtual workspace operations mutate only `virtual_workspaces.json`. `remove` deletes references from the definition only. `delete` deletes the workspace definition only. The desktop sidebar disables mutating context-menu actions while a virtual workspace is open, and the command palette suppresses create-file actions for virtual roots.
+
+## Validation
+
+- Rust unit tests for CLI parsing and dispatch.
+- Rust unit tests for persistence, add/remove/delete safety, non-absolute rejection, missing direct references, folder expansion, and virtual index generation.
+- Existing frontend tests remain applicable for read-only sidebar behavior where practical.

--- a/TODOS.md
+++ b/TODOS.md
@@ -6,6 +6,7 @@
 
 ## Done
 
+- Virtual workspaces: [`SPECs/virtual-workspaces-spec.md`](SPECs/virtual-workspaces-spec.md) — add named CLI-managed virtual collections of absolute file/folder references, preserving folder structure without copying, moving, renaming, or deleting referenced files.
 - Sidebar file label setting — add an `appearance.sidebar-file-label` enum (`title` | `filename`, default `title`) and have the sidebar file tree render the filename stem or the title-fallback chain accordingly. Also expose a "Rename..." action in the file context menu (files reuse the inline-rename flow folders already had).
 - Desktop dev script — make the root `dev` script delegate to the desktop package's Tauri dev workflow and keep desktop build/preview scripts on Vite+ commands.
 - Dependency lock refresh: [`SPECs/Agent/worksheet-dependency-lock-refresh.md`](SPECs/Agent/worksheet-dependency-lock-refresh.md) — refresh compatible Rust and JavaScript dependency lockfiles, including the `vite-plus` toolchain update, root TypeScript config alignment, and package-audit fixes.

--- a/apps/desktop/src-tauri/src/commands/fs.rs
+++ b/apps/desktop/src-tauri/src/commands/fs.rs
@@ -1,6 +1,7 @@
 use crate::error::AppError;
 use crate::ignore::WorkspaceIgnore;
 use crate::state::{AppState, WorkspaceState};
+use crate::virtual_workspace::{VirtualDirectoryEntry, VirtualReferenceKind};
 use serde::Serialize;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -12,8 +13,10 @@ use tauri::Manager;
 pub struct DirEntry {
     pub name: String,
     pub path: String,
+    pub source_path: String,
     pub is_dir: bool,
     pub is_markdown: bool,
+    pub missing: bool,
     pub modified_at: u64,
     /// Document title extracted from frontmatter `title:` or leading `# ` heading.
     /// `None` for directories or files without a recognizable title.
@@ -167,6 +170,16 @@ pub fn read_directory_impl(
     path: &str,
     state: Option<&WorkspaceState>,
 ) -> Result<Vec<DirEntry>, AppError> {
+    if let Some(state) = state {
+        if let Some(workspace) = state.virtual_workspace.read().clone() {
+            if crate::virtual_workspace::is_virtual_workspace_uri(path) {
+                let entries = crate::virtual_workspace::read_directory(&workspace, path)
+                    .map_err(|err| AppError::Io(err.to_string()))?;
+                return Ok(entries.into_iter().map(dir_entry_from_virtual).collect());
+            }
+        }
+    }
+
     let dir_path = PathBuf::from(path);
     if !dir_path.exists() {
         return Err(AppError::NotFound(path.to_string()));
@@ -208,8 +221,10 @@ pub fn read_directory_impl(
                 dirs.push(DirEntry {
                     name,
                     path: entry_path.to_string_lossy().to_string(),
+                    source_path: entry_path.to_string_lossy().to_string(),
                     is_dir: true,
                     is_markdown: false,
+                    missing: false,
                     modified_at: modified_time(&entry_path),
                     title: None,
                 });
@@ -221,8 +236,10 @@ pub fn read_directory_impl(
                 files.push(DirEntry {
                     name,
                     path: entry_path.to_string_lossy().to_string(),
+                    source_path: entry_path.to_string_lossy().to_string(),
                     is_dir: false,
                     is_markdown: true,
+                    missing: false,
                     modified_at: modified_time(&entry_path),
                     title,
                 });
@@ -235,6 +252,30 @@ pub fn read_directory_impl(
     files.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
     dirs.extend(files);
     Ok(dirs)
+}
+
+fn dir_entry_from_virtual(entry: VirtualDirectoryEntry) -> DirEntry {
+    let source = PathBuf::from(&entry.source_path);
+    let title = if entry.kind == VirtualReferenceKind::File && !entry.missing {
+        extract_title(&source)
+    } else {
+        None
+    };
+
+    DirEntry {
+        name: entry.name,
+        path: entry.path,
+        source_path: entry.source_path,
+        is_dir: entry.kind == VirtualReferenceKind::Folder,
+        is_markdown: entry.is_markdown,
+        missing: entry.missing,
+        modified_at: if entry.missing {
+            0
+        } else {
+            modified_time(&source)
+        },
+        title,
+    }
 }
 
 #[tauri::command]
@@ -334,8 +375,10 @@ pub fn create_directory_impl(path: &str) -> Result<DirEntry, AppError> {
     Ok(DirEntry {
         name,
         path: path.to_string(),
+        source_path: path.to_string(),
         is_dir: true,
         is_markdown: false,
+        missing: false,
         modified_at: modified_time(&dir_path),
         title: None,
     })

--- a/apps/desktop/src-tauri/src/commands/search.rs
+++ b/apps/desktop/src-tauri/src/commands/search.rs
@@ -30,6 +30,20 @@ pub fn index_workspace(
     app: tauri::AppHandle,
 ) -> Result<IndexStats, AppError> {
     let state = app.state::<AppState>().get_or_create(webview.label());
+    if let Some(workspace) = state.virtual_workspace.read().clone() {
+        let start = std::time::Instant::now();
+        let (indexed, dirs) = crate::virtual_workspace::index_workspace(&workspace);
+        let file_count = indexed.len();
+        let duration_ms = start.elapsed().as_millis() as u64;
+        *state.file_index.write() = indexed;
+        *state.dirs_with_markdown.write() = dirs;
+        state.index_ready.store(true, Ordering::Relaxed);
+        return Ok(IndexStats {
+            file_count,
+            duration_ms,
+        });
+    }
+
     let root = state
         .workspace_root
         .read()

--- a/apps/desktop/src-tauri/src/commands/startup.rs
+++ b/apps/desktop/src-tauri/src/commands/startup.rs
@@ -68,7 +68,9 @@ pub async fn get_startup_state(
     } else if restore_enabled {
         recent_workspaces
             .first()
-            .filter(|path| Path::new(path).is_dir())
+            .filter(|path| {
+                crate::virtual_workspace::is_virtual_workspace_uri(path) || Path::new(path).is_dir()
+            })
             .cloned()
     } else {
         None

--- a/apps/desktop/src-tauri/src/commands/workspace.rs
+++ b/apps/desktop/src-tauri/src/commands/workspace.rs
@@ -3,6 +3,10 @@ use crate::commands::search::index_workspace_impl;
 use crate::error::AppError;
 use crate::ignore::WorkspaceIgnore;
 use crate::state::{AppState, WorkspaceState};
+use crate::virtual_workspace::{
+    is_virtual_workspace_uri, workspace_name_from_uri, VirtualWorkspaceError,
+    VirtualWorkspaceRegistry,
+};
 use crate::watcher::drop_watcher_off_thread;
 use crate::PendingOpenPayload;
 use serde::{Deserialize, Serialize};
@@ -17,6 +21,7 @@ pub struct WorkspaceInfo {
     pub root: String,
     pub name: String,
     pub file_count: usize,
+    pub is_virtual: bool,
 }
 
 /// Synchronous workspace setup shared by `open_workspace` and the bundled
@@ -54,6 +59,10 @@ fn prepare_workspace_state(
     label: &str,
     path: &str,
 ) -> Result<WorkspaceInfo, AppError> {
+    if is_virtual_workspace_uri(path) {
+        return prepare_virtual_workspace_state(app, label, path);
+    }
+
     let root = canonicalize_workspace_root(path)?;
     let canonical_path = root.to_string_lossy().to_string();
 
@@ -85,6 +94,7 @@ fn prepare_workspace_state(
 
     // Reset per-workspace state.
     *state.workspace_root.write() = Some(root.clone());
+    *state.virtual_workspace.write() = None;
     *state.file_index.write() = Vec::new();
     *state.dirs_with_markdown.write() = Default::default();
     state.index_ready.store(false, Ordering::Relaxed);
@@ -122,7 +132,67 @@ fn prepare_workspace_state(
         root: canonical_path,
         name,
         file_count: 0,
+        is_virtual: false,
     })
+}
+
+fn prepare_virtual_workspace_state(
+    app: &tauri::AppHandle,
+    label: &str,
+    uri: &str,
+) -> Result<WorkspaceInfo, AppError> {
+    let name = workspace_name_from_uri(uri).ok_or_else(|| AppError::NotFound(uri.to_string()))?;
+    let workspace = VirtualWorkspaceRegistry::for_app_data()
+        .map_err(virtual_error)?
+        .get(name)
+        .map_err(virtual_error)?;
+    let workspace_uri = workspace.uri();
+    let state = app.state::<AppState>().get_or_create(label);
+
+    let _ = state.workspace_epoch.fetch_add(1, Ordering::SeqCst) + 1;
+    {
+        let mut guard = state.cancel_index.write();
+        guard.store(true, Ordering::SeqCst);
+        *guard = Arc::new(AtomicBool::new(false));
+    }
+
+    *state.workspace_root.write() = Some(PathBuf::from(&workspace_uri));
+    *state.virtual_workspace.write() = Some(workspace.clone());
+    *state.workspace_ignore.write() = None;
+    *state.dirs_with_markdown.write() = Default::default();
+
+    let old_watcher = state.watcher_handle.write().take();
+    drop_watcher_off_thread(old_watcher);
+
+    if let Some(settings) = state.settings.write().as_mut() {
+        settings.clear_workspace();
+    }
+
+    let (indexed, dirs) = crate::virtual_workspace::index_workspace(&workspace);
+    let file_count = indexed.len();
+    *state.file_index.write() = indexed;
+    *state.dirs_with_markdown.write() = dirs;
+    state.index_ready.store(true, Ordering::Relaxed);
+
+    let _ = save_recent_workspace(app, &workspace_uri);
+    let _ = app.emit_to(label, "index:complete", file_count);
+
+    Ok(WorkspaceInfo {
+        root: workspace_uri,
+        name: workspace.name,
+        file_count,
+        is_virtual: true,
+    })
+}
+
+fn virtual_error(err: VirtualWorkspaceError) -> AppError {
+    match err {
+        VirtualWorkspaceError::MissingWorkspace(_) | VirtualWorkspaceError::NotFound(_) => {
+            AppError::NotFound(err.to_string())
+        }
+        VirtualWorkspaceError::AlreadyExists(_) => AppError::AlreadyExists(err.to_string()),
+        _ => AppError::Io(err.to_string()),
+    }
 }
 
 /// Background bootstrap for a freshly-opened workspace: starts the file
@@ -393,6 +463,10 @@ pub fn open_workspace_in_new_window(
     file: Option<String>,
     app: tauri::AppHandle,
 ) -> Result<(), AppError> {
+    if is_virtual_workspace_uri(&path) {
+        return crate::open_new_workspace_window(&app, path, file);
+    }
+
     let workspace = PathBuf::from(&path);
     if !workspace.exists() || !workspace.is_dir() {
         return Err(AppError::NotFound(path.clone()));

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -8,12 +8,13 @@ pub mod open_target;
 mod state;
 #[cfg(desktop)]
 mod updater;
+pub mod virtual_workspace;
 mod watcher;
 pub mod writer_cli;
 
 use commands::settings::init_window_settings;
 use error::AppError;
-use open_target::resolve_path;
+use open_target::resolve_arg;
 pub use open_target::PendingOpenPayload;
 use state::AppState;
 use std::path::PathBuf;
@@ -54,7 +55,7 @@ fn attach_window_handlers(app: &tauri::AppHandle, window: &WebviewWindow) {
     window.on_window_event(move |event| match event {
         WindowEvent::DragDrop(DragDropEvent::Drop { paths, .. }) => {
             for path in paths {
-                if let Some(payload) = resolve_path(path) {
+                if let Some(payload) = crate::open_target::resolve_path(path) {
                     queue_open_event(&handle, &label, payload);
                     break;
                 }
@@ -81,6 +82,33 @@ pub(crate) fn open_new_workspace_window(
     workspace_path: String,
     file: Option<String>,
 ) -> Result<(), AppError> {
+    if virtual_workspace::is_virtual_workspace_uri(&workspace_path) {
+        let name = virtual_workspace::workspace_name_from_uri(&workspace_path)
+            .ok_or_else(|| AppError::NotFound(workspace_path.clone()))?;
+        virtual_workspace::VirtualWorkspaceRegistry::for_app_data()
+            .map_err(|e| AppError::Io(e.to_string()))?
+            .get(name)
+            .map_err(|e| AppError::NotFound(e.to_string()))?;
+
+        let workspace = PathBuf::from(&workspace_path);
+        if let Some(existing_label) = app.state::<AppState>().find_by_workspace(&workspace) {
+            if let Some(window) = app.get_webview_window(&existing_label) {
+                let _ = window.set_focus();
+                return Ok(());
+            }
+        }
+
+        let label = format!("w-{}", uuid::Uuid::new_v4().simple());
+        let state = app.state::<AppState>().get_or_create(&label);
+        init_window_settings(app, &state);
+        state.push_pending_open(PendingOpenPayload {
+            workspace: workspace_path,
+            file,
+        });
+
+        return build_workspace_window(app, &label);
+    }
+
     let raw_workspace = PathBuf::from(&workspace_path);
     if !raw_workspace.exists() || !raw_workspace.is_dir() {
         return Err(AppError::NotFound(workspace_path));
@@ -110,6 +138,10 @@ pub(crate) fn open_new_workspace_window(
         file,
     });
 
+    build_workspace_window(app, &label)
+}
+
+fn build_workspace_window(app: &tauri::AppHandle, label: &str) -> Result<(), AppError> {
     // Clone the main window's config (titlebar overlay, traffic-light
     // position, transparency, hudWindow vibrancy, `visible: false`) so
     // secondary windows look and animate identically. Rewrite the label,
@@ -125,11 +157,11 @@ pub(crate) fn open_new_workspace_window(
     let mut window_config = match window_config {
         Ok(c) => c,
         Err(e) => {
-            app.state::<AppState>().remove(&label);
+            app.state::<AppState>().remove(label);
             return Err(e);
         }
     };
-    window_config.label = label.clone();
+    window_config.label = label.to_string();
     window_config.center = false;
 
     let window = (|| -> Result<WebviewWindow, AppError> {
@@ -145,7 +177,7 @@ pub(crate) fn open_new_workspace_window(
             // Prevent an orphaned `WorkspaceState` from lingering in the
             // registry for a window that never opened (so `Destroyed` never
             // fires). Drops the watcher (none yet) and reclaims memory.
-            app.state::<AppState>().remove(&label);
+            app.state::<AppState>().remove(label);
             return Err(e);
         }
     };
@@ -343,7 +375,7 @@ fn run_cli_uninstall(app: tauri::AppHandle) {
 /// user just re-launched the app without an argument.
 fn handle_single_instance(app: &tauri::AppHandle, argv: Vec<String>) {
     let path_arg = argv.into_iter().nth(1);
-    match path_arg.and_then(|arg| resolve_path(&PathBuf::from(arg))) {
+    match path_arg.and_then(|arg| resolve_arg(&arg)) {
         Some(payload) => {
             if let Err(err) =
                 open_new_workspace_window(app, payload.workspace.clone(), payload.file.clone())
@@ -397,8 +429,7 @@ pub fn run() {
             // main window is the one that will host the requested workspace.
             let args: Vec<String> = std::env::args().collect();
             if args.len() > 1 {
-                let path = PathBuf::from(&args[1]);
-                if let Some(payload) = resolve_path(&path) {
+                if let Some(payload) = resolve_arg(&args[1]) {
                     main_state.push_pending_open(payload);
                 }
             }

--- a/apps/desktop/src-tauri/src/open_target.rs
+++ b/apps/desktop/src-tauri/src/open_target.rs
@@ -52,6 +52,19 @@ pub fn resolve_path(path: &Path) -> Option<PendingOpenPayload> {
     classify(path).ok()
 }
 
+/// Resolve an OS argv string. In addition to real filesystem paths, this
+/// accepts Writer's virtual workspace URI so the CLI can launch the desktop
+/// app on a saved virtual workspace without materializing a folder on disk.
+pub fn resolve_arg(arg: &str) -> Option<PendingOpenPayload> {
+    if crate::virtual_workspace::is_virtual_workspace_uri(arg) {
+        return Some(PendingOpenPayload {
+            workspace: arg.to_string(),
+            file: None,
+        });
+    }
+    resolve_path(Path::new(arg))
+}
+
 /// Strict variant used by the CLI. Produces a typed error the caller can
 /// turn into a stderr message.
 pub fn validate_and_resolve(path: &Path) -> Result<PendingOpenPayload, OpenTargetError> {
@@ -171,5 +184,12 @@ mod tests {
     fn lenient_resolver_returns_none_for_missing() {
         let dir = tempdir().unwrap();
         assert!(resolve_path(&dir.path().join("nope")).is_none());
+    }
+
+    #[test]
+    fn arg_resolver_accepts_virtual_workspace_uri() {
+        let payload = resolve_arg("writer-workspace://Drafts").unwrap();
+        assert_eq!(payload.workspace, "writer-workspace://Drafts");
+        assert!(payload.file.is_none());
     }
 }

--- a/apps/desktop/src-tauri/src/state.rs
+++ b/apps/desktop/src-tauri/src/state.rs
@@ -1,6 +1,7 @@
 use crate::config::Settings;
 use crate::ignore::WorkspaceIgnore;
 use crate::open_target::PendingOpenPayload;
+use crate::virtual_workspace::VirtualWorkspace;
 use notify::RecommendedWatcher;
 use parking_lot::{Mutex, RwLock};
 use std::collections::{HashMap, HashSet, VecDeque};
@@ -17,6 +18,7 @@ use std::time::Instant;
 /// without clobbering each other.
 pub struct WorkspaceState {
     pub workspace_root: RwLock<Option<PathBuf>>,
+    pub virtual_workspace: RwLock<Option<VirtualWorkspace>>,
     pub file_index: RwLock<Vec<IndexedFile>>,
     pub dirs_with_markdown: RwLock<HashSet<PathBuf>>,
     /// Set to `true` after the first full index completes.
@@ -62,6 +64,7 @@ impl Default for WorkspaceState {
     fn default() -> Self {
         Self {
             workspace_root: RwLock::new(None),
+            virtual_workspace: RwLock::new(None),
             file_index: RwLock::new(Vec::new()),
             dirs_with_markdown: RwLock::new(HashSet::new()),
             index_ready: AtomicBool::new(false),

--- a/apps/desktop/src-tauri/src/virtual_workspace.rs
+++ b/apps/desktop/src-tauri/src/virtual_workspace.rs
@@ -1,0 +1,858 @@
+use crate::state::IndexedFile;
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+pub const VIRTUAL_WORKSPACE_URI_PREFIX: &str = "writer-workspace://";
+const STORE_ENV: &str = "WRITER_VIRTUAL_WORKSPACES_FILE";
+const APP_IDENTIFIER: &str = "com.writer-computer";
+const STORE_FILENAME: &str = "virtual_workspaces.json";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VirtualWorkspace {
+    pub name: String,
+    #[serde(default)]
+    pub references: Vec<VirtualReference>,
+}
+
+impl VirtualWorkspace {
+    pub fn uri(&self) -> String {
+        workspace_uri(&self.name)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VirtualReference {
+    pub path: String,
+    pub kind: VirtualReferenceKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum VirtualReferenceKind {
+    File,
+    Folder,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VirtualDirectoryEntry {
+    pub name: String,
+    /// Directory entries use a virtual URI. File entries use their real
+    /// absolute path so editor reads/writes still hit the referenced file.
+    pub path: String,
+    pub source_path: String,
+    pub kind: VirtualReferenceKind,
+    pub is_markdown: bool,
+    pub missing: bool,
+}
+
+#[derive(Debug)]
+pub enum VirtualWorkspaceError {
+    AlreadyExists(String),
+    DuplicateRoot(String),
+    EmptyFileList,
+    EmptyName,
+    InvalidName(String),
+    Io(std::io::Error),
+    MissingWorkspace(String),
+    NoSuchReference(String),
+    NonAbsolutePath(PathBuf),
+    NotFound(PathBuf),
+    NotFileOrFolder(PathBuf),
+    Parse(serde_json::Error),
+}
+
+impl std::fmt::Display for VirtualWorkspaceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::AlreadyExists(name) => write!(f, "workspace already exists: {name}"),
+            Self::DuplicateRoot(name) => {
+                write!(f, "virtual workspace root name would be ambiguous: {name}")
+            }
+            Self::EmptyFileList => write!(f, "--files must contain at least one path"),
+            Self::EmptyName => write!(f, "workspace name cannot be empty"),
+            Self::InvalidName(name) => write!(f, "invalid workspace name: {name}"),
+            Self::Io(err) => write!(f, "{err}"),
+            Self::MissingWorkspace(name) => write!(f, "workspace does not exist: {name}"),
+            Self::NoSuchReference(path) => {
+                write!(f, "reference is not in the workspace: {path}")
+            }
+            Self::NonAbsolutePath(path) => write!(f, "path is not absolute: {}", path.display()),
+            Self::NotFound(path) => write!(f, "path does not exist: {}", path.display()),
+            Self::NotFileOrFolder(path) => {
+                write!(f, "path is not a file or folder: {}", path.display())
+            }
+            Self::Parse(err) => write!(f, "could not parse virtual workspaces: {err}"),
+        }
+    }
+}
+
+impl std::error::Error for VirtualWorkspaceError {}
+
+impl From<std::io::Error> for VirtualWorkspaceError {
+    fn from(err: std::io::Error) -> Self {
+        Self::Io(err)
+    }
+}
+
+impl From<serde_json::Error> for VirtualWorkspaceError {
+    fn from(err: serde_json::Error) -> Self {
+        Self::Parse(err)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct StoredVirtualWorkspaces {
+    version: u32,
+    #[serde(default)]
+    workspaces: Vec<VirtualWorkspace>,
+}
+
+impl Default for StoredVirtualWorkspaces {
+    fn default() -> Self {
+        Self {
+            version: 1,
+            workspaces: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct VirtualWorkspaceRegistry {
+    path: PathBuf,
+}
+
+impl VirtualWorkspaceRegistry {
+    pub fn for_app_data() -> Result<Self, VirtualWorkspaceError> {
+        Ok(Self {
+            path: default_store_path()?,
+        })
+    }
+
+    pub fn at(path: PathBuf) -> Self {
+        Self { path }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn list(&self) -> Result<Vec<VirtualWorkspace>, VirtualWorkspaceError> {
+        Ok(self.load()?.workspaces)
+    }
+
+    pub fn get(&self, name: &str) -> Result<VirtualWorkspace, VirtualWorkspaceError> {
+        let name = validate_workspace_name(name)?;
+        self.load()?
+            .workspaces
+            .into_iter()
+            .find(|workspace| workspace.name == name)
+            .ok_or_else(|| VirtualWorkspaceError::MissingWorkspace(name.to_string()))
+    }
+
+    pub fn create(
+        &self,
+        name: &str,
+        paths: &[PathBuf],
+    ) -> Result<VirtualWorkspace, VirtualWorkspaceError> {
+        let name = validate_workspace_name(name)?.to_string();
+        let references = normalize_references(paths)?;
+
+        let mut data = self.load()?;
+        if data
+            .workspaces
+            .iter()
+            .any(|workspace| workspace.name == name)
+        {
+            return Err(VirtualWorkspaceError::AlreadyExists(name));
+        }
+
+        validate_root_names(&references)?;
+        let workspace = VirtualWorkspace { name, references };
+        data.workspaces.push(workspace.clone());
+        sort_workspaces(&mut data.workspaces);
+        self.save(&data)?;
+        Ok(workspace)
+    }
+
+    pub fn add(
+        &self,
+        name: &str,
+        paths: &[PathBuf],
+    ) -> Result<VirtualWorkspace, VirtualWorkspaceError> {
+        let name = validate_workspace_name(name)?.to_string();
+        let mut incoming = normalize_references(paths)?;
+
+        let mut data = self.load()?;
+        let workspace = data
+            .workspaces
+            .iter_mut()
+            .find(|workspace| workspace.name == name)
+            .ok_or_else(|| VirtualWorkspaceError::MissingWorkspace(name.clone()))?;
+
+        for reference in incoming.drain(..) {
+            if !workspace
+                .references
+                .iter()
+                .any(|existing| existing.path == reference.path)
+            {
+                workspace.references.push(reference);
+            }
+        }
+        workspace.references.sort_by(|a, b| a.path.cmp(&b.path));
+        validate_root_names(&workspace.references)?;
+        let updated = workspace.clone();
+        self.save(&data)?;
+        Ok(updated)
+    }
+
+    pub fn remove(
+        &self,
+        name: &str,
+        paths: &[PathBuf],
+    ) -> Result<VirtualWorkspace, VirtualWorkspaceError> {
+        let name = validate_workspace_name(name)?.to_string();
+        let requested = normalize_paths_for_removal(paths)?;
+
+        let mut data = self.load()?;
+        let workspace = data
+            .workspaces
+            .iter_mut()
+            .find(|workspace| workspace.name == name)
+            .ok_or_else(|| VirtualWorkspaceError::MissingWorkspace(name.clone()))?;
+
+        for path in &requested {
+            if !workspace
+                .references
+                .iter()
+                .any(|reference| &reference.path == path)
+            {
+                return Err(VirtualWorkspaceError::NoSuchReference(path.clone()));
+            }
+        }
+
+        let remove_set: HashSet<&str> = requested.iter().map(String::as_str).collect();
+        workspace
+            .references
+            .retain(|reference| !remove_set.contains(reference.path.as_str()));
+        let updated = workspace.clone();
+        self.save(&data)?;
+        Ok(updated)
+    }
+
+    pub fn delete(&self, name: &str) -> Result<(), VirtualWorkspaceError> {
+        let name = validate_workspace_name(name)?.to_string();
+        let mut data = self.load()?;
+        let original_len = data.workspaces.len();
+        data.workspaces.retain(|workspace| workspace.name != name);
+        if data.workspaces.len() == original_len {
+            return Err(VirtualWorkspaceError::MissingWorkspace(name));
+        }
+        self.save(&data)
+    }
+
+    fn load(&self) -> Result<StoredVirtualWorkspaces, VirtualWorkspaceError> {
+        if !self.path.exists() {
+            return Ok(StoredVirtualWorkspaces::default());
+        }
+        let raw = std::fs::read_to_string(&self.path)?;
+        let mut data: StoredVirtualWorkspaces = serde_json::from_str(&raw)?;
+        sort_workspaces(&mut data.workspaces);
+        Ok(data)
+    }
+
+    fn save(&self, data: &StoredVirtualWorkspaces) -> Result<(), VirtualWorkspaceError> {
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let raw = serde_json::to_string_pretty(data)?;
+        std::fs::write(&self.path, raw)?;
+        Ok(())
+    }
+}
+
+pub fn workspace_uri(name: &str) -> String {
+    format!("{VIRTUAL_WORKSPACE_URI_PREFIX}{name}")
+}
+
+pub fn workspace_name_from_uri(value: &str) -> Option<&str> {
+    let name = value.strip_prefix(VIRTUAL_WORKSPACE_URI_PREFIX)?;
+    if name.is_empty() {
+        return None;
+    }
+    Some(name)
+}
+
+pub fn is_virtual_workspace_uri(value: &str) -> bool {
+    workspace_name_from_uri(value).is_some()
+}
+
+pub fn read_directory(
+    workspace: &VirtualWorkspace,
+    directory: &str,
+) -> Result<Vec<VirtualDirectoryEntry>, VirtualWorkspaceError> {
+    let root_uri = workspace.uri();
+    if directory == root_uri {
+        return read_virtual_root(workspace);
+    }
+
+    let relative = virtual_relative_path(&root_uri, directory)
+        .ok_or_else(|| VirtualWorkspaceError::NotFound(PathBuf::from(directory)))?;
+    let source = source_dir_for_virtual_path(workspace, relative)
+        .ok_or_else(|| VirtualWorkspaceError::NotFound(PathBuf::from(directory)))?;
+    read_source_directory(&root_uri, relative, &source)
+}
+
+pub fn index_workspace(workspace: &VirtualWorkspace) -> (Vec<IndexedFile>, HashSet<PathBuf>) {
+    let root_uri = workspace.uri();
+    let mut files = Vec::new();
+    let mut dirs = HashSet::new();
+
+    for reference in &workspace.references {
+        let root_name = root_name(reference);
+        let source = PathBuf::from(&reference.path);
+        match reference.kind {
+            VirtualReferenceKind::File => {
+                if source.exists() && is_markdown_path(&source) {
+                    files.push(IndexedFile {
+                        path: source,
+                        relative_path: root_name,
+                        name: file_name(&reference.path),
+                    });
+                }
+            }
+            VirtualReferenceKind::Folder => {
+                if source.is_dir() {
+                    collect_markdown_files(&source, &root_name, &mut files, &mut dirs, &root_uri);
+                }
+            }
+        }
+    }
+
+    files.sort_by(|a, b| a.relative_path.cmp(&b.relative_path));
+    (files, dirs)
+}
+
+pub fn parse_files_csv(value: &str) -> Result<Vec<PathBuf>, VirtualWorkspaceError> {
+    let mut paths = Vec::new();
+    for raw in value.split(',') {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        paths.push(PathBuf::from(trimmed));
+    }
+    if paths.is_empty() {
+        return Err(VirtualWorkspaceError::EmptyFileList);
+    }
+    Ok(paths)
+}
+
+fn default_store_path() -> Result<PathBuf, VirtualWorkspaceError> {
+    if let Some(path) = std::env::var_os(STORE_ENV) {
+        return Ok(PathBuf::from(path));
+    }
+    Ok(default_app_data_dir()?.join(STORE_FILENAME))
+}
+
+fn default_app_data_dir() -> Result<PathBuf, VirtualWorkspaceError> {
+    #[cfg(target_os = "macos")]
+    {
+        let home = std::env::var_os("HOME")
+            .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, "HOME is not set"))?;
+        return Ok(PathBuf::from(home)
+            .join("Library")
+            .join("Application Support")
+            .join(APP_IDENTIFIER));
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        let appdata = std::env::var_os("APPDATA").ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::NotFound, "APPDATA is not set")
+        })?;
+        return Ok(PathBuf::from(appdata).join(APP_IDENTIFIER));
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        if let Some(data_home) = std::env::var_os("XDG_DATA_HOME") {
+            return Ok(PathBuf::from(data_home).join(APP_IDENTIFIER));
+        }
+        let home = std::env::var_os("HOME")
+            .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, "HOME is not set"))?;
+        Ok(PathBuf::from(home)
+            .join(".local")
+            .join("share")
+            .join(APP_IDENTIFIER))
+    }
+}
+
+fn validate_workspace_name(name: &str) -> Result<&str, VirtualWorkspaceError> {
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        return Err(VirtualWorkspaceError::EmptyName);
+    }
+    if trimmed.contains('/')
+        || trimmed.contains('\\')
+        || trimmed.contains(':')
+        || trimmed.chars().any(char::is_control)
+    {
+        return Err(VirtualWorkspaceError::InvalidName(name.to_string()));
+    }
+    Ok(trimmed)
+}
+
+fn normalize_references(paths: &[PathBuf]) -> Result<Vec<VirtualReference>, VirtualWorkspaceError> {
+    if paths.is_empty() {
+        return Err(VirtualWorkspaceError::EmptyFileList);
+    }
+
+    let mut references = Vec::with_capacity(paths.len());
+    let mut seen = HashSet::new();
+    for path in paths {
+        if !path.is_absolute() {
+            return Err(VirtualWorkspaceError::NonAbsolutePath(path.clone()));
+        }
+        if !path.exists() {
+            return Err(VirtualWorkspaceError::NotFound(path.clone()));
+        }
+        let metadata = path.metadata()?;
+        let kind = if metadata.is_file() {
+            VirtualReferenceKind::File
+        } else if metadata.is_dir() {
+            VirtualReferenceKind::Folder
+        } else {
+            return Err(VirtualWorkspaceError::NotFileOrFolder(path.clone()));
+        };
+        let canonical = path.canonicalize()?;
+        let path = canonical.to_string_lossy().to_string();
+        if seen.insert(path.clone()) {
+            references.push(VirtualReference { path, kind });
+        }
+    }
+    references.sort_by(|a, b| a.path.cmp(&b.path));
+    validate_root_names(&references)?;
+    Ok(references)
+}
+
+fn normalize_paths_for_removal(paths: &[PathBuf]) -> Result<Vec<String>, VirtualWorkspaceError> {
+    if paths.is_empty() {
+        return Err(VirtualWorkspaceError::EmptyFileList);
+    }
+
+    let mut normalized = Vec::with_capacity(paths.len());
+    let mut seen = HashSet::new();
+    for path in paths {
+        if !path.is_absolute() {
+            return Err(VirtualWorkspaceError::NonAbsolutePath(path.clone()));
+        }
+        let path = if path.exists() {
+            path.canonicalize()?.to_string_lossy().to_string()
+        } else {
+            path.to_string_lossy().to_string()
+        };
+        if seen.insert(path.clone()) {
+            normalized.push(path);
+        }
+    }
+    Ok(normalized)
+}
+
+fn validate_root_names(references: &[VirtualReference]) -> Result<(), VirtualWorkspaceError> {
+    let mut by_root: HashMap<String, &str> = HashMap::new();
+    for reference in references {
+        let root = root_name(reference);
+        if let Some(existing) = by_root.insert(root.clone(), &reference.path) {
+            if existing != reference.path {
+                return Err(VirtualWorkspaceError::DuplicateRoot(root));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn sort_workspaces(workspaces: &mut [VirtualWorkspace]) {
+    workspaces.sort_by_key(|workspace| workspace.name.to_lowercase());
+}
+
+fn read_virtual_root(
+    workspace: &VirtualWorkspace,
+) -> Result<Vec<VirtualDirectoryEntry>, VirtualWorkspaceError> {
+    let root_uri = workspace.uri();
+    let mut entries = Vec::with_capacity(workspace.references.len());
+    for reference in &workspace.references {
+        let source = PathBuf::from(&reference.path);
+        let missing = !source.exists();
+        let name = root_name(reference);
+        let path = match reference.kind {
+            VirtualReferenceKind::File => reference.path.clone(),
+            VirtualReferenceKind::Folder => virtual_join(&root_uri, &name),
+        };
+        entries.push(VirtualDirectoryEntry {
+            name,
+            path,
+            source_path: reference.path.clone(),
+            kind: reference.kind,
+            is_markdown: reference.kind == VirtualReferenceKind::File && is_markdown_path(&source),
+            missing,
+        });
+    }
+    sort_entries(&mut entries);
+    Ok(entries)
+}
+
+fn read_source_directory(
+    root_uri: &str,
+    virtual_relative: &str,
+    source: &Path,
+) -> Result<Vec<VirtualDirectoryEntry>, VirtualWorkspaceError> {
+    let mut dirs = Vec::new();
+    let mut files = Vec::new();
+
+    if !source.exists() {
+        return Ok(Vec::new());
+    }
+
+    for entry in std::fs::read_dir(source)?.flatten() {
+        let file_type = entry.file_type()?;
+        let name = entry.file_name().to_string_lossy().to_string();
+        if name.starts_with('.') {
+            continue;
+        }
+        let source_path = entry.path();
+        if file_type.is_dir() {
+            let relative = append_relative(virtual_relative, &name);
+            dirs.push(VirtualDirectoryEntry {
+                name,
+                path: virtual_join(root_uri, &relative),
+                source_path: source_path.to_string_lossy().to_string(),
+                kind: VirtualReferenceKind::Folder,
+                is_markdown: false,
+                missing: false,
+            });
+        } else if file_type.is_file() && is_markdown_path(&source_path) {
+            files.push(VirtualDirectoryEntry {
+                name,
+                path: source_path.to_string_lossy().to_string(),
+                source_path: source_path.to_string_lossy().to_string(),
+                kind: VirtualReferenceKind::File,
+                is_markdown: true,
+                missing: false,
+            });
+        }
+    }
+
+    dirs.sort_by_key(|entry| entry.name.to_lowercase());
+    files.sort_by_key(|entry| entry.name.to_lowercase());
+    dirs.extend(files);
+    Ok(dirs)
+}
+
+fn source_dir_for_virtual_path(workspace: &VirtualWorkspace, relative: &str) -> Option<PathBuf> {
+    let mut parts = relative.split('/');
+    let root = parts.next()?;
+    let rest = parts.collect::<Vec<_>>();
+
+    workspace.references.iter().find_map(|reference| {
+        if reference.kind != VirtualReferenceKind::Folder || root_name(reference) != root {
+            return None;
+        }
+        let mut source = PathBuf::from(&reference.path);
+        for component in &rest {
+            if component.is_empty() || *component == "." || *component == ".." {
+                return None;
+            }
+            source.push(component);
+        }
+        Some(source)
+    })
+}
+
+fn collect_markdown_files(
+    source_dir: &Path,
+    virtual_relative: &str,
+    files: &mut Vec<IndexedFile>,
+    dirs: &mut HashSet<PathBuf>,
+    root_uri: &str,
+) {
+    let Ok(entries) = std::fs::read_dir(source_dir) else {
+        return;
+    };
+
+    for entry in entries.flatten() {
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        let name = entry.file_name().to_string_lossy().to_string();
+        if name.starts_with('.') {
+            continue;
+        }
+        let source_path = entry.path();
+        if file_type.is_dir() {
+            let child_relative = append_relative(virtual_relative, &name);
+            collect_markdown_files(&source_path, &child_relative, files, dirs, root_uri);
+        } else if file_type.is_file() && is_markdown_path(&source_path) {
+            let relative_path = append_relative(virtual_relative, &name);
+            files.push(IndexedFile {
+                path: source_path,
+                relative_path: relative_path.clone(),
+                name,
+            });
+            register_virtual_ancestors(dirs, &relative_path, root_uri);
+        }
+    }
+}
+
+fn register_virtual_ancestors(dirs: &mut HashSet<PathBuf>, relative_file: &str, root_uri: &str) {
+    let Some((mut dir, _file)) = relative_file.rsplit_once('/') else {
+        return;
+    };
+    loop {
+        dirs.insert(PathBuf::from(virtual_join(root_uri, dir)));
+        let Some((parent, _name)) = dir.rsplit_once('/') else {
+            break;
+        };
+        dir = parent;
+    }
+}
+
+fn virtual_relative_path<'a>(root_uri: &str, directory: &'a str) -> Option<&'a str> {
+    let prefix = format!("{root_uri}/");
+    let relative = directory.strip_prefix(&prefix)?;
+    if relative.is_empty() {
+        None
+    } else {
+        Some(relative)
+    }
+}
+
+fn virtual_join(root_uri: &str, relative: &str) -> String {
+    format!("{root_uri}/{}", relative.trim_matches('/'))
+}
+
+fn append_relative(parent: &str, child: &str) -> String {
+    if parent.is_empty() {
+        child.to_string()
+    } else {
+        format!("{parent}/{child}")
+    }
+}
+
+fn root_name(reference: &VirtualReference) -> String {
+    file_name(&reference.path)
+}
+
+fn file_name(path: &str) -> String {
+    Path::new(path)
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .unwrap_or_else(|| path.to_string())
+}
+
+fn sort_entries(entries: &mut [VirtualDirectoryEntry]) {
+    entries.sort_by(|a, b| {
+        match (
+            a.kind == VirtualReferenceKind::Folder,
+            b.kind == VirtualReferenceKind::Folder,
+        ) {
+            (true, false) => std::cmp::Ordering::Less,
+            (false, true) => std::cmp::Ordering::Greater,
+            _ => a.name.to_lowercase().cmp(&b.name.to_lowercase()),
+        }
+    });
+}
+
+fn is_markdown_path(path: &Path) -> bool {
+    path.extension()
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("md") || ext.eq_ignore_ascii_case("markdown"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn registry_path() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("virtual_workspaces.json");
+        (dir, path)
+    }
+
+    #[test]
+    fn parse_files_csv_rejects_empty_lists() {
+        assert!(matches!(
+            parse_files_csv(" , "),
+            Err(VirtualWorkspaceError::EmptyFileList)
+        ));
+    }
+
+    #[test]
+    fn create_rejects_non_absolute_paths() {
+        let (_dir, path) = registry_path();
+        let registry = VirtualWorkspaceRegistry::at(path);
+        let err = registry
+            .create("drafts", &[PathBuf::from("relative.md")])
+            .unwrap_err();
+        assert!(matches!(err, VirtualWorkspaceError::NonAbsolutePath(_)));
+    }
+
+    #[test]
+    fn create_persists_canonical_absolute_references() {
+        let (_store_dir, store_path) = registry_path();
+        let source = tempdir().unwrap();
+        let file = source.path().join("note.md");
+        fs::write(&file, "# Note").unwrap();
+
+        let registry = VirtualWorkspaceRegistry::at(store_path.clone());
+        registry
+            .create("drafts", std::slice::from_ref(&file))
+            .unwrap();
+
+        let loaded = VirtualWorkspaceRegistry::at(store_path)
+            .get("drafts")
+            .unwrap();
+        assert_eq!(loaded.references.len(), 1);
+        assert_eq!(
+            loaded.references[0].path,
+            file.canonicalize().unwrap().to_string_lossy().to_string()
+        );
+        assert_eq!(loaded.references[0].kind, VirtualReferenceKind::File);
+    }
+
+    #[test]
+    fn add_and_remove_mutate_only_references() {
+        let (_store_dir, store_path) = registry_path();
+        let source = tempdir().unwrap();
+        let one = source.path().join("one.md");
+        let two = source.path().join("two.md");
+        fs::write(&one, "# One").unwrap();
+        fs::write(&two, "# Two").unwrap();
+
+        let registry = VirtualWorkspaceRegistry::at(store_path);
+        registry
+            .create("drafts", std::slice::from_ref(&one))
+            .unwrap();
+        registry.add("drafts", std::slice::from_ref(&two)).unwrap();
+        registry
+            .remove("drafts", std::slice::from_ref(&one))
+            .unwrap();
+
+        let loaded = registry.get("drafts").unwrap();
+        assert_eq!(loaded.references.len(), 1);
+        assert_eq!(
+            loaded.references[0].path,
+            two.canonicalize().unwrap().to_string_lossy().to_string()
+        );
+        assert!(one.exists(), "remove must not delete referenced files");
+        assert!(two.exists());
+    }
+
+    #[test]
+    fn delete_removes_definition_only() {
+        let (_store_dir, store_path) = registry_path();
+        let source = tempdir().unwrap();
+        let file = source.path().join("note.md");
+        fs::write(&file, "# Note").unwrap();
+
+        let registry = VirtualWorkspaceRegistry::at(store_path);
+        registry
+            .create("drafts", std::slice::from_ref(&file))
+            .unwrap();
+        registry.delete("drafts").unwrap();
+
+        assert!(matches!(
+            registry.get("drafts"),
+            Err(VirtualWorkspaceError::MissingWorkspace(_))
+        ));
+        assert!(file.exists(), "delete must not delete referenced files");
+    }
+
+    #[test]
+    fn read_directory_expands_folder_with_nested_structure() {
+        let source = tempdir().unwrap();
+        let folder = source.path().join("docs");
+        let nested = folder.join("nested");
+        fs::create_dir_all(&nested).unwrap();
+        fs::write(folder.join("root.md"), "# Root").unwrap();
+        fs::write(nested.join("child.md"), "# Child").unwrap();
+        fs::write(nested.join("ignored.txt"), "ignored").unwrap();
+
+        let workspace = VirtualWorkspace {
+            name: "drafts".into(),
+            references: normalize_references(&[folder]).unwrap(),
+        };
+        let root_entries = read_directory(&workspace, &workspace.uri()).unwrap();
+        assert_eq!(root_entries[0].name, "docs");
+        assert_eq!(root_entries[0].kind, VirtualReferenceKind::Folder);
+
+        let docs_entries = read_directory(&workspace, &root_entries[0].path).unwrap();
+        assert_eq!(docs_entries.len(), 2);
+        assert_eq!(docs_entries[0].name, "nested");
+        assert_eq!(docs_entries[1].name, "root.md");
+
+        let nested_entries = read_directory(&workspace, &docs_entries[0].path).unwrap();
+        assert_eq!(nested_entries.len(), 1);
+        assert_eq!(nested_entries[0].name, "child.md");
+        assert!(nested_entries[0].path.ends_with("child.md"));
+    }
+
+    #[test]
+    fn missing_direct_reference_is_returned_as_missing() {
+        let source = tempdir().unwrap();
+        let file = source.path().join("note.md");
+        fs::write(&file, "# Note").unwrap();
+        let reference = normalize_references(std::slice::from_ref(&file))
+            .unwrap()
+            .remove(0);
+        fs::remove_file(&file).unwrap();
+
+        let workspace = VirtualWorkspace {
+            name: "drafts".into(),
+            references: vec![reference],
+        };
+        let entries = read_directory(&workspace, &workspace.uri()).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "note.md");
+        assert!(entries[0].missing);
+    }
+
+    #[test]
+    fn index_workspace_uses_virtual_relative_paths() {
+        let source = tempdir().unwrap();
+        let folder = source.path().join("docs");
+        let nested = folder.join("nested");
+        fs::create_dir_all(&nested).unwrap();
+        fs::write(nested.join("child.md"), "# Child").unwrap();
+
+        let workspace = VirtualWorkspace {
+            name: "drafts".into(),
+            references: normalize_references(&[folder]).unwrap(),
+        };
+        let (files, dirs) = index_workspace(&workspace);
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].relative_path, "docs/nested/child.md");
+        assert!(dirs.contains(&PathBuf::from(format!("{}/docs/nested", workspace.uri()))));
+    }
+
+    #[test]
+    fn duplicate_root_names_are_rejected() {
+        let source_a = tempdir().unwrap();
+        let source_b = tempdir().unwrap();
+        let folder_a = source_a.path().join("docs");
+        let folder_b = source_b.path().join("docs");
+        fs::create_dir(&folder_a).unwrap();
+        fs::create_dir(&folder_b).unwrap();
+
+        let err = normalize_references(&[folder_a, folder_b]).unwrap_err();
+        assert!(matches!(err, VirtualWorkspaceError::DuplicateRoot(_)));
+    }
+
+    #[test]
+    fn workspace_uri_round_trips_name() {
+        let uri = workspace_uri("Draft Notes");
+        assert_eq!(workspace_name_from_uri(&uri), Some("Draft Notes"));
+        assert!(is_virtual_workspace_uri(&uri));
+    }
+}

--- a/apps/desktop/src-tauri/src/writer_cli.rs
+++ b/apps/desktop/src-tauri/src/writer_cli.rs
@@ -5,6 +5,7 @@
 //! fake without spawning the real desktop app.
 
 use crate::open_target::{self, PendingOpenPayload};
+use crate::virtual_workspace::{parse_files_csv, VirtualWorkspaceRegistry};
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
@@ -16,6 +17,7 @@ const EXIT_RUNTIME: u8 = 3;
 
 pub const USAGE: &str = "\
 Usage: writer [PATH]
+       writer workspace <command>
 
 Open a folder or markdown file in the Writer desktop app.
 
@@ -27,9 +29,21 @@ Options:
   -h, --help        Print this help and exit.
   -V, --version     Print version and exit.
 
+Workspace commands:
+  workspace new <name> --files=<paths>       Create a virtual workspace.
+  workspace list                             List virtual workspaces.
+  workspace open <name>                      Open a virtual workspace.
+  workspace add <name> --files=<paths>       Add references.
+  workspace remove <name> --files=<paths>    Remove references only.
+  workspace delete <name>                    Delete the workspace definition.
+
+  <paths> is a comma-separated list of absolute file or folder paths.
+
 Environment:
   WRITER_APP_PATH   Override the path to the Writer bundle (macOS) or
                     binary (Linux/Windows). Useful for development builds.
+  WRITER_VIRTUAL_WORKSPACES_FILE
+                    Override the virtual workspace definition file.
 ";
 
 /// Version embedded at compile time from the Cargo package.
@@ -41,18 +55,35 @@ enum ParsedArgs {
     Help,
     Version,
     Open { path: Option<PathBuf> },
+    Workspace(WorkspaceCommand),
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum WorkspaceCommand {
+    New { name: String, files: Vec<PathBuf> },
+    List,
+    Open { name: String },
+    Add { name: String, files: Vec<PathBuf> },
+    Remove { name: String, files: Vec<PathBuf> },
+    Delete { name: String },
 }
 
 #[derive(Debug, PartialEq, Eq)]
 enum ParseError {
+    MissingArgument(&'static str),
+    MissingFiles,
     UnknownFlag(String),
+    UnknownCommand(String),
     TooManyArgs,
 }
 
 impl std::fmt::Display for ParseError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::MissingArgument(arg) => write!(f, "missing argument: {arg}"),
+            Self::MissingFiles => write!(f, "missing required option: --files=<paths>"),
             Self::UnknownFlag(flag) => write!(f, "unknown option: {flag}"),
+            Self::UnknownCommand(command) => write!(f, "unknown command: {command}"),
             Self::TooManyArgs => write!(f, "expected at most one path argument"),
         }
     }
@@ -60,6 +91,14 @@ impl std::fmt::Display for ParseError {
 
 fn parse_args(argv: &[OsString]) -> Result<ParsedArgs, ParseError> {
     // argv[0] is the program name.
+    if argv
+        .get(1)
+        .and_then(|arg| arg.to_str())
+        .is_some_and(|arg| arg == "workspace")
+    {
+        return parse_workspace_args(&argv[2..]);
+    }
+
     let mut positional: Option<PathBuf> = None;
 
     for arg in argv.iter().skip(1) {
@@ -81,6 +120,87 @@ fn parse_args(argv: &[OsString]) -> Result<ParsedArgs, ParseError> {
     }
 
     Ok(ParsedArgs::Open { path: positional })
+}
+
+fn parse_workspace_args(args: &[OsString]) -> Result<ParsedArgs, ParseError> {
+    let command = args
+        .first()
+        .and_then(|arg| arg.to_str())
+        .ok_or(ParseError::MissingArgument("workspace command"))?;
+
+    let parsed = match command {
+        "new" => {
+            let name = workspace_name_arg(args, 1)?;
+            let files = parse_required_files(args, 2)?;
+            WorkspaceCommand::New { name, files }
+        }
+        "list" => {
+            if args.len() > 1 {
+                return Err(ParseError::TooManyArgs);
+            }
+            WorkspaceCommand::List
+        }
+        "open" => {
+            let name = workspace_name_arg(args, 1)?;
+            if args.len() > 2 {
+                return Err(ParseError::TooManyArgs);
+            }
+            WorkspaceCommand::Open { name }
+        }
+        "add" => {
+            let name = workspace_name_arg(args, 1)?;
+            let files = parse_required_files(args, 2)?;
+            WorkspaceCommand::Add { name, files }
+        }
+        "remove" => {
+            let name = workspace_name_arg(args, 1)?;
+            let files = parse_required_files(args, 2)?;
+            WorkspaceCommand::Remove { name, files }
+        }
+        "delete" => {
+            let name = workspace_name_arg(args, 1)?;
+            if args.len() > 2 {
+                return Err(ParseError::TooManyArgs);
+            }
+            WorkspaceCommand::Delete { name }
+        }
+        other if other.starts_with('-') => return Err(ParseError::UnknownFlag(other.to_string())),
+        other => return Err(ParseError::UnknownCommand(other.to_string())),
+    };
+
+    Ok(ParsedArgs::Workspace(parsed))
+}
+
+fn workspace_name_arg(args: &[OsString], index: usize) -> Result<String, ParseError> {
+    args.get(index)
+        .map(|arg| arg.to_string_lossy().to_string())
+        .filter(|name| !name.trim().is_empty())
+        .ok_or(ParseError::MissingArgument("name"))
+}
+
+fn parse_required_files(args: &[OsString], start: usize) -> Result<Vec<PathBuf>, ParseError> {
+    let mut files: Option<Vec<PathBuf>> = None;
+    let mut index = start;
+    while index < args.len() {
+        let arg = args[index].to_string_lossy();
+        if arg == "--files" {
+            index += 1;
+            let value = args
+                .get(index)
+                .ok_or(ParseError::MissingArgument("--files value"))?
+                .to_string_lossy()
+                .to_string();
+            files = Some(parse_files_csv(&value).map_err(|_| ParseError::MissingFiles)?);
+        } else if let Some(value) = arg.strip_prefix("--files=") {
+            files = Some(parse_files_csv(value).map_err(|_| ParseError::MissingFiles)?);
+        } else if arg.starts_with('-') {
+            return Err(ParseError::UnknownFlag(arg.to_string()));
+        } else {
+            return Err(ParseError::TooManyArgs);
+        }
+        index += 1;
+    }
+    files.ok_or(ParseError::MissingFiles)
 }
 
 /// Resolve a user-supplied path against `cwd`. Relative paths and `.` / `..`
@@ -147,7 +267,12 @@ fn launch_system(target: Option<&Path>) -> Result<(), LaunchError> {
     };
 
     if let Some(path) = target {
-        cmd.arg(path);
+        let target_arg = path.to_string_lossy();
+        if crate::virtual_workspace::is_virtual_workspace_uri(&target_arg) {
+            cmd.arg("--args").arg(path);
+        } else {
+            cmd.arg(path);
+        }
     }
 
     let status = cmd.status()?;
@@ -200,9 +325,77 @@ pub fn run<L: Launcher>(argv: Vec<OsString>, cwd: &Path, launcher: &L) -> ExitCo
             ExitCode::from(EXIT_SUCCESS)
         }
         Ok(ParsedArgs::Open { path }) => run_open(path, cwd, launcher),
+        Ok(ParsedArgs::Workspace(command)) => run_workspace(command, launcher),
         Err(err) => {
             fail_usage(err);
             ExitCode::from(EXIT_USAGE)
+        }
+    }
+}
+
+fn run_workspace<L: Launcher>(command: WorkspaceCommand, launcher: &L) -> ExitCode {
+    let registry = match VirtualWorkspaceRegistry::for_app_data() {
+        Ok(registry) => registry,
+        Err(err) => {
+            fail_runtime(&err);
+            return ExitCode::from(EXIT_RUNTIME);
+        }
+    };
+
+    let result = match command {
+        WorkspaceCommand::New { name, files } => registry.create(&name, &files).map(|workspace| {
+            println!(
+                "Created workspace {} ({} references)",
+                workspace.name,
+                workspace.references.len()
+            );
+        }),
+        WorkspaceCommand::List => registry.list().map(|workspaces| {
+            for workspace in workspaces {
+                println!(
+                    "{}\t{} references",
+                    workspace.name,
+                    workspace.references.len()
+                );
+            }
+        }),
+        WorkspaceCommand::Open { name } => match registry.get(&name) {
+            Ok(workspace) => {
+                let target = PathBuf::from(workspace.uri());
+                launcher.launch(Some(&target)).map_err(|err| {
+                    crate::virtual_workspace::VirtualWorkspaceError::Io(std::io::Error::other(
+                        err.to_string(),
+                    ))
+                })
+            }
+            Err(err) => Err(err),
+        },
+        WorkspaceCommand::Add { name, files } => registry.add(&name, &files).map(|workspace| {
+            println!(
+                "Updated workspace {} ({} references)",
+                workspace.name,
+                workspace.references.len()
+            );
+        }),
+        WorkspaceCommand::Remove { name, files } => {
+            registry.remove(&name, &files).map(|workspace| {
+                println!(
+                    "Updated workspace {} ({} references)",
+                    workspace.name,
+                    workspace.references.len()
+                );
+            })
+        }
+        WorkspaceCommand::Delete { name } => registry.delete(&name).map(|()| {
+            println!("Deleted workspace {name}");
+        }),
+    };
+
+    match result {
+        Ok(()) => ExitCode::from(EXIT_SUCCESS),
+        Err(err) => {
+            fail_runtime(&err);
+            ExitCode::from(EXIT_RUNTIME)
         }
     }
 }
@@ -342,6 +535,79 @@ mod tests {
     }
 
     #[test]
+    fn parse_workspace_new_with_files_equals() {
+        assert_eq!(
+            parse_args(&argv(&[
+                "writer",
+                "workspace",
+                "new",
+                "Drafts",
+                "--files=/tmp/a.md,/tmp/b"
+            ]))
+            .unwrap(),
+            ParsedArgs::Workspace(WorkspaceCommand::New {
+                name: "Drafts".into(),
+                files: vec![PathBuf::from("/tmp/a.md"), PathBuf::from("/tmp/b")]
+            })
+        );
+    }
+
+    #[test]
+    fn parse_workspace_add_with_files_value() {
+        assert_eq!(
+            parse_args(&argv(&[
+                "writer",
+                "workspace",
+                "add",
+                "Drafts",
+                "--files",
+                "/tmp/a.md,/tmp/b"
+            ]))
+            .unwrap(),
+            ParsedArgs::Workspace(WorkspaceCommand::Add {
+                name: "Drafts".into(),
+                files: vec![PathBuf::from("/tmp/a.md"), PathBuf::from("/tmp/b")]
+            })
+        );
+    }
+
+    #[test]
+    fn parse_workspace_list() {
+        assert_eq!(
+            parse_args(&argv(&["writer", "workspace", "list"])).unwrap(),
+            ParsedArgs::Workspace(WorkspaceCommand::List)
+        );
+    }
+
+    #[test]
+    fn parse_workspace_open() {
+        assert_eq!(
+            parse_args(&argv(&["writer", "workspace", "open", "Drafts"])).unwrap(),
+            ParsedArgs::Workspace(WorkspaceCommand::Open {
+                name: "Drafts".into()
+            })
+        );
+    }
+
+    #[test]
+    fn parse_workspace_delete() {
+        assert_eq!(
+            parse_args(&argv(&["writer", "workspace", "delete", "Drafts"])).unwrap(),
+            ParsedArgs::Workspace(WorkspaceCommand::Delete {
+                name: "Drafts".into()
+            })
+        );
+    }
+
+    #[test]
+    fn parse_workspace_remove_requires_files() {
+        assert!(matches!(
+            parse_args(&argv(&["writer", "workspace", "remove", "Drafts"])),
+            Err(ParseError::MissingFiles)
+        ));
+    }
+
+    #[test]
     fn parse_rejects_multiple_positional() {
         assert!(matches!(
             parse_args(&argv(&["writer", "a", "b"])),
@@ -444,6 +710,50 @@ mod tests {
             format!("{code:?}"),
             format!("{:?}", ExitCode::from(EXIT_RUNTIME))
         );
+    }
+
+    #[test]
+    fn run_workspace_open_launches_virtual_workspace_uri() {
+        let store = tempdir().unwrap();
+        let source = tempdir().unwrap();
+        let note = source.path().join("note.md");
+        fs::write(&note, "# Note").unwrap();
+        let store_file = store.path().join("virtual_workspaces.json");
+        std::env::set_var("WRITER_VIRTUAL_WORKSPACES_FILE", &store_file);
+
+        let launcher = FakeLauncher::new();
+        let cwd = tempdir().unwrap();
+        let create_code = run(
+            argv(&[
+                "writer",
+                "workspace",
+                "new",
+                "Drafts",
+                &format!("--files={}", note.display()),
+            ]),
+            cwd.path(),
+            &launcher,
+        );
+        assert_eq!(
+            format!("{create_code:?}"),
+            format!("{:?}", ExitCode::from(EXIT_SUCCESS))
+        );
+
+        let open_code = run(
+            argv(&["writer", "workspace", "open", "Drafts"]),
+            cwd.path(),
+            &launcher,
+        );
+        assert_eq!(
+            format!("{open_code:?}"),
+            format!("{:?}", ExitCode::from(EXIT_SUCCESS))
+        );
+        assert_eq!(
+            launcher.calls.borrow().as_slice(),
+            &[Some(PathBuf::from("writer-workspace://Drafts"))]
+        );
+
+        std::env::remove_var("WRITER_VIRTUAL_WORKSPACES_FILE");
     }
 
     #[test]

--- a/apps/desktop/src/components/command-palette/index.tsx
+++ b/apps/desktop/src/components/command-palette/index.tsx
@@ -46,7 +46,7 @@ export function CommandPalette() {
   const search = useCommandPaletteSearch();
   const setSearch = useSetCommandPaletteSearch();
   const { toggleSidebar } = useSidebar();
-  const { root, isIndexing, openWorkspace, closeWorkspace } = useWorkspace();
+  const { root, isVirtual, isIndexing, openWorkspace, closeWorkspace } = useWorkspace();
   const openFile = useOpenFile();
   const closeActiveTab = useCloseActiveTab();
   const closeTab = useCloseTab();
@@ -59,7 +59,7 @@ export function CommandPalette() {
   const trimmedSearch = search.trim();
   const fileQuery = isCreateIntent ? "" : search;
   const results = useFuzzySearch(fileQuery);
-  const createPath = root && trimmedSearch ? toCreatePath(root, trimmedSearch) : null;
+  const createPath = root && !isVirtual && trimmedSearch ? toCreatePath(root, trimmedSearch) : null;
 
   function matchesSearch(text: string, q: string) {
     return text.toLowerCase().includes(q.toLowerCase());
@@ -100,12 +100,13 @@ export function CommandPalette() {
         close();
       },
     },
-    root && {
-      id: "new-file",
-      label: "Create New File",
-      description: "Command",
-      run: () => openCommandPalette("create-file"),
-    },
+    root &&
+      !isVirtual && {
+        id: "new-file",
+        label: "Create New File",
+        description: "Command",
+        run: () => openCommandPalette("create-file"),
+      },
     activeTabId && {
       id: "close-tab",
       label: "Close Current Tab",

--- a/apps/desktop/src/components/sidebar/file-tree-node.tsx
+++ b/apps/desktop/src/components/sidebar/file-tree-node.tsx
@@ -83,6 +83,7 @@ export const FileTreeNode = memo(function FileTreeNode({
     : fileLabelMode === "filename"
       ? getFileStem(entry.name)
       : editorTitle || entry.title || getFileStem(entry.name);
+  const renderedName = entry.missing ? `${displayName} (missing)` : displayName;
   const inputRef = useRef<HTMLInputElement>(null);
 
   // Auto-focus and select the stem when entering rename mode.
@@ -98,6 +99,7 @@ export const FileTreeNode = memo(function FileTreeNode({
 
   function handleClick(event: MouseEvent<HTMLElement>) {
     if (isRenaming) return;
+    if (entry.missing) return;
     // All clicks go through onClick so the parent can manage selection.
     // The parent decides whether to also open/toggle based on modifiers.
     if (onClick) {
@@ -112,7 +114,7 @@ export const FileTreeNode = memo(function FileTreeNode({
   }
 
   function handleContextMenu(event: MouseEvent<HTMLElement>) {
-    if (!entry.is_dir && !entry.is_markdown) return;
+    if (entry.missing || (!entry.is_dir && !entry.is_markdown)) return;
     if (!onContextMenu) return;
     event.preventDefault();
     event.stopPropagation();
@@ -169,11 +171,17 @@ export const FileTreeNode = memo(function FileTreeNode({
       data-tree-path={entry.path}
       aria-selected={isActive}
       aria-expanded={entry.is_dir ? isExpanded : undefined}
-      aria-label={entry.is_dir ? `${entry.name} folder` : displayName}
+      aria-label={
+        entry.missing
+          ? `${renderedName} unavailable`
+          : entry.is_dir
+            ? `${entry.name} folder`
+            : displayName
+      }
       onMouseDown={(e) => e.preventDefault()}
       onClick={handleClick}
       onContextMenu={handleContextMenu}
-      className={`group ${entry.is_dir ? "group/folder " : ""}flex h-[32px] w-full items-center gap-1.5 overflow-hidden rounded-lg pr-2 text-left text-[13px] leading-[1.15] text-[var(--fg-base)] ${bgClassName}`}
+      className={`group ${entry.is_dir ? "group/folder " : ""}flex h-[32px] w-full items-center gap-1.5 overflow-hidden rounded-lg pr-2 text-left text-[13px] leading-[1.15] text-[var(--fg-base)] ${entry.missing ? "cursor-default" : ""} ${bgClassName}`}
       style={{ paddingLeft: depth === 0 ? 10 : depth * 12 + 6 }}
     >
       <span className="relative flex w-5 shrink-0 items-center justify-center">
@@ -201,7 +209,7 @@ export const FileTreeNode = memo(function FileTreeNode({
       <span
         className={`min-w-0 overflow-hidden text-ellipsis whitespace-nowrap ${isHighlighted ? "opacity-100" : "opacity-60 group-hover:opacity-100"}`}
       >
-        {displayName}
+        {renderedName}
       </span>
     </button>
   );

--- a/apps/desktop/src/components/sidebar/file-tree.tsx
+++ b/apps/desktop/src/components/sidebar/file-tree.tsx
@@ -19,7 +19,7 @@ import {
   renameOpenFile,
   rewritePathPrefix,
 } from "@/hooks/editor-api";
-import { useWorkspaceRoot } from "@/hooks/use-workspace";
+import { useIsVirtualWorkspace, useWorkspaceRoot } from "@/hooks/use-workspace";
 import * as tauri from "@/lib/tauri";
 import { getFileStem, getParentDir, getRelativePath } from "@/lib/paths";
 import { duplicateFile } from "./duplicate-file";
@@ -66,6 +66,7 @@ export function FileTree({ rootPath }: FileTreeProps) {
   const invalidatePath = useInvalidatePath();
   const rewriteExpandedDir = useRewriteExpandedDir();
   const workspaceRoot = useWorkspaceRoot();
+  const isVirtualWorkspace = useIsVirtualWorkspace();
   const fileLabelMode = useSetting("appearance.sidebar-file-label");
   const [renamingPath, setRenamingPath] = useState<string | null>(null);
   const [selectedPaths, setSelectedPaths] = useState<Set<string>>(new Set());
@@ -129,6 +130,9 @@ export function FileTree({ rootPath }: FileTreeProps) {
         // Plain click: clear selection and perform normal action
         setSelectedPaths(new Set());
         setSelectionAnchor(entry.path);
+        if (entry.missing) {
+          return;
+        }
         if (entry.is_dir) {
           void toggleDirectory(entry.path);
         } else {
@@ -430,6 +434,10 @@ export function FileTree({ rootPath }: FileTreeProps) {
 
   const handleContextMenu = useCallback(
     (_event: MouseEvent<HTMLElement>, entry: DirEntry) => {
+      if (isVirtualWorkspace || entry.missing) {
+        return;
+      }
+
       // If multiple items are selected and the right-clicked item is in the selection,
       // show the bulk menu
       if (selectedPaths.size >= 2 && selectedPaths.has(entry.path)) {
@@ -447,7 +455,13 @@ export function FileTree({ rootPath }: FileTreeProps) {
         handleFileContextMenu(entry);
       }
     },
-    [handleBulkContextMenu, handleFileContextMenu, handleFolderContextMenu, selectedPaths],
+    [
+      handleBulkContextMenu,
+      handleFileContextMenu,
+      handleFolderContextMenu,
+      isVirtualWorkspace,
+      selectedPaths,
+    ],
   );
 
   if (flatItems.length === 0) {

--- a/apps/desktop/src/hooks/use-workspace.ts
+++ b/apps/desktop/src/hooks/use-workspace.ts
@@ -2,6 +2,7 @@ import { useWorkspaceStore } from "@/stores/workspace-store";
 
 export function useWorkspace() {
   const root = useWorkspaceStore((s) => s.root);
+  const isVirtual = useWorkspaceStore((s) => s.isVirtual);
   const isIndexing = useWorkspaceStore((s) => s.isIndexing);
   const openWorkspace = useWorkspaceStore((s) => s.openWorkspace);
   const closeWorkspace = useWorkspaceStore((s) => s.closeWorkspace);
@@ -9,6 +10,7 @@ export function useWorkspace() {
   const removeRecentWorkspace = useWorkspaceStore((s) => s.removeRecentWorkspace);
   return {
     root,
+    isVirtual,
     isIndexing,
     openWorkspace,
     closeWorkspace,
@@ -23,4 +25,8 @@ export function useIsStartupResolved() {
 
 export function useWorkspaceRoot() {
   return useWorkspaceStore((s) => s.root);
+}
+
+export function useIsVirtualWorkspace() {
+  return useWorkspaceStore((s) => s.isVirtual);
 }

--- a/apps/desktop/src/stores/workspace-store.ts
+++ b/apps/desktop/src/stores/workspace-store.ts
@@ -7,6 +7,7 @@ import { getEditorSessionSnapshot, useEditorStore } from "@/stores/editor-store"
 
 interface WorkspaceState {
   root: string | null;
+  isVirtual: boolean;
   isIndexing: boolean;
   isStartupResolved: boolean;
   directoryCache: Map<string, DirEntry[]>;
@@ -28,6 +29,7 @@ interface WorkspaceState {
 
 export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
   root: null,
+  isVirtual: false,
   isIndexing: false,
   isStartupResolved: false,
   directoryCache: new Map(),
@@ -65,6 +67,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     const recents = await tauri.getRecentWorkspaces();
     set({
       root: info.root,
+      isVirtual: info.is_virtual ?? false,
       isIndexing: true,
       directoryCache: new Map([[info.root, entries]]),
       expandedDirs: new Set(),
@@ -91,7 +94,13 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       activeTabId: null,
       activeFilePath: null,
     });
-    set({ root: null, directoryCache: new Map(), expandedDirs: new Set(), isIndexing: false });
+    set({
+      root: null,
+      isVirtual: false,
+      directoryCache: new Map(),
+      expandedDirs: new Set(),
+      isIndexing: false,
+    });
   },
 
   restoreFromBundle: async (bundle) => {
@@ -105,6 +114,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
 
     set({
       root: bundle.workspace.root,
+      isVirtual: bundle.workspace.is_virtual ?? false,
       isIndexing: true,
       directoryCache: new Map([[bundle.workspace.root, bundle.entries]]),
       expandedDirs: new Set(),

--- a/apps/desktop/src/types/fs.ts
+++ b/apps/desktop/src/types/fs.ts
@@ -1,8 +1,10 @@
 export interface DirEntry {
   name: string;
   path: string;
+  source_path?: string;
   is_dir: boolean;
   is_markdown: boolean;
+  missing?: boolean;
   modified_at: number;
   title: string | null;
 }
@@ -22,6 +24,7 @@ export interface WorkspaceInfo {
   root: string;
   name: string;
   file_count: number;
+  is_virtual?: boolean;
 }
 
 export interface SearchResult {


### PR DESCRIPTION
## Summary
- add CLI-managed virtual workspace definitions for absolute file/folder references
- route writer-workspace:// opens through desktop startup/window state, virtual directory reads, and search indexing
- mark missing references unavailable and suppress filesystem-mutating UI actions in virtual workspaces

## Validation
- cargo test
- cargo fmt --check
- cargo clippy (passes with existing unrelated warnings)
- ./node_modules/.bin/vp install
- ./node_modules/.bin/vp check (0 errors; existing e2e warnings)
- ./node_modules/.bin/vp test
- ./node_modules/.bin/vp run desktop#build

## Notes
- ./node_modules/.bin/vp run build -r is not accepted by this Vite+ version; ran desktop#build instead.
- Virtual workspace file watching across every referenced root is intentionally deferred for this first pass.