### PR TITLE
Add macOS Quick Look markdown preview extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-07-11
+
+- Add macOS Quick Look support (issue #80): pressing Space on a `.md`/`.markdown` file in Finder now shows a rendered markdown preview instead of plain text. A Quick Look app extension (`WriterQuickLook.appex`, embedded in `Writer.app/Contents/PlugIns`) renders GFM — tables, task lists, fenced code — via JavaScriptCore + `marked`, strips YAML frontmatter, caps input at 2 MB with a truncation notice, and styles output like Writer's editor with light/dark support. The extension is built by `src-tauri/quicklook/build.sh` (Tauri `beforeBundleCommand`), embedded via `bundle.macOS.files`, and signed by the build script itself since tauri-bundler does not sign nested `.appex` bundles.
+
 ## 2026-06-22
 
 - Code-health pass across the desktop app and marketing site (now scoring 100/100 on React Doctor). Mostly internal, with a few user-relevant effects: more screen-reader labels on editor and settings controls, semantic landmarks in the editor chrome, a lighter backdrop blur on the anchor-warning banner, and DOMPurify sanitization of rendered Mermaid diagram SVG. Also broke several module import cycles (notably by splitting page-kind views from their behavior so the stores no longer pull in the editor UI), removed unused dependencies (`motion`, `react-resizable-panels`) and dead code, and parallelized a few independent file reads.

--- a/SPECs/quicklook-extension-spec.md
+++ b/SPECs/quicklook-extension-spec.md
@@ -1,0 +1,96 @@
+# macOS Quick Look Extension
+
+GitHub issue: [#80 — Feature request: add Quick Look support](https://github.com/joelbqz/writer-computer/issues/80)
+
+Pressing Space on a `.md` / `.markdown` file in Finder should show a rendered
+markdown preview instead of the system plain-text preview. Reference
+implementation: [FluxMarkdown](https://github.com/xykong/flux-markdown), a
+dedicated Swift app whose Quick Look app extension renders markdown through a
+web renderer.
+
+## Approach
+
+Ship a native Quick Look **preview app extension** (`WriterQuickLook.appex`)
+embedded in `Writer.app/Contents/PlugIns/`. macOS discovers extensions inside
+installed apps automatically once the host app has been launched (or the
+bundle is registered with LaunchServices) — no separate install step.
+
+The extension uses the **data-based preview API** (macOS 12+):
+`QLPreviewProvider` returns a `QLPreviewReply` of type `.html`, and Quick Look
+renders that HTML in its own sandboxed, script-disabled web view. No view
+controller, no WKWebView of our own.
+
+### Markdown rendering
+
+Writer's editor renders markdown in place via CodeMirror — there is no
+markdown→HTML pipeline in the app to reuse. The extension renders with
+[`marked`](https://github.com/markedjs/marked) (GFM tables, task lists,
+autolinks) evaluated through the system **JavaScriptCore** framework:
+
+- `marked.min.js` is copied from `node_modules` at build time (declared as a
+  devDependency of `apps/desktop`) — no vendored blob in the repo, no network
+  at appex build time beyond the normal `vp install`.
+- JavaScriptCore runs interpreter-only inside the sandbox (no JIT
+  entitlement); a one-document parse is well within budget.
+- YAML frontmatter is stripped before rendering.
+- Input is capped (2 MB) with a truncation notice so a giant file can't stall
+  Quick Look.
+
+A hand-written `preview.css` approximates Writer's editor typography and
+supports light/dark via `prefers-color-scheme`.
+
+### Bundle integration
+
+- `apps/desktop/src-tauri/quicklook/` holds the extension: Swift sources,
+  `Info.plist` template, `entitlements.plist`, `preview.css`, `build.sh`.
+- `build.sh` (macOS-only, no-op elsewhere) compiles the Swift sources with
+  `swiftc -application-extension` linking `_NSExtensionMain`, assembles the
+  `.appex` under `src-tauri/target/quicklook/`, stamps the app version from
+  `tauri.conf.json`, copies `marked.min.js` + `preview.css` into Resources,
+  and codesigns it.
+- `tauri.conf.json` gains `build.beforeBundleCommand` (runs `build.sh`) and
+  `bundle.macOS.files` mapping `PlugIns/WriterQuickLook.appex` to the build
+  output. tauri-bundler copies custom files **before** signing the outer app,
+  so the sealed bundle includes the appex.
+
+### Signing
+
+tauri-bundler's nested-code signing walk only matches `.app`/`.xpc`/dylibs —
+it does **not** sign `.appex` bundles. `build.sh` therefore signs the appex
+itself:
+
+- Dev builds: ad-hoc (`-`).
+- Release builds: `APPLE_SIGNING_IDENTITY` (already exported by
+  `scripts/distribute.sh`), with hardened runtime — required for
+  notarization.
+
+App extensions must be sandboxed: `entitlements.plist` sets
+`com.apple.security.app-sandbox`. Quick Look grants the extension read access
+to the previewed file only.
+
+### Content-type matching
+
+The appex declares `QLSupportedContentTypes = [net.daringfireball.markdown]`.
+The host `Info.plist` gains a `UTImportedTypeDeclarations` entry for
+`net.daringfireball.markdown` (conforming to `public.plain-text`, extensions
+`md`, `markdown`) so `.md` files resolve to that UTI even when no other app
+declares it.
+
+## Out of scope (v1)
+
+- Images: relative-path images can't be read (sandbox only exposes the
+  previewed file) and remote images aren't loaded by the Quick Look web view.
+  `<img>` tags keep their alt text; no attachment plumbing.
+- Mermaid / KaTeX / syntax highlighting — code blocks render as plain
+  monospaced blocks. Requires bundling more JS; revisit on demand.
+- A Quick Look **thumbnail** extension (Finder icon previews).
+- Windows/Linux: the appex build script exits 0 off-macOS; nothing else
+  changes.
+
+## Verification
+
+- `build.sh` output passes `codesign --verify --deep` and `plutil -lint`.
+- A swiftc test harness compiles the renderer sources (QL-free) and asserts
+  HTML output for headings, tables, task lists, frontmatter stripping.
+- Full `tauri build --debug --bundles app`, then `pluginkit -a` on the
+  embedded appex and a `qlmanage -p` smoke test on a sample document.

--- a/TODOS.md
+++ b/TODOS.md
@@ -6,6 +6,7 @@
 
 ## Done
 
+- Quick Look extension: [`SPECs/quicklook-extension-spec.md`](SPECs/quicklook-extension-spec.md) — macOS Quick Look preview appex (issue #80): Swift `QLPreviewProvider` rendering markdown to HTML via JavaScriptCore + `marked`, built by `src-tauri/quicklook/build.sh` (`beforeBundleCommand`) and embedded via `bundle.macOS.files`; the build script signs the appex itself since tauri-bundler skips `.appex` bundles.
 - Sidebar drag-and-drop move: [`SPECs/sidebar-drag-and-drop-move-spec.md`](SPECs/sidebar-drag-and-drop-move-spec.md) — drag files/folders in the `Everything` tree to re-parent them (drop on folder → inside, on file → its folder, on empty space → workspace root), with multi-select batches, open-tab/pin/expanded-state rewrites, and collision reporting. Pointer-event based so it coexists with the existing Finder-drop-to-open; inline rename and drag-move now share one write path (`use-move-entry`).
 - Compact picker recents polish — add a plain non-hovering Recents label using sidebar section styling, remove the search field, per-row opened time, Open other file row, and active file entry, then keep the row remove affordance small so the picker is a direct global recents list.
 - Global-scoped compact mode: [`SPECs/global-compact-mode-spec.md`](SPECs/global-compact-mode-spec.md) — compact windows are fully workspace-free (no root, no indexing, parent-dir single-file watcher), the picker shows a persisted global recent-files list, and the workspace-scoped compact setting is replaced by an "Open File in Compact Window" command.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -47,6 +47,7 @@
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",
     "@welldone-software/why-did-you-render": "catalog:",
+    "marked": "^18.0.6",
     "typescript": "~5.8.3",
     "vite": "^7.0.4"
   }

--- a/apps/desktop/src-tauri/Info.plist
+++ b/apps/desktop/src-tauri/Info.plist
@@ -30,5 +30,33 @@
       </array>
     </dict>
   </array>
+  <!-- Declare the markdown UTI so .md files resolve to it even when no other
+       installed app declares it — the Quick Look extension's
+       QLSupportedContentTypes matches against this identifier. -->
+  <key>UTImportedTypeDeclarations</key>
+  <array>
+    <dict>
+      <key>UTTypeIdentifier</key>
+      <string>net.daringfireball.markdown</string>
+      <key>UTTypeDescription</key>
+      <string>Markdown Document</string>
+      <key>UTTypeConformsTo</key>
+      <array>
+        <string>public.plain-text</string>
+      </array>
+      <key>UTTypeTagSpecification</key>
+      <dict>
+        <key>public.filename-extension</key>
+        <array>
+          <string>md</string>
+          <string>markdown</string>
+        </array>
+        <key>public.mime-type</key>
+        <array>
+          <string>text/markdown</string>
+        </array>
+      </dict>
+    </dict>
+  </array>
 </dict>
 </plist>

--- a/apps/desktop/src-tauri/quicklook/Info.plist
+++ b/apps/desktop/src-tauri/quicklook/Info.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleName</key>
+  <string>Writer Quick Look</string>
+  <key>CFBundleDisplayName</key>
+  <string>Writer Markdown Preview</string>
+  <key>CFBundleIdentifier</key>
+  <string>com.writer-computer.quicklook</string>
+  <key>CFBundleExecutable</key>
+  <string>WriterQuickLook</string>
+  <key>CFBundlePackageType</key>
+  <string>XPC!</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleShortVersionString</key>
+  <string>__VERSION__</string>
+  <key>CFBundleVersion</key>
+  <string>__VERSION__</string>
+  <key>LSMinimumSystemVersion</key>
+  <string>12.0</string>
+  <key>NSExtension</key>
+  <dict>
+    <key>NSExtensionPointIdentifier</key>
+    <string>com.apple.quicklook.preview</string>
+    <key>NSExtensionPrincipalClass</key>
+    <string>WriterQuickLook.PreviewProvider</string>
+    <key>NSExtensionAttributes</key>
+    <dict>
+      <key>QLIsDataBasedPreview</key>
+      <true/>
+      <key>QLSupportedContentTypes</key>
+      <array>
+        <string>net.daringfireball.markdown</string>
+      </array>
+    </dict>
+  </dict>
+</dict>
+</plist>

--- a/apps/desktop/src-tauri/quicklook/MarkdownRenderer.swift
+++ b/apps/desktop/src-tauri/quicklook/MarkdownRenderer.swift
@@ -1,0 +1,134 @@
+import Foundation
+import JavaScriptCore
+
+enum MarkdownRenderError: Error, CustomStringConvertible {
+    case rendererUnavailable(String)
+    case renderFailed(String)
+
+    var description: String {
+        switch self {
+        case .rendererUnavailable(let detail): return "markdown renderer unavailable: \(detail)"
+        case .renderFailed(let detail): return "markdown render failed: \(detail)"
+        }
+    }
+}
+
+/// Renders markdown to a self-contained HTML document using the bundled
+/// `marked` library evaluated in JavaScriptCore. Stateless; each call builds
+/// a fresh JSContext so a poisoned context can't leak across previews.
+struct MarkdownRenderer {
+    /// Documents larger than this are truncated before rendering so a huge
+    /// file cannot stall the Quick Look service.
+    static let maxInputBytes = 2 * 1024 * 1024
+
+    let markedSource: String
+    let stylesheet: String
+
+    init(resourceBundle: Bundle) throws {
+        guard let markedURL = resourceBundle.url(forResource: "marked", withExtension: "js"),
+              let cssURL = resourceBundle.url(forResource: "preview", withExtension: "css")
+        else {
+            throw MarkdownRenderError.rendererUnavailable("marked.js or preview.css missing from bundle")
+        }
+        self.markedSource = try String(contentsOf: markedURL, encoding: .utf8)
+        self.stylesheet = try String(contentsOf: cssURL, encoding: .utf8)
+    }
+
+    init(markedSource: String, stylesheet: String) {
+        self.markedSource = markedSource
+        self.stylesheet = stylesheet
+    }
+
+    func renderDocument(markdown: String, title: String) throws -> String {
+        let (prepared, truncated) = Self.prepare(markdown)
+        let body = try renderBody(markdown: prepared)
+        let notice = truncated
+            ? "<p class=\"truncation-notice\">Preview truncated — open in Writer to read the full document.</p>"
+            : ""
+        return """
+        <!DOCTYPE html>
+        <html>
+        <head>
+        <meta charset="utf-8">
+        <title>\(Self.escapeHTML(title))</title>
+        <style>\(stylesheet)</style>
+        </head>
+        <body><article class="markdown-body">\(body)\(notice)</article></body>
+        </html>
+        """
+    }
+
+    func renderBody(markdown: String) throws -> String {
+        guard let context = JSContext() else {
+            throw MarkdownRenderError.rendererUnavailable("JSContext creation failed")
+        }
+        var jsException: String?
+        context.exceptionHandler = { _, exception in
+            jsException = exception?.toString() ?? "unknown JS exception"
+        }
+        context.evaluateScript(markedSource)
+        if let exception = jsException {
+            throw MarkdownRenderError.rendererUnavailable(exception)
+        }
+        guard let marked = context.globalObject.objectForKeyedSubscript("marked"),
+              !marked.isUndefined,
+              let parse = marked.objectForKeyedSubscript("parse"),
+              !parse.isUndefined
+        else {
+            throw MarkdownRenderError.rendererUnavailable("marked.parse not found after evaluating library")
+        }
+        let options: [String: Any] = ["gfm": true, "breaks": false, "async": false]
+        guard let result = parse.call(withArguments: [markdown, options]), jsException == nil,
+              result.isString, let html = result.toString()
+        else {
+            throw MarkdownRenderError.renderFailed(jsException ?? "marked.parse returned a non-string")
+        }
+        return html
+    }
+
+    /// Strips YAML frontmatter and enforces the input size cap.
+    static func prepare(_ markdown: String) -> (markdown: String, truncated: Bool) {
+        var text = stripFrontmatter(markdown)
+        var truncated = false
+        if text.utf8.count > maxInputBytes {
+            var bytes = Array(text.utf8.prefix(maxInputBytes))
+            // Trim a trailing partial UTF-8 scalar so decoding stays lossless:
+            // drop continuation bytes, then the dangling lead byte if any.
+            while let last = bytes.last, last & 0b1100_0000 == 0b1000_0000 {
+                bytes.removeLast()
+            }
+            if let last = bytes.last, last & 0b1100_0000 == 0b1100_0000 {
+                bytes.removeLast()
+            }
+            text = String(decoding: bytes, as: UTF8.self)
+            truncated = true
+        }
+        return (text, truncated)
+    }
+
+    static func stripFrontmatter(_ markdown: String) -> String {
+        guard markdown.hasPrefix("---\n") || markdown.hasPrefix("---\r\n") else { return markdown }
+        let afterOpen = markdown.index(markdown.startIndex, offsetBy: markdown.hasPrefix("---\r\n") ? 5 : 4)
+        let rest = markdown[afterOpen...]
+        for close in ["\n---\n", "\n---\r\n", "\r\n---\r\n", "\r\n---\n"] {
+            if let range = rest.range(of: close) {
+                return String(rest[range.upperBound...])
+            }
+        }
+        // Frontmatter that ends the file ("\n---" with no trailing newline).
+        for close in ["\n---", "\r\n---"] {
+            if rest.hasSuffix(close) {
+                return ""
+            }
+        }
+        return markdown
+    }
+
+    static func escapeHTML(_ text: String) -> String {
+        text
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+    }
+}

--- a/apps/desktop/src-tauri/quicklook/PreviewProvider.swift
+++ b/apps/desktop/src-tauri/quicklook/PreviewProvider.swift
@@ -1,0 +1,41 @@
+import Foundation
+import QuickLookUI
+
+/// Data-based Quick Look preview (macOS 12+): returns rendered HTML that the
+/// Quick Look service displays in its own sandboxed, script-disabled web view.
+final class PreviewProvider: QLPreviewProvider, QLPreviewingController {
+    func providePreview(
+        for request: QLFilePreviewRequest,
+        completionHandler handler: @escaping (QLPreviewReply?, Error?) -> Void
+    ) {
+        do {
+            let markdown = try Self.readText(at: request.fileURL)
+            let renderer = try MarkdownRenderer(resourceBundle: Bundle(for: PreviewProvider.self))
+            let html = try renderer.renderDocument(
+                markdown: markdown,
+                title: request.fileURL.lastPathComponent
+            )
+            let reply = QLPreviewReply(
+                dataOfContentType: .html,
+                contentSize: CGSize(width: 800, height: 1000)
+            ) { reply in
+                reply.stringEncoding = .utf8
+                reply.title = request.fileURL.lastPathComponent
+                return Data(html.utf8)
+            }
+            handler(reply, nil)
+        } catch {
+            handler(nil, error)
+        }
+    }
+
+    static func readText(at url: URL) throws -> String {
+        let data = try Data(contentsOf: url)
+        if let utf8 = String(data: data, encoding: .utf8) {
+            return utf8
+        }
+        // Non-UTF-8 markdown is rare; decode lossily rather than failing the
+        // preview outright.
+        return String(decoding: data, as: UTF8.self)
+    }
+}

--- a/apps/desktop/src-tauri/quicklook/build.sh
+++ b/apps/desktop/src-tauri/quicklook/build.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Builds WriterQuickLook.appex — the macOS Quick Look markdown preview
+# extension embedded into Writer.app via `bundle.macOS.files`.
+#
+# Runs as tauri's beforeBundleCommand (cwd: apps/desktop). Safe to run
+# standalone from anywhere. No-op on non-macOS hosts.
+#
+# Signing: tauri-bundler does not sign .appex bundles in its nested-code walk,
+# so the appex is signed here — with APPLE_SIGNING_IDENTITY (exported by
+# scripts/distribute.sh) and hardened runtime for releases, ad-hoc otherwise.
+set -euo pipefail
+
+if [ "$(uname)" != "Darwin" ]; then
+  echo "quicklook: skipping appex build (not macOS)"
+  exit 0
+fi
+
+QL_DIR="$(cd "$(dirname "$0")" && pwd)"
+SRC_TAURI="$(dirname "$QL_DIR")"
+APP_DIR="$(dirname "$SRC_TAURI")"
+
+VERSION=$(python3 -c "import json; print(json.load(open('$SRC_TAURI/tauri.conf.json'))['version'])")
+
+MARKED_JS="$APP_DIR/node_modules/marked/lib/marked.umd.js"
+if [ ! -f "$MARKED_JS" ]; then
+  echo "quicklook: error: $MARKED_JS not found — run 'vp install' first" >&2
+  exit 1
+fi
+
+OUT_DIR="$SRC_TAURI/target/quicklook"
+APPEX="$OUT_DIR/WriterQuickLook.appex"
+rm -rf "$APPEX"
+mkdir -p "$APPEX/Contents/MacOS" "$APPEX/Contents/Resources"
+
+echo "quicklook: compiling WriterQuickLook.appex (v$VERSION)"
+swiftc -O \
+  -parse-as-library \
+  -application-extension \
+  -target arm64-apple-macos12.0 \
+  -module-name WriterQuickLook \
+  -framework QuickLookUI \
+  -framework JavaScriptCore \
+  -Xlinker -e -Xlinker _NSExtensionMain \
+  -o "$APPEX/Contents/MacOS/WriterQuickLook" \
+  "$QL_DIR/MarkdownRenderer.swift" \
+  "$QL_DIR/PreviewProvider.swift"
+
+sed "s/__VERSION__/$VERSION/g" "$QL_DIR/Info.plist" > "$APPEX/Contents/Info.plist"
+plutil -lint "$APPEX/Contents/Info.plist" > /dev/null
+
+cp "$MARKED_JS" "$APPEX/Contents/Resources/marked.js"
+cp "$QL_DIR/preview.css" "$APPEX/Contents/Resources/preview.css"
+
+IDENTITY="${APPLE_SIGNING_IDENTITY:--}"
+SIGN_ARGS=(--force --sign "$IDENTITY" --entitlements "$QL_DIR/entitlements.plist")
+if [ "$IDENTITY" != "-" ]; then
+  SIGN_ARGS+=(--options runtime --timestamp)
+fi
+codesign "${SIGN_ARGS[@]}" "$APPEX"
+codesign --verify --deep --strict "$APPEX"
+
+echo "quicklook: built $APPEX"

--- a/apps/desktop/src-tauri/quicklook/entitlements.plist
+++ b/apps/desktop/src-tauri/quicklook/entitlements.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!-- App extensions must be sandboxed. Quick Look grants read access to the
+       previewed file; the extension needs nothing else. -->
+  <key>com.apple.security.app-sandbox</key>
+  <true/>
+</dict>
+</plist>

--- a/apps/desktop/src-tauri/quicklook/preview.css
+++ b/apps/desktop/src-tauri/quicklook/preview.css
@@ -1,0 +1,182 @@
+/* Quick Look preview stylesheet — approximates Writer's editor typography
+   (system font, 16px/1.8, 734px measure, #ff6a00 accent, #111 dark bg). */
+
+:root {
+  color-scheme: light dark;
+  --bg: #fcfcfc;
+  --fg: #1a1a1a;
+  --fg-secondary: rgba(26, 26, 26, 0.8);
+  --fg-muted: rgba(26, 26, 26, 0.54);
+  --accent: #ff6a00;
+  --code-bg: rgba(26, 26, 26, 0.06);
+  --border: rgba(26, 26, 26, 0.14);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #111111;
+    --fg: #fcfcfc;
+    --fg-secondary: rgba(252, 252, 252, 0.8);
+    --fg-muted: rgba(252, 252, 252, 0.54);
+    --code-bg: rgba(252, 252, 252, 0.08);
+    --border: rgba(252, 252, 252, 0.16);
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  background: var(--bg);
+}
+
+body {
+  margin: 0;
+  font-family:
+    -apple-system-body,
+    ui-sans-serif,
+    -apple-system,
+    system-ui,
+    "Segoe UI",
+    Helvetica,
+    "Apple Color Emoji",
+    Arial,
+    sans-serif;
+  font-size: 16px;
+  line-height: 1.8;
+  color: var(--fg-secondary);
+  -webkit-font-smoothing: antialiased;
+}
+
+.markdown-body {
+  max-width: 734px;
+  margin: 0 auto;
+  padding: 2.5rem clamp(1.5rem, 4vw, 4rem) 4rem;
+  overflow-wrap: break-word;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  color: var(--fg);
+  line-height: 1.3;
+  margin: 2rem 0 0.5rem;
+  font-weight: 650;
+}
+
+h1 {
+  font-size: 1.75em;
+}
+
+h2 {
+  font-size: 1.4em;
+}
+
+h3 {
+  font-size: 1.2em;
+}
+
+h4,
+h5,
+h6 {
+  font-size: 1em;
+}
+
+p {
+  margin: 0.75em 0;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+strong {
+  color: var(--fg);
+}
+
+hr {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: 2rem 0;
+}
+
+blockquote {
+  margin: 0.75em 0;
+  padding: 0 0 0 1em;
+  border-left: 3px solid var(--border);
+  color: var(--fg-muted);
+}
+
+ul,
+ol {
+  margin: 0.75em 0;
+  padding-left: 1.6em;
+}
+
+li {
+  margin: 0.2em 0;
+}
+
+li input[type="checkbox"] {
+  margin-right: 0.4em;
+  accent-color: var(--accent);
+}
+
+code {
+  font-family: "SF Mono", ui-monospace, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.875em;
+  background: var(--code-bg);
+  border-radius: 4px;
+  padding: 0.1em 0.35em;
+}
+
+pre {
+  background: var(--code-bg);
+  border-radius: 8px;
+  padding: 0.9em 1.1em;
+  overflow-x: auto;
+  line-height: 1.55;
+}
+
+pre code {
+  background: none;
+  padding: 0;
+}
+
+table {
+  border-collapse: collapse;
+  margin: 1em 0;
+  display: block;
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+th,
+td {
+  border: 1px solid var(--border);
+  padding: 0.4em 0.75em;
+  text-align: left;
+}
+
+th {
+  color: var(--fg);
+  background: var(--code-bg);
+}
+
+img {
+  max-width: 100%;
+}
+
+.truncation-notice {
+  margin-top: 2rem;
+  padding: 0.6em 1em;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--fg-muted);
+  font-style: italic;
+}

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -7,6 +7,7 @@
     "beforeDevCommand": "vp dev",
     "devUrl": "http://localhost:1420",
     "beforeBuildCommand": "vp build",
+    "beforeBundleCommand": "bash src-tauri/quicklook/build.sh",
     "frontendDist": "../dist"
   },
   "app": {
@@ -46,7 +47,10 @@
       "entitlements": "./Entitlements.plist",
       "signingIdentity": null,
       "hardenedRuntime": true,
-      "minimumSystemVersion": "10.15"
+      "minimumSystemVersion": "10.15",
+      "files": {
+        "PlugIns/WriterQuickLook.appex": "target/quicklook/WriterQuickLook.appex"
+      }
     },
     "fileAssociations": [
       {

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -62,6 +62,8 @@ The script will, in order:
 
 Expect the whole script to take several minutes — most of it is the cargo release build and Apple notarization.
 
+Note on the Quick Look extension: `tauri build` runs `src-tauri/quicklook/build.sh` (as `beforeBundleCommand`) which compiles and signs `WriterQuickLook.appex` before it is embedded at `Writer.app/Contents/PlugIns/`. The script signs the appex with `APPLE_SIGNING_IDENTITY` (hardened runtime + sandbox entitlements) when that env var is set — which `distribute.sh` guarantees — because tauri-bundler's nested-code signing does not cover `.appex` bundles. An ad-hoc-signed appex inside a release build will fail notarization; if notarization reports an unsigned or ad-hoc binary at `Contents/PlugIns/WriterQuickLook.appex`, check that the env var was exported when the appex was built.
+
 ## Step 4 — Review and publish on GitHub
 
 Open the draft URL printed by `distribute.sh`. Confirm:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,6 +228,9 @@ importers:
       '@welldone-software/why-did-you-render':
         specifier: 'catalog:'
         version: 10.0.1(react@19.2.4)
+      marked:
+        specifier: ^18.0.6
+        version: 18.0.6
       typescript:
         specifier: ~5.8.3
         version: 5.8.3
@@ -3451,6 +3454,11 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  marked@18.0.6:
+    resolution: {integrity: sha512-MrV5puXBfuiy6wl6DLaq3BtIJQAJToAd5zt/ZKhRfGRAuFPALE7/4Y7jnxRQoEgK/pBgurGqLyAuRgZ2xOjr6w==}
+    engines: {node: '>= 20'}
+    hasBin: true
 
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
@@ -7437,6 +7445,8 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  marked@18.0.6: {}
 
   minimatch@3.1.5:
     dependencies:


### PR DESCRIPTION
Closes #80.

Pressing Space on a `.md`/`.markdown` file in Finder now shows a rendered markdown preview instead of the system plain-text one.

## How it works

- **`WriterQuickLook.appex`** — a Quick Look preview app extension embedded at `Writer.app/Contents/PlugIns/`, using the data-based `QLPreviewProvider` API (macOS 12+): it returns rendered HTML that Quick Look displays in its own sandboxed, script-disabled web view.
- **Rendering** — JavaScriptCore evaluating `marked` (new devDependency, copied from `node_modules` at build time), same web-renderer approach as [FluxMarkdown](https://github.com/xykong/flux-markdown) referenced in the issue. GFM tables, task lists, and fenced code render; YAML frontmatter is stripped; input is capped at 2 MB with a truncation notice. `preview.css` mirrors Writer's editor typography with light/dark support.
- **Build/bundle** — `src-tauri/quicklook/build.sh` runs as Tauri's `beforeBundleCommand`: compiles the Swift sources (`swiftc -application-extension`, `_NSExtensionMain` entry), assembles the appex, stamps the app version, and signs it. `bundle.macOS.files` embeds it; tauri-bundler copies custom files before signing the outer app.
- **Signing** — tauri-bundler's nested-code walk doesn't cover `.appex`, so the script signs the appex itself: ad-hoc in dev, `APPLE_SIGNING_IDENTITY` + hardened runtime when set (which `distribute.sh` guarantees for releases). Sandbox entitlement as required for app extensions. `docs/releasing.md` documents this.
- **UTI** — the host `Info.plist` imports `net.daringfireball.markdown` so `.md` files resolve to the UTI the appex declares in `QLSupportedContentTypes`.

Spec: `SPECs/quicklook-extension-spec.md`. Out of scope for v1 (documented there): images (sandbox only exposes the previewed file), mermaid/KaTeX/syntax highlighting, thumbnail extension.

## Verification

- Renderer harness (swiftc + the real `marked.umd.js`): headings, GFM tables, task-list checkboxes, fenced code, links, frontmatter stripping (incl. frontmatter-only files), 2 MB truncation, UTF-8 boundary safety at the cap (the harness caught and fixed a dangling-lead-byte bug).
- `tauri build --debug --bundles app`: appex lands in `Contents/PlugIns/`, `codesign --verify --deep --strict` passes, sandbox entitlement present.
- Live: registered the built appex with PluginKit, opened `qlmanage -p sample.md` — QuickLookUIService launched `WriterQuickLook` and served the preview with no errors in the unified log. (Machines with other markdown Quick Look apps installed — Bear, Ulysses, Clearly… — compete for the preview; with those set to ignore, ours renders.)
- `vp check` and `vp test` (472 tests) pass. No Rust source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)