### PR TITLE
Scatter new windows to random on-screen positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-06-16
+
+- Open each new window at a random on-screen position instead of stacking them in the same spot, so it is obvious when more than one window is open. The position is chosen within the active display's work area (the screen minus menu bar/dock) and clamped so the whole window stays visible; it prefers the display under the cursor. This applies to secondary windows — compact single-file windows, new workspace windows, drag-drop opens, and second launches — while the first window keeps its default placement.
+
 ## 2026-06-09
 
 - Make compact mode fully global instead of workspace-scoped. Opening a markdown file directly (CLI, Finder, drag-drop) now opens a standalone compact window with no workspace at all — no file/folder indexing, no recursive watcher, no gitignore loading — so single-file windows open fast. The open file is still watched for external changes via a lightweight non-recursive watch on its parent directory that survives atomic-rename saves.

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -22,7 +22,7 @@ use tauri::menu::MenuItem;
 use tauri::menu::{MenuBuilder, MenuItemBuilder, PredefinedMenuItem, SubmenuBuilder};
 #[cfg(target_os = "macos")]
 use tauri::RunEvent;
-use tauri::{DragDropEvent, Emitter, Manager, WebviewWindow, WindowEvent};
+use tauri::{DragDropEvent, Emitter, Manager, PhysicalPosition, WebviewWindow, WindowEvent};
 
 #[cfg(target_os = "macos")]
 const CLI_MENU_INSTALL_LABEL: &str = "Install 'writer' Command Line Tool…";
@@ -202,8 +202,52 @@ fn build_secondary_window(app: &tauri::AppHandle, label: String) -> Result<(), A
     };
 
     attach_window_handlers(app, &window);
+    position_new_window(app, &window);
 
     Ok(())
+}
+
+/// Place a freshly built secondary window at a random on-screen position so
+/// multiple open windows don't stack on top of each other — scattering them
+/// makes it obvious that more than one window is open. Each window gets a
+/// random `(x, y)` inside the target monitor's work area (the screen minus the
+/// menu bar / dock), clamped so the whole window stays visible. Runs while the
+/// window is still `visible: false`, so there's no visible jump when it's shown.
+///
+/// Fail-soft: any missing monitor info or platform error leaves the window at
+/// its OS-default position — a positioning hiccup must never stop a window from
+/// opening.
+fn position_new_window(app: &tauri::AppHandle, window: &WebviewWindow) {
+    // Prefer the monitor under the cursor (where the user is working), then the
+    // window's own monitor, then the primary monitor.
+    let monitor = app
+        .cursor_position()
+        .ok()
+        .and_then(|p| app.monitor_from_point(p.x, p.y).ok().flatten())
+        .or_else(|| window.current_monitor().ok().flatten())
+        .or_else(|| window.primary_monitor().ok().flatten());
+    let Some(monitor) = monitor else { return };
+    let Ok(win_size) = window.outer_size() else {
+        return;
+    };
+
+    let area = monitor.work_area();
+    // Span of valid top-left positions that keep the whole window inside the
+    // work area. `saturating_sub` guards a window larger than the work area
+    // (span collapses to 0 → pinned to the work-area origin).
+    let span_x = area.size.width.saturating_sub(win_size.width) as f64;
+    let span_y = area.size.height.saturating_sub(win_size.height) as f64;
+
+    // Two random fractions in [0, 1] from a fresh v4 UUID's bytes — `uuid` is
+    // already a dependency, so no extra crate just for randomness.
+    let bytes = uuid::Uuid::new_v4().into_bytes();
+    let frac_x = bytes[0] as f64 / u8::MAX as f64;
+    let frac_y = bytes[1] as f64 / u8::MAX as f64;
+
+    let x = area.position.x + (span_x * frac_x).round() as i32;
+    let y = area.position.y + (span_y * frac_y).round() as i32;
+
+    let _ = window.set_position(PhysicalPosition::new(x, y));
 }
 
 /// Build the native menu bar and wire updater menu events. macOS only needs a


### PR DESCRIPTION
## Why

When you open a second (or third…) window — "Open File in Compact Window", "Open Workspace in New Window", a drag-drop open, or a second app launch — every new window appeared at nearly the same spot and stacked on top of the previous one. It wasn't obvious that more than one window was open.

## What

Each newly built **secondary** window is now placed at a random point inside the target display's **work area** (the screen minus the menu bar/dock), clamped so the whole window stays on-screen. The result is a visible scatter that makes multiple open windows immediately obvious.

Details:
- **Monitor selection** prefers the display under the cursor (where you're working), falling back to the window's own monitor, then the primary monitor.
- **Runs while the window is still `visible: false`**, so there's no visible jump when the frontend reveals it.
- **Fail-soft**: any missing monitor info or platform error leaves the window at its OS-default position — a positioning hiccup can never block a window from opening.
- **Randomness** is derived from a fresh v4 UUID (reusing the existing `uuid` dependency) — no new crate.
- Only secondary windows are affected; the first/main window keeps its default placement.

Implementation is a single new helper, `position_new_window()`, called from `build_secondary_window()` in `apps/desktop/src-tauri/src/lib.rs`.

## Testing

Automated (run and passing):
- `cargo fmt --check` ✅
- `cargo clippy` — no new warnings ✅
- `cargo test` — 118 passed ✅

Manual (not yet run — suggested before merge): `vp dev`, then open several windows via the command palette and drag-drop and confirm each lands at a distinct, fully on-screen position; on a multi-monitor setup, confirm the new window appears on the display under the cursor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)