### PR TITLE
Fix cold-start duplicate window and session bleed on explicit open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-06-01
+
+- Fix opening a folder or file from the CLI, Finder, or by dropping onto the dock so it lands in a single window instead of spawning a duplicate empty one on cold start. On macOS the open target arrives via the system open event (not argv), which previously raced window creation; it now seeds the main window's startup open target when that window hasn't been built yet, and opens a new window only when the app is already running with a different workspace.
+- Make the startup open target a single source of truth (`startup_open`) that Rust sets before the webview loads and the client reads once during startup hydration — same lifecycle as settings — so an explicit open no longer restores the previous session's tabs alongside the requested file. Runtime drag-and-drop onto a live window still uses the separate pending-open queue.
+
 ## 2026-05-28
 
 - Animate the sidebar folder caret so it rotates smoothly between collapsed (pointing right) and expanded (pointing down) instead of swapping icons instantly. The caret rotation is now the only animated transition on sidebar rows — the hover background highlight and the icon/label opacity changes apply instantly.

--- a/apps/desktop/src-tauri/src/commands/startup.rs
+++ b/apps/desktop/src-tauri/src/commands/startup.rs
@@ -4,7 +4,6 @@ use crate::commands::workspace::{
 };
 use crate::error::AppError;
 use crate::state::AppState;
-use crate::PendingOpenPayload;
 use serde::Serialize;
 use serde_json::Value;
 use std::path::Path;
@@ -16,14 +15,10 @@ const RESTORE_WORKSPACE_KEY: &str = "window.restore-workspace";
 pub struct StartupState {
     pub settings: Value,
     pub recent_workspaces: Vec<String>,
-    pub pending_open: Option<PendingOpenPayload>,
-    /// Prefetched workspace restore payload. Populated when there is a
-    /// `pending_open` (CLI / drag-drop cold start — bundle is built for that
-    /// workspace) or, failing that, when `window.restore-workspace` is enabled
-    /// and the most-recent recent workspace still exists on disk. When
-    /// present, the frontend hydrates its stores synchronously from this
-    /// bundle so React's first render already has full content — no second
-    /// IPC waterfall, no intermediate "empty shell" frame.
+    /// Single source of truth for what to render on startup. Built from
+    /// either an explicit open (CLI arg / drag-drop — `open_file` is set,
+    /// `session` is `None`) or a workspace restore (`session` is populated,
+    /// `open_file` is `None`). The frontend only looks at this one payload.
     pub restore_bundle: Option<RestoreWorkspaceResponse>,
 }
 
@@ -55,15 +50,14 @@ pub async fn get_startup_state(
     };
 
     let recent_workspaces = load_recent_workspaces(&app).unwrap_or_default();
-    let pending_open = state.pop_pending_open();
+    let startup_open = state.take_startup_open();
 
     // Pick a workspace to prefetch a bundle for so the frontend can hydrate
     // synchronously on first render — no second IPC waterfall, no welcome
-    // screen flash. CLI / drag-drop cold starts get their pending workspace;
-    // otherwise fall back to the recent list (gated on the restore setting).
-    // Secondary windows opened via `open_workspace_in_new_window` follow the
-    // pending-open branch via their pre-seeded queue.
-    let restore_target = if let Some(payload) = &pending_open {
+    // screen flash. startup_open is set during window creation (from CLI
+    // args or open_new_workspace_window) before the webview loads — same
+    // lifecycle as settings. No runtime event touches it.
+    let restore_target = if let Some(payload) = &startup_open {
         Some(payload.workspace.clone())
     } else if restore_enabled {
         recent_workspaces
@@ -74,7 +68,7 @@ pub async fn get_startup_state(
         None
     };
 
-    let restore_bundle = if let Some(path) = restore_target {
+    let mut restore_bundle = if let Some(path) = restore_target {
         match build_restore_bundle(&app, &label, &path).await {
             Ok(bundle) => Some(bundle),
             Err(err) => {
@@ -88,10 +82,20 @@ pub async fn get_startup_state(
         None
     };
 
+    // Fold the explicit open into the bundle so the frontend has a single
+    // source of truth. Strip the saved session (old tabs) — the user asked
+    // for a specific file, not their previous editor state.
+    if let Some(pending) = startup_open {
+        if let Some(ref mut bundle) = restore_bundle {
+            bundle.session = None;
+            bundle.active_file = None;
+            bundle.open_file = pending.file;
+        }
+    }
+
     Ok(StartupState {
         settings,
         recent_workspaces,
-        pending_open,
         restore_bundle,
     })
 }

--- a/apps/desktop/src-tauri/src/commands/workspace.rs
+++ b/apps/desktop/src-tauri/src/commands/workspace.rs
@@ -226,6 +226,7 @@ pub struct RestoreWorkspaceResponse {
     pub recent_workspaces: Vec<String>,
     pub session: Option<SessionData>,
     pub active_file: Option<FileContent>,
+    pub open_file: Option<String>,
 }
 
 /// Shared workspace-restore body used by both the `restore_workspace` IPC
@@ -300,6 +301,7 @@ pub(crate) async fn build_restore_bundle(
         recent_workspaces,
         session,
         active_file,
+        open_file: None,
     })
 }
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -39,7 +39,7 @@ const MAIN_WINDOW_LABEL: &str = "main";
 /// routed via `emit_to` so a drop onto window A never triggers window B.
 fn queue_open_event(app: &tauri::AppHandle, label: &str, payload: PendingOpenPayload) {
     if let Some(state) = app.state::<AppState>().get(label) {
-        state.set_pending_open(payload.clone());
+        state.push_pending_open(payload.clone());
     }
     let _ = app.emit_to(label, "open:from-drop", payload);
 }
@@ -481,35 +481,44 @@ pub fn run() {
                     if let Ok(path) = url.to_file_path() {
                         if let Some(payload) = resolve_path(&path) {
                             let app_state = _app.state::<AppState>();
-                            let existing = app_state
-                                .find_by_workspace(&PathBuf::from(&payload.workspace));
+                            let existing =
+                                app_state.find_by_workspace(&PathBuf::from(&payload.workspace));
                             match existing {
                                 Some(label) => {
                                     queue_open_event(_app, &label, payload);
                                 }
                                 None => {
-                                    // If the main webview window doesn't exist
-                                    // yet, this Opened event beat window
-                                    // creation — a cold start. Seed the main
-                                    // window's startup_open so it hydrates onto
-                                    // this workspace when it loads, instead of
-                                    // spawning a second window beside the empty
-                                    // main. `open -a` delivers the path here,
-                                    // not through argv.
-                                    if _app.get_webview_window(MAIN_WINDOW_LABEL).is_none() {
-                                        app_state
-                                            .get_or_create(MAIN_WINDOW_LABEL)
-                                            .set_startup_open(payload);
-                                    } else {
-                                        // Warm start: the app is already running
-                                        // with its main window loaded. Open the
-                                        // workspace in a new window so the user's
-                                        // current editor state is preserved.
-                                        let _ = open_new_workspace_window(
-                                            _app,
-                                            payload.workspace.clone(),
-                                            payload.file.clone(),
-                                        );
+                                    let main_state = app_state.get_or_create(MAIN_WINDOW_LABEL);
+                                    match main_state.try_set_startup_open(payload) {
+                                        Ok(()) => {}
+                                        Err(payload) => {
+                                            let main_visible = _app
+                                                .get_webview_window(MAIN_WINDOW_LABEL)
+                                                .is_some_and(|window| {
+                                                    window.is_visible().unwrap_or(false)
+                                                });
+
+                                            if main_visible {
+                                                // Warm start: the app is already
+                                                // running with its main window
+                                                // visible. Open the workspace in a
+                                                // new window so the user's current
+                                                // editor state is preserved.
+                                                let _ = open_new_workspace_window(
+                                                    _app,
+                                                    payload.workspace.clone(),
+                                                    payload.file.clone(),
+                                                );
+                                            } else {
+                                                // Startup state has already been
+                                                // read, but the hidden main window
+                                                // is still hydrating. Queue the
+                                                // open for the startup drainer
+                                                // instead of spawning a duplicate
+                                                // empty main-adjacent window.
+                                                queue_open_event(_app, MAIN_WINDOW_LABEL, payload);
+                                            }
+                                        }
                                     }
                                 }
                             }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -39,7 +39,7 @@ const MAIN_WINDOW_LABEL: &str = "main";
 /// routed via `emit_to` so a drop onto window A never triggers window B.
 fn queue_open_event(app: &tauri::AppHandle, label: &str, payload: PendingOpenPayload) {
     if let Some(state) = app.state::<AppState>().get(label) {
-        state.push_pending_open(payload.clone());
+        state.set_pending_open(payload.clone());
     }
     let _ = app.emit_to(label, "open:from-drop", payload);
 }
@@ -105,7 +105,7 @@ pub(crate) fn open_new_workspace_window(
     let label = format!("w-{}", uuid::Uuid::new_v4().simple());
     let state = app.state::<AppState>().get_or_create(&label);
     init_window_settings(app, &state);
-    state.push_pending_open(PendingOpenPayload {
+    state.set_startup_open(PendingOpenPayload {
         workspace: workspace_str,
         file,
     });
@@ -393,13 +393,17 @@ pub fn run() {
             let main_state = app.state::<AppState>().get_or_create(MAIN_WINDOW_LABEL);
             init_window_settings(app.handle(), &main_state);
 
-            // CLI arg → main window's pending-open queue. On cold start the
-            // main window is the one that will host the requested workspace.
-            let args: Vec<String> = std::env::args().collect();
-            if args.len() > 1 {
-                let path = PathBuf::from(&args[1]);
-                if let Some(payload) = resolve_path(&path) {
-                    main_state.push_pending_open(payload);
+            // On macOS, `open -a Writer /path` delivers the path via
+            // RunEvent::Opened, not argv. On Linux/Windows the path
+            // arrives through argv (or the single-instance plugin).
+            #[cfg(not(target_os = "macos"))]
+            {
+                let args: Vec<String> = std::env::args().collect();
+                if args.len() > 1 {
+                    let path = PathBuf::from(&args[1]);
+                    if let Some(payload) = resolve_path(&path) {
+                        main_state.set_startup_open(payload);
+                    }
                 }
             }
 
@@ -476,24 +480,37 @@ pub fn run() {
                 for url in urls {
                     if let Ok(path) = url.to_file_path() {
                         if let Some(payload) = resolve_path(&path) {
-                            // A dock drop isn't associated with a specific
-                            // window — route it to an already-open window
-                            // showing the same workspace, else open a new
-                            // one so the user never loses their current
-                            // editor state.
-                            let existing = _app
-                                .state::<AppState>()
+                            let app_state = _app.state::<AppState>();
+                            let existing = app_state
                                 .find_by_workspace(&PathBuf::from(&payload.workspace));
                             match existing {
                                 Some(label) => {
                                     queue_open_event(_app, &label, payload);
                                 }
                                 None => {
-                                    let _ = open_new_workspace_window(
-                                        _app,
-                                        payload.workspace.clone(),
-                                        payload.file.clone(),
-                                    );
+                                    // If the main webview window doesn't exist
+                                    // yet, this Opened event beat window
+                                    // creation — a cold start. Seed the main
+                                    // window's startup_open so it hydrates onto
+                                    // this workspace when it loads, instead of
+                                    // spawning a second window beside the empty
+                                    // main. `open -a` delivers the path here,
+                                    // not through argv.
+                                    if _app.get_webview_window(MAIN_WINDOW_LABEL).is_none() {
+                                        app_state
+                                            .get_or_create(MAIN_WINDOW_LABEL)
+                                            .set_startup_open(payload);
+                                    } else {
+                                        // Warm start: the app is already running
+                                        // with its main window loaded. Open the
+                                        // workspace in a new window so the user's
+                                        // current editor state is preserved.
+                                        let _ = open_new_workspace_window(
+                                            _app,
+                                            payload.workspace.clone(),
+                                            payload.file.clone(),
+                                        );
+                                    }
                                 }
                             }
                             break;

--- a/apps/desktop/src-tauri/src/state.rs
+++ b/apps/desktop/src-tauri/src/state.rs
@@ -5,7 +5,7 @@ use notify::RecommendedWatcher;
 use parking_lot::{Mutex, RwLock};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, AtomicU64};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -45,14 +45,18 @@ pub struct WorkspaceState {
     /// window's workspace. Two windows with different workspaces therefore
     /// carry different merged settings without clobbering each other.
     pub settings: RwLock<Option<Settings>>,
-    /// Open target set during window creation (from CLI args or
-    /// `open_new_workspace_window`). Read once by `get_startup_state`.
-    /// Follows the same lifecycle as `settings` — set before the webview
-    /// loads, consumed during startup hydration. Runtime events never
-    /// touch this field.
+    /// Open target set before this window's `get_startup_state` has read the
+    /// startup slot. Usually seeded during window creation (CLI args or
+    /// `open_new_workspace_window`); macOS `RunEvent::Opened` can also seed
+    /// the hidden main window before React asks for startup state.
     pub startup_open: Mutex<Option<PendingOpenPayload>>,
-    /// Runtime-only queue for drag-drop / dock-drop events on a live,
-    /// already-hydrated window. Never read by `get_startup_state`.
+    /// Flips to `true` once `get_startup_state` has attempted to read
+    /// `startup_open`. After this point, open events must use `pending_open`
+    /// because the startup slot will not be read again.
+    pub startup_open_taken: AtomicBool,
+    /// Runtime-only queue for drag-drop / dock-drop events after the startup
+    /// slot has been read. Drained by the frontend once startup hydration
+    /// completes. Never read by `get_startup_state`.
     pub pending_open: Mutex<VecDeque<PendingOpenPayload>>,
 }
 
@@ -77,6 +81,7 @@ impl Default for WorkspaceState {
             cancel_index: RwLock::new(Arc::new(AtomicBool::new(false))),
             settings: RwLock::new(None),
             startup_open: Mutex::new(None),
+            startup_open_taken: AtomicBool::new(false),
             pending_open: Mutex::new(VecDeque::new()),
         }
     }
@@ -84,16 +89,37 @@ impl Default for WorkspaceState {
 
 impl WorkspaceState {
     pub fn set_startup_open(&self, payload: PendingOpenPayload) {
+        debug_assert!(
+            !self.startup_open_taken.load(Ordering::Acquire),
+            "startup_open was set after get_startup_state consumed it"
+        );
         *self.startup_open.lock() = Some(payload);
     }
 
-    pub fn take_startup_open(&self) -> Option<PendingOpenPayload> {
-        self.startup_open.lock().take()
+    pub fn try_set_startup_open(
+        &self,
+        payload: PendingOpenPayload,
+    ) -> Result<(), PendingOpenPayload> {
+        let mut startup_open = self.startup_open.lock();
+        if self.startup_open_taken.load(Ordering::Acquire) || startup_open.is_some() {
+            return Err(payload);
+        }
+        *startup_open = Some(payload);
+        Ok(())
     }
 
-    pub fn set_pending_open(&self, payload: PendingOpenPayload) {
+    pub fn take_startup_open(&self) -> Option<PendingOpenPayload> {
+        let mut startup_open = self.startup_open.lock();
+        let payload = startup_open.take();
+        self.startup_open_taken.store(true, Ordering::Release);
+        payload
+    }
+
+    pub fn push_pending_open(&self, payload: PendingOpenPayload) {
         let mut pending = self.pending_open.lock();
-        pending.clear();
+        if pending.back() == Some(&payload) {
+            return;
+        }
         pending.push_back(payload);
     }
 
@@ -247,7 +273,7 @@ mod tests {
     fn find_by_workspace_matches_pending_open() {
         let app_state = AppState::new();
         let window_state = app_state.get_or_create("pending-window");
-        window_state.set_pending_open(PendingOpenPayload {
+        window_state.push_pending_open(PendingOpenPayload {
             workspace: "/tmp/workspace".to_string(),
             file: None,
         });
@@ -256,5 +282,77 @@ mod tests {
             app_state.find_by_workspace(Path::new("/tmp/workspace")),
             Some("pending-window".to_string())
         );
+    }
+
+    #[test]
+    fn pending_open_preserves_distinct_payloads_in_order() {
+        let window_state = WorkspaceState::default();
+        let first = PendingOpenPayload {
+            workspace: "/tmp/workspace-a".to_string(),
+            file: Some("/tmp/workspace-a/a.md".to_string()),
+        };
+        let second = PendingOpenPayload {
+            workspace: "/tmp/workspace-b".to_string(),
+            file: Some("/tmp/workspace-b/b.md".to_string()),
+        };
+
+        window_state.push_pending_open(first.clone());
+        window_state.push_pending_open(second.clone());
+
+        assert_eq!(window_state.pop_pending_open(), Some(first));
+        assert_eq!(window_state.pop_pending_open(), Some(second));
+        assert_eq!(window_state.pop_pending_open(), None);
+    }
+
+    #[test]
+    fn pending_open_dedupes_repeated_tail_payload() {
+        let window_state = WorkspaceState::default();
+        let payload = PendingOpenPayload {
+            workspace: "/tmp/workspace".to_string(),
+            file: Some("/tmp/workspace/a.md".to_string()),
+        };
+
+        window_state.push_pending_open(payload.clone());
+        window_state.push_pending_open(payload.clone());
+
+        assert_eq!(window_state.pop_pending_open(), Some(payload));
+        assert_eq!(window_state.pop_pending_open(), None);
+    }
+
+    #[test]
+    fn startup_open_cannot_be_seeded_after_take() {
+        let window_state = WorkspaceState::default();
+        assert_eq!(window_state.take_startup_open(), None);
+
+        let payload = PendingOpenPayload {
+            workspace: "/tmp/workspace".to_string(),
+            file: None,
+        };
+
+        assert_eq!(
+            window_state.try_set_startup_open(payload.clone()),
+            Err(payload)
+        );
+    }
+
+    #[test]
+    fn startup_open_try_seed_preserves_existing_payload() {
+        let window_state = WorkspaceState::default();
+        let first = PendingOpenPayload {
+            workspace: "/tmp/workspace-a".to_string(),
+            file: None,
+        };
+        let second = PendingOpenPayload {
+            workspace: "/tmp/workspace-b".to_string(),
+            file: None,
+        };
+
+        window_state.set_startup_open(first.clone());
+
+        assert_eq!(
+            window_state.try_set_startup_open(second.clone()),
+            Err(second)
+        );
+        assert_eq!(window_state.take_startup_open(), Some(first));
     }
 }

--- a/apps/desktop/src-tauri/src/state.rs
+++ b/apps/desktop/src-tauri/src/state.rs
@@ -45,9 +45,14 @@ pub struct WorkspaceState {
     /// window's workspace. Two windows with different workspaces therefore
     /// carry different merged settings without clobbering each other.
     pub settings: RwLock<Option<Settings>>,
-    /// Per-window queue of deferred workspace/file opens (CLI arg at window
-    /// creation, drag-drop onto this window). Drained by the frontend via
-    /// `take_pending_open` once the store is ready.
+    /// Open target set during window creation (from CLI args or
+    /// `open_new_workspace_window`). Read once by `get_startup_state`.
+    /// Follows the same lifecycle as `settings` — set before the webview
+    /// loads, consumed during startup hydration. Runtime events never
+    /// touch this field.
+    pub startup_open: Mutex<Option<PendingOpenPayload>>,
+    /// Runtime-only queue for drag-drop / dock-drop events on a live,
+    /// already-hydrated window. Never read by `get_startup_state`.
     pub pending_open: Mutex<VecDeque<PendingOpenPayload>>,
 }
 
@@ -71,17 +76,24 @@ impl Default for WorkspaceState {
             workspace_epoch: AtomicU64::new(0),
             cancel_index: RwLock::new(Arc::new(AtomicBool::new(false))),
             settings: RwLock::new(None),
+            startup_open: Mutex::new(None),
             pending_open: Mutex::new(VecDeque::new()),
         }
     }
 }
 
 impl WorkspaceState {
-    pub fn push_pending_open(&self, payload: PendingOpenPayload) {
+    pub fn set_startup_open(&self, payload: PendingOpenPayload) {
+        *self.startup_open.lock() = Some(payload);
+    }
+
+    pub fn take_startup_open(&self) -> Option<PendingOpenPayload> {
+        self.startup_open.lock().take()
+    }
+
+    pub fn set_pending_open(&self, payload: PendingOpenPayload) {
         let mut pending = self.pending_open.lock();
-        if pending.back() == Some(&payload) {
-            return;
-        }
+        pending.clear();
         pending.push_back(payload);
     }
 
@@ -90,6 +102,14 @@ impl WorkspaceState {
     }
 
     pub fn has_pending_workspace(&self, path: &Path) -> bool {
+        let has_startup = self
+            .startup_open
+            .lock()
+            .as_ref()
+            .is_some_and(|p| Path::new(&p.workspace) == path);
+        if has_startup {
+            return true;
+        }
         self.pending_open
             .lock()
             .iter()
@@ -209,10 +229,25 @@ mod tests {
     use super::*;
 
     #[test]
+    fn find_by_workspace_matches_startup_open() {
+        let app_state = AppState::new();
+        let window_state = app_state.get_or_create("startup-window");
+        window_state.set_startup_open(PendingOpenPayload {
+            workspace: "/tmp/workspace".to_string(),
+            file: None,
+        });
+
+        assert_eq!(
+            app_state.find_by_workspace(Path::new("/tmp/workspace")),
+            Some("startup-window".to_string())
+        );
+    }
+
+    #[test]
     fn find_by_workspace_matches_pending_open() {
         let app_state = AppState::new();
         let window_state = app_state.get_or_create("pending-window");
-        window_state.push_pending_open(PendingOpenPayload {
+        window_state.set_pending_open(PendingOpenPayload {
             workspace: "/tmp/workspace".to_string(),
             file: None,
         });

--- a/apps/desktop/src/hooks/use-open-drop.ts
+++ b/apps/desktop/src/hooks/use-open-drop.ts
@@ -84,13 +84,7 @@ let startupReady: Promise<void> = Promise.resolve();
 async function resolveStartup() {
   mark("resolve-start");
 
-  let pendingOpen: PendingOpenPayload | null = null;
-
   try {
-    // Single IPC call returns settings, recents, pending opens, AND the
-    // prefetched workspace restore bundle (when applicable). React's first
-    // render can paint the full editor because everything is already in the
-    // stores by the time we flip the gate.
     mark("ipc:get_startup_state:start");
     const startup = await tauri.getStartupState();
     mark("ipc:get_startup_state:end");
@@ -103,29 +97,11 @@ async function resolveStartup() {
       recentWorkspaces: startup.recent_workspaces,
     });
 
-    pendingOpen = startup.pending_open;
-
     if (startup.restore_bundle) {
       await useWorkspaceStore.getState().restoreFromBundle(startup.restore_bundle);
     }
   } catch (error) {
     console.error("Failed to resolve startup state", error);
-    // Fall through to welcome screen — settings and workspace stores keep
-    // whatever defaults they started with.
-  }
-
-  // Handle pending opens (CLI arg, drag-to-dock) BEFORE flipping the startup
-  // gate. If the bundle above already hydrated the pending workspace,
-  // `handleOpenPayload` short-circuits the workspace open and only opens the
-  // requested file. Either way, by the time `setStartupResolved` flips, the
-  // workspace store is populated, so React's first render is the full
-  // `AppLayout` — no flash of `WelcomeScreen` while awaits resolve.
-  if (pendingOpen) {
-    try {
-      await queueOpenPayload(pendingOpen);
-    } catch (error) {
-      console.error("Failed to handle pending open on startup", error);
-    }
   }
 
   useWorkspaceStore.getState().setStartupResolved();

--- a/apps/desktop/src/lib/tauri.ts
+++ b/apps/desktop/src/lib/tauri.ts
@@ -71,6 +71,7 @@ export interface RestoreWorkspaceResponse {
   recent_workspaces: string[];
   session: SessionData | null;
   active_file: FileContent | null;
+  open_file: string | null;
 }
 
 export function restoreWorkspace(path: string): Promise<RestoreWorkspaceResponse> {
@@ -181,12 +182,6 @@ export function takePendingOpen(): Promise<PendingOpenPayload | null> {
 export interface StartupState {
   settings: Record<string, unknown>;
   recent_workspaces: string[];
-  pending_open: PendingOpenPayload | null;
-  /** Prefetched workspace restore payload. Populated when
-   *  `window.restore-workspace` is enabled, there's no pending open, and the
-   *  most-recent recent workspace still exists on disk. The frontend hydrates
-   *  its stores synchronously from this bundle before the first render, so
-   *  React mounts with full content instead of an empty shell. */
   restore_bundle: RestoreWorkspaceResponse | null;
 }
 

--- a/apps/desktop/src/stores/workspace-store.ts
+++ b/apps/desktop/src/stores/workspace-store.ts
@@ -130,6 +130,11 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       return;
     }
 
+    if (bundle.open_file) {
+      void useEditorStore.getState().openFile(bundle.open_file);
+      return;
+    }
+
     useEditorStore.getState().ensureLauncherTab();
   },
 

--- a/docs/open-flow.md
+++ b/docs/open-flow.md
@@ -4,13 +4,14 @@ How files and folders reach the editor from every entry point.
 
 There are **two distinct open mechanisms**, deliberately kept separate:
 
-- **`startup_open`** — a single `Option<PendingOpenPayload>` set in Rust during
-  window creation, *before* the webview loads. Read exactly once by
-  `get_startup_state` during startup hydration. Same lifecycle as settings: set
-  before the webview, consumed during the first render. No runtime event touches
-  it. This is the source of truth for what a freshly-created window opens.
+- **`startup_open`** — a single `Option<PendingOpenPayload>` seeded in Rust
+  before `get_startup_state` reads it. For new windows this happens during
+  window creation; for macOS cold-start `RunEvent::Opened`, it can happen while
+  the main webview exists but is still hidden and unhydrated. Read exactly once
+  during startup hydration. Same lifecycle as settings: set before first render,
+  consumed during the first render.
 - **`pending_open`** — a per-window queue for runtime drag-and-drop / dock drops
-  onto an *already-running* window. Drained by the frontend via the
+  onto an _already-running_ window. Drained by the frontend via the
   `open:from-drop` event + `take_pending_open` IPC.
 
 Both feed the single `get_startup_state` IPC (for startup) or the
@@ -36,9 +37,11 @@ dispatches on argv\[0\]: basename `writer` → CLI launcher, `Writer` → Tauri 
 
 On macOS the open target is **not** delivered through argv — `open -a Writer
 /path` (which the CLI launcher, Finder, and dock all use) delivers it via the
-`RunEvent::Opened` system event. That event can fire *before* `setup()` builds
-the main window, so the handler seeds `startup_open` on the main window's state.
-The webview then reads it during hydration — a single window, no duplicate.
+`RunEvent::Opened` system event. That event can fire before `setup()` builds the
+main window or after Tauri has built the still-hidden webview but before React
+calls `get_startup_state`. In either case the handler seeds `startup_open` as
+long as that startup slot has not been read yet. The webview then reads it
+during hydration — a single window, no duplicate.
 
 ```mermaid
 sequenceDiagram
@@ -52,8 +55,8 @@ sequenceDiagram
     OS->>Run: RunEvent::Opened { urls: [file:///path] }
     Run->>Run: resolve_path(url)
     Run->>State: find_by_workspace(path) → None
-    Note over Run: Main webview not built yet →<br/>cold start. Seed startup_open.
-    Run->>State: get_or_create("main").set_startup_open(payload)
+    Note over Run: Main startup slot unread →<br/>cold start. Seed startup_open.
+    Run->>State: get_or_create("main").try_set_startup_open(payload)
 
     Note over WV: setup() builds the window,<br/>get_or_create("main") returns the<br/>same state with startup_open set
     WV->>React: WebView loads, React mounts
@@ -93,7 +96,7 @@ sequenceDiagram
         Rust->>Rust: resolve_path(path)
         Note over Rust: Lenient: skip non-dir / non-.md
     end
-    Rust->>State: set_pending_open(payload)  (runtime queue)
+    Rust->>State: push_pending_open(payload)  (runtime queue)
     Rust->>WV: emit_to(label, "open:from-drop", payload)
 
     React->>React: listen("open:from-drop") fires
@@ -114,7 +117,8 @@ sequenceDiagram
 
 Dragging onto the dock icon (or double-clicking a `.md` in Finder via the
 `fileAssociations` registration) fires `RunEvent::Opened`. The handler routes by
-whether the main webview already exists and whether a window hosts the workspace.
+whether a window already hosts the workspace, whether the main startup slot is
+still unread, and whether the main window is already visible.
 
 ```mermaid
 sequenceDiagram
@@ -130,19 +134,28 @@ sequenceDiagram
 
     alt A window already hosts this workspace
         State-->>Run: Some(label)
-        Run->>State: set_pending_open(payload)  (runtime queue)
+        Run->>State: push_pending_open(payload)  (runtime queue)
         Run->>WV: emit_to(label, "open:from-drop")
         Note over WV: Drains queue, focuses,<br/>opens file if specified
-    else No window hosts it
+    else No window hosts it and main startup slot unread
         State-->>Run: None
-        Note over Run: Main webview exists (warm) →<br/>preserve current editor state
+        Run->>State: try_set_startup_open(payload) → Ok
+        Note over WV: Hidden main hydrates onto<br/>requested workspace
+    else No window hosts it and main hidden
+        State-->>Run: None
+        Run->>State: push_pending_open(payload)
+        Run->>WV: emit_to("main", "open:from-drop")
+        Note over WV: Startup drainer runs after<br/>hydration completes
+    else No window hosts it and main visible
+        State-->>Run: None
+        Note over Run: Warm start → preserve<br/>current editor state
         Run->>NewWV: open_new_workspace_window(workspace, file)
         Note over NewWV: New window seeded via<br/>startup_open, hydrates on load
     end
 ```
 
-The cold-start branch of this same handler (main webview not built yet) is
-covered in flow 1 — it seeds the main window instead of spawning a new one.
+The cold-start branch of this same handler is covered in flow 1 — it seeds the
+main window while `startup_open` is still readable instead of spawning a new one.
 
 ## 4. Second Launch (Single-Instance Plugin)
 
@@ -238,9 +251,9 @@ sequenceDiagram
 
 ## Key Design Decisions
 
-- **Single source of truth per concern**: `startup_open` owns the *initial* open
-  (set before the webview, read once — like settings); `pending_open` owns
-  *runtime* drops (queue + event). They never overlap, which removes the
+- **Single source of truth per concern**: `startup_open` owns the _initial_ open
+  (seeded before `get_startup_state` reads it); `pending_open` owns _runtime_
+  drops (queue + event). Their consumers do not overlap, which removes the
   cold-start double-open and the race where a runtime event clobbered startup.
 
 - **Explicit open ≠ session restore**: when `startup_open` is set, the restore
@@ -264,4 +277,3 @@ sequenceDiagram
 - **Lenient vs. strict resolution**: drag-drop and `RunEvent::Opened` use
   `resolve_path` (returns `None` for unsupported files). The CLI uses
   `validate_and_resolve` (typed error for stderr).
-```

--- a/docs/open-flow.md
+++ b/docs/open-flow.md
@@ -1,0 +1,267 @@
+# Writer Open Flows
+
+How files and folders reach the editor from every entry point.
+
+There are **two distinct open mechanisms**, deliberately kept separate:
+
+- **`startup_open`** — a single `Option<PendingOpenPayload>` set in Rust during
+  window creation, *before* the webview loads. Read exactly once by
+  `get_startup_state` during startup hydration. Same lifecycle as settings: set
+  before the webview, consumed during the first render. No runtime event touches
+  it. This is the source of truth for what a freshly-created window opens.
+- **`pending_open`** — a per-window queue for runtime drag-and-drop / dock drops
+  onto an *already-running* window. Drained by the frontend via the
+  `open:from-drop` event + `take_pending_open` IPC.
+
+Both feed the single `get_startup_state` IPC (for startup) or the
+`restoreFromBundle` path, so React's first render already has full content.
+
+## Path Resolution (shared)
+
+Every entry point funnels through `open_target::classify()`:
+
+```
+Input path
+  ├─ is_dir?    → { workspace: canonicalize(path),   file: None }
+  ├─ is_file?
+  │   └─ .md/.markdown (case-insensitive)?
+  │       → { workspace: canonicalize(parent), file: canonicalize(path) }
+  └─ otherwise  → None (lenient) / Error (strict CLI)
+```
+
+## 1. Cold Start (`writer .`, Finder open, dock drop while not running)
+
+The `writer` symlink invokes the same binary as the GUI app. `main.rs`
+dispatches on argv\[0\]: basename `writer` → CLI launcher, `Writer` → Tauri app.
+
+On macOS the open target is **not** delivered through argv — `open -a Writer
+/path` (which the CLI launcher, Finder, and dock all use) delivers it via the
+`RunEvent::Opened` system event. That event can fire *before* `setup()` builds
+the main window, so the handler seeds `startup_open` on the main window's state.
+The webview then reads it during hydration — a single window, no duplicate.
+
+```mermaid
+sequenceDiagram
+    participant OS as macOS (open -a)
+    participant Run as Tauri run loop
+    participant State as AppState (main)
+    participant WV as Main WebviewWindow
+    participant React as React (useOpenDrop)
+    participant IPC as get_startup_state
+
+    OS->>Run: RunEvent::Opened { urls: [file:///path] }
+    Run->>Run: resolve_path(url)
+    Run->>State: find_by_workspace(path) → None
+    Note over Run: Main webview not built yet →<br/>cold start. Seed startup_open.
+    Run->>State: get_or_create("main").set_startup_open(payload)
+
+    Note over WV: setup() builds the window,<br/>get_or_create("main") returns the<br/>same state with startup_open set
+    WV->>React: WebView loads, React mounts
+    React->>React: useOpenDrop → resolveStartup()
+    React->>IPC: get_startup_state()
+    IPC->>State: take_startup_open() → Some(payload)
+    IPC->>IPC: build_restore_bundle(payload.workspace)
+    Note over IPC: Strip session + active_file,<br/>set open_file = payload.file
+    IPC-->>React: { settings, recents, restore_bundle }
+    React->>React: restoreFromBundle(bundle)
+    Note over React: open_file set → open just that file,<br/>no previous-session tabs
+    React->>React: setStartupResolved() → show window
+```
+
+On Linux/Windows the path arrives through argv instead; `setup()` reads
+`std::env::args()[1]` and calls `set_startup_open` directly (gated behind
+`#[cfg(not(target_os = "macos"))]`).
+
+## 2. Runtime Drag-and-Drop onto a Window
+
+When the app is already running and the user drops a file/folder onto a window,
+the per-window `pending_open` queue + `open:from-drop` event carry it. This path
+never touches `startup_open`.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant WV as WebviewWindow
+    participant Rust as Tauri (lib.rs)
+    participant State as WorkspaceState
+    participant React as React (useOpenDrop)
+    participant Store as Zustand Stores
+
+    User->>WV: Drag folder/file onto window
+    WV->>Rust: WindowEvent::DragDrop { paths }
+    loop First valid path in drop
+        Rust->>Rust: resolve_path(path)
+        Note over Rust: Lenient: skip non-dir / non-.md
+    end
+    Rust->>State: set_pending_open(payload)  (runtime queue)
+    Rust->>WV: emit_to(label, "open:from-drop", payload)
+
+    React->>React: listen("open:from-drop") fires
+    React->>React: await startupReady, then drainPendingOpens()
+    React->>Rust: IPC: take_pending_open()
+    Rust->>State: pop_pending_open()
+    Rust-->>React: PendingOpenPayload
+
+    alt Same workspace as current window
+        React->>Store: openFile(payload.file) if present
+    else Different workspace
+        React->>Rust: IPC: open_workspace_in_new_window()
+        Note over Rust: New window seeded via startup_open
+    end
+```
+
+## 3. Dock Drop / Finder Open While Running
+
+Dragging onto the dock icon (or double-clicking a `.md` in Finder via the
+`fileAssociations` registration) fires `RunEvent::Opened`. The handler routes by
+whether the main webview already exists and whether a window hosts the workspace.
+
+```mermaid
+sequenceDiagram
+    participant OS as macOS
+    participant Run as Tauri run loop
+    participant State as AppState
+    participant WV as Existing Window
+    participant NewWV as New Window
+
+    OS->>Run: RunEvent::Opened { urls: [file:///path] }
+    Run->>Run: resolve_path(url)
+    Run->>State: find_by_workspace(canonical_path)
+
+    alt A window already hosts this workspace
+        State-->>Run: Some(label)
+        Run->>State: set_pending_open(payload)  (runtime queue)
+        Run->>WV: emit_to(label, "open:from-drop")
+        Note over WV: Drains queue, focuses,<br/>opens file if specified
+    else No window hosts it
+        State-->>Run: None
+        Note over Run: Main webview exists (warm) →<br/>preserve current editor state
+        Run->>NewWV: open_new_workspace_window(workspace, file)
+        Note over NewWV: New window seeded via<br/>startup_open, hydrates on load
+    end
+```
+
+The cold-start branch of this same handler (main webview not built yet) is
+covered in flow 1 — it seeds the main window instead of spawning a new one.
+
+## 4. Second Launch (Single-Instance Plugin)
+
+When Writer is already running and the user runs `writer .` again, the OS hands
+the second process's argv to the existing process via
+`tauri-plugin-single-instance`.
+
+```mermaid
+sequenceDiagram
+    participant Shell
+    participant OS as macOS (open -a)
+    participant Plugin as single-instance plugin
+    participant Rust as Tauri (existing process)
+    participant NewWV as New Window
+    participant WV as Existing Window
+
+    Shell->>OS: writer ~/docs → open -a Writer ~/docs
+    OS->>Plugin: 2nd process argv intercepted
+    Plugin->>Rust: handle_single_instance(argv)
+    Rust->>Rust: resolve_path(argv[1])
+
+    alt Path resolves
+        Rust->>NewWV: open_new_workspace_window(workspace, file)
+        Note over NewWV: Focuses existing window if that<br/>workspace is already open
+    else No path argument
+        Rust->>WV: set_focus() on "main" window
+    end
+```
+
+## 5. New Window (`open_new_workspace_window`)
+
+Every secondary window — whether opened from the frontend
+(`open_workspace_in_new_window`), the single-instance plugin, or a warm dock
+drop — is seeded the same way: a fresh `WorkspaceState` is created, its
+`startup_open` is set, and the window's webview reads it through the same
+`get_startup_state` path as the main window on cold start. If a window already
+hosts the requested workspace, it is focused instead of duplicated.
+
+## 6. Unified Startup (per-window)
+
+Every window — main or secondary — runs this once. The single `get_startup_state`
+IPC eliminates the waterfall of separate settings/recents/workspace fetches.
+
+```mermaid
+sequenceDiagram
+    participant WV as WebviewWindow
+    participant React as useOpenDrop
+    participant IPC as get_startup_state (Rust)
+    participant State as WorkspaceState
+    participant Store as Zustand Stores
+
+    WV->>React: React mounts → useOpenDrop()
+    React->>React: resolveStartup() (guarded, runs once)
+
+    React->>IPC: get_startup_state()
+    IPC->>State: read settings (merged layers)
+    IPC->>IPC: load_recent_workspaces()
+    IPC->>State: take_startup_open()
+
+    alt startup_open set (CLI / Finder / new-window)
+        IPC->>IPC: build_restore_bundle(startup_open.workspace)
+        Note over IPC: Strip session + active_file,<br/>set open_file = startup_open.file
+    else no startup_open, restore-workspace enabled
+        IPC->>IPC: build_restore_bundle(recents[0])
+        Note over IPC: Keep session → restore previous tabs
+    else no startup_open, restore disabled
+        Note over IPC: No bundle — welcome screen
+    end
+
+    IPC-->>React: StartupState { settings, recents, restore_bundle }
+
+    React->>Store: settings.hydrateFromBackend()
+    React->>Store: workspace.recentWorkspaces = recents
+
+    opt restore_bundle present
+        React->>Store: workspace.restoreFromBundle(bundle)
+        alt bundle.session has tabs
+            Store->>Store: restoreSession(tabs, active_file)
+        else bundle.open_file set
+            Store->>Store: openFile(open_file)
+        else neither
+            Store->>Store: ensureLauncherTab()
+        end
+    end
+
+    React->>Store: setStartupResolved()
+    Note over Store: Gate flips → AppLayout renders
+    React->>WV: show_main_window()
+
+    React->>React: listen("open:from-drop")
+    Note over React: Runtime drops drain via pending_open
+```
+
+## Key Design Decisions
+
+- **Single source of truth per concern**: `startup_open` owns the *initial* open
+  (set before the webview, read once — like settings); `pending_open` owns
+  *runtime* drops (queue + event). They never overlap, which removes the
+  cold-start double-open and the race where a runtime event clobbered startup.
+
+- **Explicit open ≠ session restore**: when `startup_open` is set, the restore
+  bundle's session and active file are stripped and `open_file` carries the
+  request. So `writer file.md` opens just that file, not the previous session's
+  tabs. With no `startup_open`, the bundle keeps the session and restores tabs.
+
+- **One IPC, one render**: `get_startup_state` bundles settings + recents + the
+  prefetched restore bundle. React hydrates everything before flipping the
+  startup gate, so the first visible frame is the full editor — no welcome
+  screen flash, no second IPC waterfall.
+
+- **Canonical paths everywhere**: paths are canonicalized on the Rust side
+  (`/var` → `/private/var` on macOS) so watcher events, sidebar entries, and
+  window lookups (`find_by_workspace`) all key off the same string.
+
+- **Per-window isolation**: each window has its own `WorkspaceState` (workspace
+  root, file index, watcher, settings layer, `startup_open`, `pending_open`).
+  Concurrent session saves serialize through a process-wide lock.
+
+- **Lenient vs. strict resolution**: drag-drop and `RunEvent::Opened` use
+  `resolve_path` (returns `None` for unsupported files). The CLI uses
+  `validate_and_resolve` (typed error for stderr).
+```


### PR DESCRIPTION
## Problem

Opening a folder or file from the CLI (`writer .`), Finder, or by dropping onto the dock had two bugs:

1. **Duplicate window on cold start.** On macOS the open target is delivered via the `RunEvent::Opened` system event (not argv), which can fire *before* `setup()` builds the main window. The handler didn't recognize this as a cold start, so it spawned a *second* window beside the empty main one.
2. **Previous session bleeding into explicit opens.** `get_startup_state` returned `pending_open` and `restore_bundle` as two separate fields the frontend had to coordinate. The bundle restored the workspace's saved session (old tabs) *before* the requested file was handled, so `writer file.md` showed all your old tabs plus the new file.

## Fix

Split the open target into two distinct concepts with clear ownership:

- **`startup_open`** — an `Option` set in Rust during window creation, *before* the webview loads, and read exactly once by `get_startup_state`. Same lifecycle as settings: set before the webview, consumed during the first render. The single source of truth for what a new window opens.
- **`pending_open`** — the per-window queue, now used *only* for runtime drag-drop / dock drops onto an already-running window.

The `RunEvent::Opened` handler distinguishes cold from warm start by whether the main **webview window** exists yet:

- Webview not built → cold start → seed the main window's `startup_open` (single window, no duplicate).
- Webview exists → warm start → `open_new_workspace_window` (or focus the existing window if that workspace is already open).

When `startup_open` is set, the restore bundle's `session`/`active_file` are stripped and a new `open_file` field carries the request, so the frontend opens just that file — no previous-session tabs.

## Testing

- `cargo test` — 104 passed
- `cargo clippy` — clean (only pre-existing warnings)
- `vp check` — clean
- Manual (debug bundle via `open -a`):
  - Cold start with folder → **1 window**
  - Cold start with file → **1 window**, only that file opens
  - Cold start no arg → restores last session
  - Warm open of a different folder → opens in a **new window**
  - Warm re-open of an already-open folder → **focuses**, no duplicate

`docs/open-flow.md` updated to document the new architecture with sequence diagrams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)