### PR TITLE
Stabilize table widget scroll heights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-06-01
+
+- Stabilize scrolling through documents with folded Markdown tables. Table preview widgets now provide CodeMirror with a deterministic height estimate before they enter the measured viewport, so the editor no longer suddenly changes document height, scrollbar thumb size, or scroll position as tables virtualize in.
+
 ## 2026-05-28
 
 - Animate the sidebar folder caret so it rotates smoothly between collapsed (pointing right) and expanded (pointing down) instead of swapping icons instantly. The caret rotation is now the only animated transition on sidebar rows — the hover background highlight and the icon/label opacity changes apply instantly.

--- a/SPECs/Agent/worksheet-table-virtualization-scroll-stability.md
+++ b/SPECs/Agent/worksheet-table-virtualization-scroll-stability.md
@@ -1,0 +1,51 @@
+# Worksheet: Table Virtualization Scroll Stability
+
+## Task
+
+- User request: "there's an issue when scrolling documents with tables: as i scroll the size of the doc and scroll position/size changes suddenly. Look into the codemirror/prosemark editor"
+- Spec: `SPECs/table-virtualization-scroll-stability-spec.md`
+- TODO: `Table virtualization scroll stability`
+
+## Reviewed
+
+- `TODOS.md`
+- `docs/editor.md`
+- `docs/react-guidelines.md`
+- `docs/consolidation.md`
+- `docs/workflows/agent-loop.md`
+- `apps/desktop/src/components/editor-area/table-decorations.ts`
+- `apps/desktop/tests/table-decorations.test.ts`
+- `apps/desktop/src/components/editor-area/use-prosemark-editor.ts`
+- `apps/desktop/src/components/editor-area/editor-scroll-container.tsx`
+- `apps/desktop/src/lib/prosemark-core/fold/core.ts`
+- `@codemirror/view` 6.40.0 `WidgetType` type definitions
+
+## Findings
+
+- Folded tables are `Decoration.replace({ block: true })` widgets spanning the parsed Markdown table.
+- CodeMirror uses `WidgetType.estimatedHeight` for unmeasured block widgets in the heightmap. The default is `-1`, which falls back to one editor line height.
+- A rendered table is usually much taller than one line. When scrolling brings the widget into the measured viewport, CodeMirror replaces the low estimate with the real height, changing the document height and outer scrollbar position.
+- The actual scroll container is Writer's outer `EditorScrollContainer`; the table height estimate still belongs on the CodeMirror widget because that owns the heightmap.
+
+## Plan
+
+- Add a deterministic table height estimator in `table-decorations.ts`.
+- Pass the estimate into `TableWidget` and expose it through `estimatedHeight`.
+- Derive the estimate from parsed row count and the editor font-size default plus the table preview's own line-height/padding constants.
+- Add focused tests for positive estimates and row-count scaling.
+- Update changelog and move the TODO entry to Done after validation.
+
+## Results
+
+- Added a deterministic height estimator for folded table preview widgets in `table-decorations.ts`.
+- `TableWidget` now exposes `estimatedHeight`, letting CodeMirror reserve a close height for unmeasured table widgets instead of falling back to one editor line.
+- Reused the same table sizing constants for the estimate and the `EditorView.baseTheme` table CSS to avoid drift.
+- Added focused tests for widget height estimates and row-count scaling.
+- Validation:
+  - `vp install` passed.
+  - `vp test apps/desktop/tests/table-decorations.test.ts` passed: 9 tests.
+  - `vp check` passed with two existing E2E JS warnings.
+  - `vp test` passed: 27 files, 438 tests.
+  - `cargo fmt --check` passed.
+  - `cargo test` passed: 103 Rust tests.
+  - `cargo clippy` passed with existing Rust warnings.

--- a/SPECs/table-virtualization-scroll-stability-spec.md
+++ b/SPECs/table-virtualization-scroll-stability-spec.md
@@ -1,0 +1,31 @@
+# Table Virtualization Scroll Stability Spec
+
+## Summary
+
+Folded markdown tables should not cause sudden document height or scrollbar jumps when scrolling. CodeMirror should have a close table-widget height estimate before the widget is measured in the viewport.
+
+## Goals
+
+- Keep the outer editor scroll height stable while documents with folded table previews are virtualized.
+- Preserve the current folded table preview and touched-table source-editing behavior.
+- Keep the estimate deterministic and derived from the same parsed table data used to render the preview.
+- Cover the estimate with focused tests so future table style changes account for scroll stability.
+
+## Non-Goals
+
+- Rich table editing.
+- Horizontal table virtualization.
+- Pixel-perfect prediction for every possible wrapped cell value.
+
+## Implementation Notes
+
+- `apps/desktop/src/components/editor-area/table-decorations.ts` owns folded table widget rendering.
+- CodeMirror `WidgetType.estimatedHeight` is the intended API for reserving space for unmeasured block widgets in the heightmap.
+- The estimate should account for the table header, body rows, borders, and widget padding using the editor font-size default plus the table preview's own line-height/padding constants.
+
+## Acceptance Criteria
+
+- Folded table widgets provide a positive estimated height before DOM measurement.
+- The estimate grows with table row count.
+- Existing folded/unfolded table behavior remains unchanged.
+- Focused table decoration tests pass.

--- a/TODOS.md
+++ b/TODOS.md
@@ -6,6 +6,7 @@
 
 ## Done
 
+- Table virtualization scroll stability: [`SPECs/table-virtualization-scroll-stability-spec.md`](SPECs/table-virtualization-scroll-stability-spec.md) — give folded markdown table widgets stable CodeMirror height estimates so scrolling through virtualized documents with tables does not suddenly resize the document or scrollbar.
 - Sidebar file label setting — add an `appearance.sidebar-file-label` enum (`title` | `filename`, default `title`) and have the sidebar file tree render the filename stem or the title-fallback chain accordingly. Also expose a "Rename..." action in the file context menu (files reuse the inline-rename flow folders already had).
 - Desktop dev script — make the root `dev` script delegate to the desktop package's Tauri dev workflow and keep desktop build/preview scripts on Vite+ commands.
 - Dependency lock refresh: [`SPECs/Agent/worksheet-dependency-lock-refresh.md`](SPECs/Agent/worksheet-dependency-lock-refresh.md) — refresh compatible Rust and JavaScript dependency lockfiles, including the `vite-plus` toolchain update, root TypeScript config alignment, and package-audit fixes.

--- a/apps/desktop/src/components/editor-area/table-decorations.ts
+++ b/apps/desktop/src/components/editor-area/table-decorations.ts
@@ -14,11 +14,24 @@ import {
   prosemarkMarkdownSyntaxExtensions,
   selectAllDecorationsOnSelectExtension,
 } from "@/lib/prosemark-core/main";
+import { SETTINGS_SCHEMA } from "@/lib/settings-schema";
 import { parseWikiLink } from "@/lib/wiki-links";
 
 const fallbackMonospaceCodeFont =
   "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace";
 const codeFontFamily = `var(--pm-code-font, ${fallbackMonospaceCodeFont})`;
+
+const tableCellLineHeight = 1.4;
+const tableCellVerticalPaddingEm = 1;
+const tableWidgetVerticalPaddingEm = 0.5;
+const tableBorderWidthPx = 1;
+
+function numericSettingDefault(key: string, fallback: number): number {
+  const def = SETTINGS_SCHEMA.find((entry) => entry.key === key);
+  return typeof def?.default === "number" ? def.default : fallback;
+}
+
+const defaultEditorFontSizePx = numericSettingDefault("editor.font-size", 16);
 
 type Alignment = "left" | "center" | "right";
 
@@ -146,6 +159,15 @@ function parseMarkdownTable(text: string): ParsedTable | undefined {
   const rows = lines.slice(2).map(parseCells);
 
   return { headers, alignments, rows };
+}
+
+function estimateTableWidgetHeight(table: ParsedTable): number {
+  const visualRows = 1 + table.rows.length;
+  const rowHeight = defaultEditorFontSizePx * (tableCellLineHeight + tableCellVerticalPaddingEm);
+  const wrapperPadding = defaultEditorFontSizePx * tableWidgetVerticalPaddingEm;
+  const horizontalBorders = Math.max(0, visualRows + 1) * tableBorderWidthPx;
+
+  return Math.ceil(wrapperPadding + visualRows * rowHeight + horizontalBorders);
 }
 
 function tableSourceLineClass(isFirst: boolean, isLast: boolean): string {
@@ -372,6 +394,7 @@ class TableWidget extends WidgetType {
   constructor(
     readonly table: ParsedTable,
     readonly rawText: string,
+    private readonly heightEstimate: number,
   ) {
     super();
   }
@@ -382,6 +405,10 @@ class TableWidget extends WidgetType {
 
   ignoreEvent(): boolean {
     return false;
+  }
+
+  get estimatedHeight(): number {
+    return this.heightEstimate;
   }
 
   toDOM(): HTMLElement {
@@ -455,7 +482,7 @@ const tableFoldExtension = foldableSyntaxFacet.of({
     }
 
     return Decoration.replace({
-      widget: new TableWidget(parsed, text),
+      widget: new TableWidget(parsed, text, estimateTableWidgetHeight(parsed)),
       block: true,
       inclusiveStart: true,
     }).range(node.from, node.to);
@@ -464,7 +491,7 @@ const tableFoldExtension = foldableSyntaxFacet.of({
 
 const tableTheme = EditorView.baseTheme({
   ".cm-table-widget": {
-    padding: "0.25em 0",
+    padding: `${tableWidgetVerticalPaddingEm / 2}em 0`,
   },
   ".cm-table-inner": {
     display: "inline-block",
@@ -472,7 +499,7 @@ const tableTheme = EditorView.baseTheme({
   ".cm-table-widget table": {
     borderCollapse: "separate",
     borderSpacing: "0",
-    border: "1px solid var(--border-color, #3e3e42)",
+    border: `${tableBorderWidthPx}px solid var(--border-color, #3e3e42)`,
     borderRadius: "8px",
     overflow: "hidden",
     fontFamily: "inherit",
@@ -480,12 +507,12 @@ const tableTheme = EditorView.baseTheme({
     width: "auto",
   },
   ".cm-table-widget th, .cm-table-widget td": {
-    padding: "0.5em 0.8em",
+    padding: `${tableCellVerticalPaddingEm / 2}em 0.8em`,
     minWidth: "6em",
     fontSize: "inherit",
-    lineHeight: "1.4",
-    borderBottom: "1px solid var(--border-color, #3e3e42)",
-    borderRight: "1px solid var(--border-color, #3e3e42)",
+    lineHeight: `${tableCellLineHeight}`,
+    borderBottom: `${tableBorderWidthPx}px solid var(--border-color, #3e3e42)`,
+    borderRight: `${tableBorderWidthPx}px solid var(--border-color, #3e3e42)`,
   },
   ".cm-table-widget th:last-child, .cm-table-widget td:last-child": {
     borderRight: "none",

--- a/apps/desktop/tests/table-decorations.test.ts
+++ b/apps/desktop/tests/table-decorations.test.ts
@@ -21,31 +21,46 @@ type FoldDecoration = {
   to: number;
   className: string;
   hasWidget: boolean;
+  estimatedHeight?: number;
 };
 
-function makeState(anchor: number, head = anchor): EditorState {
+function makeState(anchor: number, head = anchor, content = doc): EditorState {
   let state = EditorState.create({
-    doc,
+    doc: content,
     extensions: [markdown({ extensions: [GFM] }), tableDecorations()],
     selection: EditorSelection.single(anchor, head),
   });
-  ensureSyntaxTree(state, doc.length, 1000);
+  ensureSyntaxTree(state, content.length, 1000);
   state = state.update({ selection: state.selection }).state;
   return state;
 }
 
 function collectFoldDecorations(state: EditorState): FoldDecoration[] {
   const decorations: FoldDecoration[] = [];
-  state.field(foldExtension).between(0, doc.length, (from, to, decoration) => {
+  state.field(foldExtension).between(0, state.doc.length, (from, to, decoration) => {
     const spec = decoration.spec as { class?: string; widget?: unknown };
+    const widget = spec.widget as { estimatedHeight?: unknown } | undefined;
+    const estimatedHeight =
+      typeof widget?.estimatedHeight === "number" ? widget.estimatedHeight : undefined;
     decorations.push({
       from,
       to,
       className: spec.class ?? "",
       hasWidget: spec.widget !== undefined,
+      estimatedHeight,
     });
   });
   return decorations;
+}
+
+function foldedTableEstimate(markdownTable: string): number {
+  const content = `${before}${markdownTable}${after}`;
+  const decorations = collectFoldDecorations(makeState(0, 0, content));
+  const widget = decorations.find((decoration) => decoration.hasWidget);
+  if (!widget?.estimatedHeight) {
+    throw new Error("Expected folded table widget with an estimated height");
+  }
+  return widget.estimatedHeight;
 }
 
 describe("tableDecorations", () => {
@@ -120,9 +135,31 @@ describe("tableDecorations", () => {
     const decorations = collectFoldDecorations(makeState(0));
 
     expect(decorations).toContainEqual(
-      expect.objectContaining({ from: tableFrom, to: tableTo, hasWidget: true }),
+      expect.objectContaining({
+        from: tableFrom,
+        to: tableTo,
+        hasWidget: true,
+        estimatedHeight: expect.any(Number),
+      }),
     );
     expect(decorations.some((d) => d.className.includes("cm-table-source-line"))).toBe(false);
+  });
+
+  test("estimates folded table widget height for the virtualized heightmap", () => {
+    const estimate = foldedTableEstimate(table);
+
+    expect(estimate).toBeGreaterThan(70);
+  });
+
+  test("increases the folded table height estimate with body rows", () => {
+    const shortTable = ["| Name | Count |", "| --- | ---: |", "| Tea | 2 |"].join("\n");
+    const longTable = [
+      "| Name | Count |",
+      "| --- | ---: |",
+      ...Array.from({ length: 12 }, (_, index) => `| Row ${index + 1} | ${index + 1} |`),
+    ].join("\n");
+
+    expect(foldedTableEstimate(longTable)).toBeGreaterThan(foldedTableEstimate(shortTable));
   });
 
   test("unfolds a touched table as codeblock-styled source lines", () => {


### PR DESCRIPTION
Summary:
- Add deterministic estimated heights for folded Markdown table widgets so CodeMirror reserves space before DOM measurement.
- Reuse table sizing constants between the estimate and table preview theme styles.
- Add table decoration tests covering positive estimates and row-count scaling.

Validation:
- vp test apps/desktop/tests/table-decorations.test.ts
- vp check (passes with existing E2E JS warnings)
- vp test
- cargo fmt --check
- cargo test
- cargo clippy (passes with existing Rust warnings)