### PR TITLE
Compact sidebar recents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2026-06-03
 
 - Redesign the sidebar into collapsible `Pinned`, `Recents`, and `Everything` sections. The existing file tree now lives under Everything; files can be pinned/unpinned into Pinned; Recents is metadata-sorted from the workspace index with cached pagination so Show More does not rescan the workspace.
+- Keep the sidebar compact in small workspaces by hiding `Recents` below 10 indexed files, and show recent files in 4-item pages when it is visible.
 - Stop auto-expanding and scrolling the `Everything` tree when a file is opened from Pinned, Recents, search, links, or other open paths. The explicit tab context menu `Reveal in sidebar` action still expands ancestors and scrolls the tree on demand.
 - Add a large subtle shadow to the shared floating card surface used by the command palette and related popovers.
 

--- a/SPECs/sidebar-sections-spec.md
+++ b/SPECs/sidebar-sections-spec.md
@@ -11,6 +11,8 @@ Redesign the sidebar into three ordered sections: `Pinned`, `Recents`, and `Ever
 - Add a `Recents` section above Everything, sorted by file metadata recency.
 - Add `Show More` controls for Pinned and Recents.
 - Let each section collapse/expand from a caret in the section label row.
+- Hide `Recents` for small workspaces with fewer than 10 indexed files.
+- Show 4 recent files per page so Recents stays compact above the full tree.
 - Preserve existing file row behaviors: open, active highlight, title-vs-filename setting, and context menu actions.
 - Keep recent-file reads cheap by paging from an index-backed in-memory cache.
 
@@ -44,7 +46,9 @@ Redesign the sidebar into three ordered sections: `Pinned`, `Recents`, and `Ever
 - Section order: `Pinned`, `Recents`, `Everything`.
 - Each 12px section label uses normal letter spacing and has a caret immediately to the right of the label text. Clicking the label row toggles the section body.
 - Initial visible count: small enough to keep the tree prominent; `Show More` reveals/fetches the next page.
+- Recents starts at 4 visible files and reveals 4 more per `Show More`; Pinned starts at 6 and reveals 6 more per page.
 - Empty `Pinned` / `Recents` sections are hidden until they have entries.
+- `Recents` is hidden while the workspace has fewer than 10 indexed files, even if recent metadata exists.
 - Flat section rows use the same document label setting as the tree.
 - Pinned rows expose an unpin affordance and file context menu.
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -7,7 +7,7 @@
 ## Done
 
 - Floating card shadow polish — add a large subtle shadow to the shared command-palette/popover card surface.
-- Sidebar sections redesign: [`SPECs/sidebar-sections-spec.md`](SPECs/sidebar-sections-spec.md) — split the sidebar into collapsible Pinned, Recents, and Everything sections; keep the existing file tree under Everything; add per-workspace pinned files and metadata-backed recent files with Show More pagination.
+- Sidebar sections redesign: [`SPECs/sidebar-sections-spec.md`](SPECs/sidebar-sections-spec.md) — split the sidebar into collapsible Pinned, Recents, and Everything sections; keep the existing file tree under Everything; add per-workspace pinned files and compact metadata-backed recent files with Show More pagination.
 - Table virtualization scroll stability: [`SPECs/table-virtualization-scroll-stability-spec.md`](SPECs/table-virtualization-scroll-stability-spec.md) — give folded markdown table widgets stable CodeMirror height estimates so scrolling through virtualized documents with tables does not suddenly resize the document or scrollbar.
 - Sidebar file label setting — add an `appearance.sidebar-file-label` enum (`title` | `filename`, default `title`) and have the sidebar file tree render the filename stem or the title-fallback chain accordingly. Also expose a "Rename..." action in the file context menu (files reuse the inline-rename flow folders already had).
 - Desktop dev script — make the root `dev` script delegate to the desktop package's Tauri dev workflow and keep desktop build/preview scripts on Vite+ commands.

--- a/apps/desktop/src/components/sidebar/file-browser.tsx
+++ b/apps/desktop/src/components/sidebar/file-browser.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/hooks/editor-api";
 import {
   SIDEBAR_SECTION_PAGE_SIZE,
+  RECENTS_SECTION_PAGE_SIZE,
   usePinnedSidebarFiles,
   useRecentSidebarFiles,
 } from "@/hooks/use-sidebar-files";
@@ -50,7 +51,7 @@ export function FileBrowser() {
   const togglePinnedFile = useTogglePinnedFile();
   const removePinnedFile = useRemovePinnedFile();
   const rewritePinnedPath = useRewritePinnedPath();
-  const [recentVisibleCount, setRecentVisibleCount] = useState(SIDEBAR_SECTION_PAGE_SIZE);
+  const [recentVisibleCount, setRecentVisibleCount] = useState(RECENTS_SECTION_PAGE_SIZE);
   const [pinnedVisibleCount, setPinnedVisibleCount] = useState(SIDEBAR_SECTION_PAGE_SIZE);
   const recentFiles = useRecentSidebarFiles(recentVisibleCount);
   const pinnedEntries = usePinnedSidebarFiles(pinnedVisibleCount);
@@ -254,7 +255,7 @@ export function FileBrowser() {
                 {recentFiles.hasMore && (
                   <ShowMoreButton
                     onClick={() =>
-                      setRecentVisibleCount((count) => count + SIDEBAR_SECTION_PAGE_SIZE)
+                      setRecentVisibleCount((count) => count + RECENTS_SECTION_PAGE_SIZE)
                     }
                   />
                 )}

--- a/apps/desktop/src/hooks/use-file-tree.ts
+++ b/apps/desktop/src/hooks/use-file-tree.ts
@@ -28,6 +28,10 @@ export function usePinnedFiles() {
   return useWorkspaceStore((s) => s.pinnedFiles);
 }
 
+export function useWorkspaceFileCount() {
+  return useWorkspaceStore((s) => s.fileCount);
+}
+
 export function useTogglePinnedFile() {
   return useWorkspaceStore((s) => s.togglePinnedFile);
 }

--- a/apps/desktop/src/hooks/use-file-watcher.ts
+++ b/apps/desktop/src/hooks/use-file-watcher.ts
@@ -35,9 +35,10 @@ export function useFileWatcher() {
       });
     });
 
-    const unlistenIndexComplete = listen<number>("index:complete", () => {
+    const unlistenIndexComplete = listen<number>("index:complete", (event) => {
       if (useWorkspaceStore.getState().root) {
         useWorkspaceStore.setState((state) => ({
+          fileCount: event.payload,
           isIndexing: false,
           sidebarMetadataVersion: state.sidebarMetadataVersion + 1,
         }));

--- a/apps/desktop/src/hooks/use-sidebar-files.ts
+++ b/apps/desktop/src/hooks/use-sidebar-files.ts
@@ -1,10 +1,16 @@
 import { useEffect, useState } from "react";
-import { usePinnedFiles, useSidebarMetadataVersion } from "@/hooks/use-file-tree";
+import {
+  usePinnedFiles,
+  useSidebarMetadataVersion,
+  useWorkspaceFileCount,
+} from "@/hooks/use-file-tree";
 import { useWorkspaceRoot } from "@/hooks/use-workspace";
 import * as tauri from "@/lib/tauri";
 import type { DirEntry } from "@/types/fs";
 
 export const SIDEBAR_SECTION_PAGE_SIZE = 6;
+export const RECENTS_SECTION_PAGE_SIZE = 4;
+export const RECENTS_MIN_WORKSPACE_FILE_COUNT = 10;
 
 const RECENTS_READ_PAGE_SIZE = 100;
 
@@ -18,12 +24,13 @@ const EMPTY_STATE: SidebarFilesState = { files: [], hasMore: false, isLoading: f
 
 export function useRecentSidebarFiles(visibleCount: number): SidebarFilesState {
   const root = useWorkspaceRoot();
+  const fileCount = useWorkspaceFileCount();
   const pinnedFiles = usePinnedFiles();
   const metadataVersion = useSidebarMetadataVersion();
   const [state, setState] = useState<SidebarFilesState>(EMPTY_STATE);
 
   useEffect(() => {
-    if (!root) {
+    if (!root || fileCount < RECENTS_MIN_WORKSPACE_FILE_COUNT) {
       setState(EMPTY_STATE);
       return;
     }
@@ -64,7 +71,7 @@ export function useRecentSidebarFiles(visibleCount: number): SidebarFilesState {
     return () => {
       cancelled = true;
     };
-  }, [metadataVersion, pinnedFiles, root, visibleCount]);
+  }, [fileCount, metadataVersion, pinnedFiles, root, visibleCount]);
 
   return state;
 }

--- a/apps/desktop/src/stores/workspace-store.ts
+++ b/apps/desktop/src/stores/workspace-store.ts
@@ -8,6 +8,7 @@ import { getEditorSessionSnapshot, useEditorStore } from "@/stores/editor-store"
 
 interface WorkspaceState {
   root: string | null;
+  fileCount: number;
   isIndexing: boolean;
   isStartupResolved: boolean;
   directoryCache: Map<string, DirEntry[]>;
@@ -73,6 +74,7 @@ function dedupe(paths: string[]) {
 
 export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
   root: null,
+  fileCount: 0,
   isIndexing: false,
   isStartupResolved: false,
   directoryCache: new Map(),
@@ -112,6 +114,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     const recents = await tauri.getRecentWorkspaces();
     set({
       root: info.root,
+      fileCount: info.file_count,
       isIndexing: true,
       directoryCache: new Map([[info.root, entries]]),
       expandedDirs: new Set(),
@@ -143,6 +146,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     });
     set({
       root: null,
+      fileCount: 0,
       directoryCache: new Map(),
       expandedDirs: new Set(),
       pinnedFiles: [],
@@ -162,6 +166,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
 
     set({
       root: bundle.workspace.root,
+      fileCount: bundle.workspace.file_count,
       isIndexing: true,
       directoryCache: new Map([[bundle.workspace.root, bundle.entries]]),
       expandedDirs: new Set(),

--- a/apps/desktop/tests/stores.test.ts
+++ b/apps/desktop/tests/stores.test.ts
@@ -60,6 +60,7 @@ describe("workspace-store", () => {
       pinnedFiles: [],
       sidebarMetadataVersion: 0,
       recentWorkspaces: [],
+      fileCount: 0,
     });
   });
 
@@ -75,6 +76,7 @@ describe("workspace-store", () => {
     await useWorkspaceStore.getState().openWorkspace("/test");
 
     expect(useWorkspaceStore.getState().root).toBe("/test");
+    expect(useWorkspaceStore.getState().fileCount).toBe(2);
     expect(useWorkspaceStore.getState().directoryCache.has("/test")).toBe(true);
     expect(useWorkspaceStore.getState().recentWorkspaces).toEqual(["/test"]);
     expect(useEditorStore.getState().tabs).toEqual([


### PR DESCRIPTION
## Summary
- Hide the Recents sidebar section when a workspace has fewer than 10 indexed files.
- Store the workspace file count from open/restore/index-complete state so the Recents gate does not scan from React.
- Show Recents in 4-item pages while keeping Pinned at 6-item pages.

## Validation
- vp check passed with existing e2e warnings.
- vp test passed: 27 files, 444 tests.