### PR TITLE
Fix mermaid error message rendering vertically

### DIFF
--- a/apps/desktop/src/components/editor-area/mermaid-canvas.css
+++ b/apps/desktop/src/components/editor-area/mermaid-canvas.css
@@ -254,11 +254,13 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 0.5em 1em;
+  padding: 1.5em 2em;
   color: var(--text-error, #ff6b6b);
   font-family: "SF Mono", Menlo, Monaco, Consolas, monospace;
   font-size: 0.85em;
   text-align: center;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
 }
 
 /* Fullscreen overlay: fixed-position div that fills the viewport and hosts

--- a/apps/desktop/src/components/editor-area/mermaid-canvas.ts
+++ b/apps/desktop/src/components/editor-area/mermaid-canvas.ts
@@ -388,6 +388,8 @@ export function mountMermaidCanvas(
     stage.innerHTML = "";
     stage.style.transform = "none";
     stage.style.opacity = "1";
+    stage.style.width = "100%";
+    stage.style.height = "100%";
     state.zoom = 1;
     state.panX = 0;
     state.panY = 0;
@@ -424,6 +426,8 @@ export function mountMermaidCanvas(
     }
 
     // Re-render: replace stage's SVG, reset measurement cache, refit.
+    stage.style.width = "";
+    stage.style.height = "";
     stage.innerHTML = svgHtml;
     svg = stage.querySelector("svg") as SVGSVGElement | null;
     decorateSvg(svg, opts.ariaLabel);


### PR DESCRIPTION
## Summary
- Fix mermaid diagram error messages rendering one character per line by expanding the stage element to fill the viewport during error display
- The stage element (`position: absolute; top: 0; left: 0`) has no explicit dimensions — it sizes from its SVG child, collapsing to zero width when the SVG is cleared for an error
- Added `white-space: pre-wrap` and `overflow-wrap: break-word` so long error messages wrap correctly

## Test plan
- [ ] Open a markdown file with an unsupported mermaid diagram type (e.g. `xychart-beta` or an invalid type)
- [ ] Verify the error message renders horizontally and is readable
- [ ] Fix the mermaid source to a valid diagram and verify it renders correctly (stage dimensions reset)
- [ ] Test in fullscreen mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)