### PR TITLE
Support hiding status bar metrics and sidebar sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-07-20
+
+- Hide status bar metrics and sidebar sections. Right-click the bottom status bar to toggle the word, character, and paragraph counts individually (the bar disappears when all three are off); right-click the sidebar background or a section title to toggle the Search button and the Recents section. All five toggles also live in Preferences — the metric toggles under a new "Status Bar" section, the sidebar ones under Appearance — and every menu lists hidden items as unchecked entries so they can be re-shown from the same place.
+
 ## 2026-07-18
 
 - Simplify the Typography font controls to ordinary installed-font selects matching the rest of Settings. Remove the separate AppKit Font panel and editable stack field; choosing a family still preserves the setting's existing CSS fallback tail. UI and editor now default to SF Pro, while the renamed Code font setting defaults to SF Mono.

--- a/SPECs/statusbar-sidebar-visibility-spec.md
+++ b/SPECs/statusbar-sidebar-visibility-spec.md
@@ -1,0 +1,65 @@
+# Status bar metrics and sidebar section visibility
+
+## Problem
+
+The document footer always shows all three metrics (words, characters,
+paragraphs), and the sidebar always shows the Search button and the Recents
+section. Writers who want a quieter chrome have no way to hide any of them.
+
+## Behavior
+
+### Settings
+
+Five new boolean settings in `settings.schema.json`, all defaulting to `true`
+and persisted at global scope:
+
+- `statusbar.show-words`, `statusbar.show-characters`,
+  `statusbar.show-paragraphs` — category **Status Bar** (renders after the
+  Editor section in Preferences via the schema-driven panel).
+- `appearance.sidebar-show-search`, `appearance.sidebar-show-recents` —
+  category **Appearance**.
+
+No settings-panel code changes: the generic boolean control renders them.
+
+### Status bar
+
+- `DocumentFooter` renders only the metrics whose setting is on. When all
+  three are off, the footer element is not rendered at all.
+- Right-clicking the footer opens a native context menu (same
+  `build…Spec` + `Menu.popup()` pattern as the sidebar file menus) listing
+  **every** metric as a check item — checked = visible — so a hidden metric
+  can be re-shown from the same menu, not only from Settings. Toggles write
+  through the settings store, so Preferences stays in sync.
+- The metric list (setting key ↔ stat key ↔ labels) lives once in
+  `FOOTER_METRICS` (`footer-context-menu.ts`); the footer and the menu both
+  iterate it.
+
+### Sidebar
+
+- The Search button hides when `appearance.sidebar-show-search` is off; the
+  Recents section hides when `appearance.sidebar-show-recents` is off
+  (regardless of recent files existing).
+- Right-clicking the sidebar surface — empty space, section headers
+  (including the Recents title), or the search button — opens a native
+  context menu with two check items, Search and Recents. File and folder rows
+  keep their existing menus (they stop propagation, so the surface menu never
+  fires for them).
+- Hiding Recents does not clear recents metadata; re-enabling restores the
+  section as it was.
+
+### Typing note
+
+`SettingsMap` cannot type boolean settings as `boolean` (TypeScript widens
+JSON imports, so the `"type": "boolean"` literal never narrows). Boolean
+reads go through a new `useBooleanSetting(key, fallback = true)` hook that
+narrows at runtime, replacing ad-hoc `as boolean | undefined` casts.
+
+## Verification
+
+- Unit tests for both menu spec builders (`footer-context-menu.test.ts`,
+  `sidebar-surface-context-menu.test.ts`).
+- Runtime: `e2e/specs/visibility-settings.spec.js` drives the built app —
+  default metric set, single-metric hide, all-hidden footer removal, Search
+  button hide, Recents section hide. Native menu popups themselves are
+  OS-level and not driveable from WebDriver; the menus' actions share the
+  `setSetting` write path the e2e spec exercises.

--- a/TODOS.md
+++ b/TODOS.md
@@ -6,6 +6,7 @@
 
 ## Done
 
+- Status bar + sidebar visibility toggles: [`SPECs/statusbar-sidebar-visibility-spec.md`](SPECs/statusbar-sidebar-visibility-spec.md) — hide/show each footer metric (words, characters, paragraphs) and the sidebar Search button and Recents section, via five new boolean settings and native right-click check-item menus on the footer and sidebar surface.
 - Select-only Typography font controls: [`SPECs/font-select-spec.md`](SPECs/font-select-spec.md) — replace the AppKit Font panel and editable stack field with a standard installed-family `<select>` matching the other settings controls; default UI/editor to SF Pro and the renamed Code font setting to SF Mono.
 - Native macOS font picker + Typography settings: [`SPECs/native-font-picker-spec.md`](SPECs/native-font-picker-spec.md) — replace the custom installed-font combobox with AppKit's system Font panel, route selections back to the originating settings row/window, preserve editable CSS fallback stacks, and rename the settings section from Fonts to Typography.
 - Global font settings: [`SPECs/global-font-settings-spec.md`](SPECs/global-font-settings-spec.md) — the six per-mode `theme.{mode}.{ui,editor,mono}-font` settings become three global `fonts.{ui,editor,mono}` settings in a Typography section above the theme cards (fonts are typographic, not chromatic); startup migration adopts existing per-mode values (light wins, dark fallback) and drops the old keys. The font control is a single select-style pill (stack input + chevron in one surface).

--- a/apps/desktop/e2e/specs/visibility-settings.spec.js
+++ b/apps/desktop/e2e/specs/visibility-settings.spec.js
@@ -114,6 +114,39 @@ describe("status bar and sidebar visibility settings", function () {
     strictEqual(await $("[data-sidebar-search-button]").isExisting(), false);
   });
 
+  it("renders all five toggles in Preferences", async function () {
+    await browser.execute(() => {
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "p", metaKey: true, bubbles: true, cancelable: true }),
+      );
+    });
+    const settingsCommand = await $('[cmdk-item][data-value="open-settings"]');
+    await settingsCommand.waitForExist({ timeout: 5_000 });
+    await settingsCommand.click();
+    await $("[data-settings-panel]").waitForExist({ timeout: 5_000 });
+
+    const rows = await browser.execute(() => {
+      const labels = Array.from(
+        document.querySelectorAll("[data-settings-panel] section"),
+      ).flatMap((section) => {
+        const heading = section.querySelector("h2")?.textContent ?? "";
+        return Array.from(section.querySelectorAll("div.text-\\[13px\\].font-medium")).map(
+          (label) => `${heading}: ${label.textContent}`,
+        );
+      });
+      return labels;
+    });
+    for (const expected of [
+      "Appearance: Sidebar Search Button",
+      "Appearance: Sidebar Recents",
+      "Status Bar: Words",
+      "Status Bar: Characters",
+      "Status Bar: Paragraphs",
+    ]) {
+      ok(rows.includes(expected), `missing settings row "${expected}" in ${JSON.stringify(rows)}`);
+    }
+  });
+
   it("hides the Recents section when off", async function () {
     // Opening README earlier recorded it, so Recents should be populated.
     const recents = await $('section[aria-label="Recents"]');

--- a/apps/desktop/e2e/specs/visibility-settings.spec.js
+++ b/apps/desktop/e2e/specs/visibility-settings.spec.js
@@ -1,0 +1,132 @@
+import { ok, strictEqual } from "node:assert/strict";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const E2E_WORKSPACE = resolve(dirname(fileURLToPath(import.meta.url)), "../../../..");
+
+const VISIBILITY_KEYS = [
+  "statusbar.show-words",
+  "statusbar.show-characters",
+  "statusbar.show-paragraphs",
+  "appearance.sidebar-show-search",
+  "appearance.sidebar-show-recents",
+];
+
+async function invoke(cmd, args) {
+  const result = await browser.executeAsync(
+    (cmdName, cmdArgs, done) => {
+      window.__TAURI_INTERNALS__
+        .invoke(cmdName, cmdArgs)
+        .then((value) => done({ ok: true, value }))
+        .catch((error) =>
+          done({ ok: false, error: error && error.message ? error.message : String(error) }),
+        );
+    },
+    cmd,
+    args,
+  );
+  if (!result.ok) throw new Error(`${cmd} failed: ${result.error}`);
+  return result.value;
+}
+
+async function setSetting(key, value) {
+  await invoke("set_setting", { key, value, scope: "global" });
+}
+
+async function resetVisibilitySettings() {
+  for (const key of VISIBILITY_KEYS) {
+    await invoke("reset_setting", { key, scope: "global" });
+  }
+}
+
+async function waitForMount() {
+  await $('button[aria-label="Hide sidebar"]').waitForExist({ timeout: 15_000 });
+}
+
+async function openReadme() {
+  const row = await $('[data-tree-path$="/README.md"]');
+  await row.waitForExist({ timeout: 10_000 });
+  await row.click();
+  await $("[data-document-footer]").waitForExist({ timeout: 10_000 });
+}
+
+async function footerMetricLabels() {
+  return browser.execute(() => {
+    const footer = document.querySelector("[data-document-footer]");
+    if (!footer) return null;
+    return Array.from(footer.querySelectorAll("span"))
+      .map((span) => span.textContent ?? "")
+      .filter((text) => /^[a-z]+$/.test(text));
+  });
+}
+
+describe("status bar and sidebar visibility settings", function () {
+  before(async function () {
+    const workspaceRestored = await $('button[aria-label="Hide sidebar"]')
+      .waitForExist({ timeout: 3_000 })
+      .catch(() => false);
+    if (!workspaceRestored) {
+      await invoke("open_workspace", { path: E2E_WORKSPACE });
+    }
+    await waitForMount();
+    await resetVisibilitySettings();
+    await browser.refresh();
+    await waitForMount();
+  });
+
+  after(async function () {
+    await resetVisibilitySettings().catch(() => {});
+  });
+
+  it("shows all three footer metrics by default", async function () {
+    await openReadme();
+    const labels = await footerMetricLabels();
+    strictEqual(JSON.stringify(labels), JSON.stringify(["words", "characters", "paragraphs"]));
+  });
+
+  it("hides a single metric when its setting is off", async function () {
+    await setSetting("statusbar.show-characters", false);
+    await browser.refresh();
+    await waitForMount();
+    await openReadme();
+    const labels = await footerMetricLabels();
+    strictEqual(JSON.stringify(labels), JSON.stringify(["words", "paragraphs"]));
+  });
+
+  it("removes the footer entirely when every metric is off", async function () {
+    await setSetting("statusbar.show-words", false);
+    await setSetting("statusbar.show-paragraphs", false);
+    await browser.refresh();
+    await waitForMount();
+    // The document restores without a footer, so wait on the editor instead.
+    const row = await $('[data-tree-path$="/README.md"]');
+    await row.waitForExist({ timeout: 10_000 });
+    await row.click();
+    await browser.pause(1_000);
+    strictEqual(await $("[data-document-footer]").isExisting(), false);
+  });
+
+  it("shows the sidebar Search button by default and hides it when off", async function () {
+    ok(await $("[data-sidebar-search-button]").isExisting());
+    await setSetting("appearance.sidebar-show-search", false);
+    await browser.refresh();
+    await waitForMount();
+    strictEqual(await $("[data-sidebar-search-button]").isExisting(), false);
+  });
+
+  it("hides the Recents section when off", async function () {
+    // Opening README earlier recorded it, so Recents should be populated.
+    const recents = await $('section[aria-label="Recents"]');
+    const hadRecents = await recents
+      .waitForExist({ timeout: 10_000 })
+      .then(() => true)
+      .catch(() => false);
+    await setSetting("appearance.sidebar-show-recents", false);
+    await browser.refresh();
+    await waitForMount();
+    await browser.pause(1_000);
+    strictEqual(await $('section[aria-label="Recents"]').isExisting(), false);
+    // Only meaningful if the section was there to begin with.
+    ok(hadRecents, "Recents section never appeared while enabled");
+  });
+});

--- a/apps/desktop/shared/settings.schema.json
+++ b/apps/desktop/shared/settings.schema.json
@@ -29,6 +29,30 @@
       "default": 2
     },
     {
+      "key": "statusbar.show-words",
+      "label": "Words",
+      "description": "Show the word count in the status bar",
+      "category": "Status Bar",
+      "type": "boolean",
+      "default": true
+    },
+    {
+      "key": "statusbar.show-characters",
+      "label": "Characters",
+      "description": "Show the character count in the status bar",
+      "category": "Status Bar",
+      "type": "boolean",
+      "default": true
+    },
+    {
+      "key": "statusbar.show-paragraphs",
+      "label": "Paragraphs",
+      "description": "Show the paragraph count in the status bar",
+      "category": "Status Bar",
+      "type": "boolean",
+      "default": true
+    },
+    {
       "key": "appearance.theme",
       "label": "Schema",
       "description": "Light or dark color schema",
@@ -61,6 +85,22 @@
       "type": "enum",
       "options": ["title", "filename"],
       "default": "title"
+    },
+    {
+      "key": "appearance.sidebar-show-search",
+      "label": "Sidebar Search Button",
+      "description": "Show the Search button at the top of the sidebar",
+      "category": "Appearance",
+      "type": "boolean",
+      "default": true
+    },
+    {
+      "key": "appearance.sidebar-show-recents",
+      "label": "Sidebar Recents",
+      "description": "Show the Recents section in the sidebar",
+      "category": "Appearance",
+      "type": "boolean",
+      "default": true
     },
     {
       "key": "appearance.editor-width",

--- a/apps/desktop/src/components/editor-area/document-footer.tsx
+++ b/apps/desktop/src/components/editor-area/document-footer.tsx
@@ -1,4 +1,11 @@
+import type { MouseEvent } from "react";
 import { useFileStats } from "@/hooks/use-tabs";
+import { useBooleanSetting, useSetSetting } from "@/hooks/use-settings";
+import {
+  FOOTER_METRICS,
+  showFooterContextMenu,
+  type FooterMetricSettingKey,
+} from "./footer-context-menu";
 
 function FooterMetric({ label, value }: { label: string; value: number }) {
   return (
@@ -11,12 +18,39 @@ function FooterMetric({ label, value }: { label: string; value: number }) {
 
 export function DocumentFooter({ filePath }: { filePath: string }) {
   const stats = useFileStats(filePath);
+  const setSetting = useSetSetting();
+  const visibility: Record<FooterMetricSettingKey, boolean> = {
+    "statusbar.show-words": useBooleanSetting("statusbar.show-words"),
+    "statusbar.show-characters": useBooleanSetting("statusbar.show-characters"),
+    "statusbar.show-paragraphs": useBooleanSetting("statusbar.show-paragraphs"),
+  };
+  const visibleMetrics = FOOTER_METRICS.filter((metric) => visibility[metric.settingKey]);
+
+  if (visibleMetrics.length === 0) return null;
+
+  const handleContextMenu = (event: MouseEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    void showFooterContextMenu({
+      visibility,
+      onToggle: (key, visible) => {
+        void setSetting(key, visible);
+      },
+    });
+  };
 
   return (
-    <div className="flex absolute bottom-0 w-full z-10 h-11 shrink-0 items-center justify-end gap-5 px-6 text-[13px] leading-[1.15] text-[var(--text-muted)] md:px-8">
-      <FooterMetric label="words" value={stats.words} />
-      <FooterMetric label="characters" value={stats.characters} />
-      <FooterMetric label="paragraphs" value={stats.paragraphs} />
+    <div
+      data-document-footer
+      onContextMenu={handleContextMenu}
+      className="flex absolute bottom-0 w-full z-10 h-11 shrink-0 items-center justify-end gap-5 px-6 text-[13px] leading-[1.15] text-[var(--text-muted)] md:px-8"
+    >
+      {visibleMetrics.map((metric) => (
+        <FooterMetric
+          key={metric.settingKey}
+          label={metric.footerLabel}
+          value={stats[metric.statKey]}
+        />
+      ))}
     </div>
   );
 }

--- a/apps/desktop/src/components/editor-area/footer-context-menu.ts
+++ b/apps/desktop/src/components/editor-area/footer-context-menu.ts
@@ -1,0 +1,83 @@
+import { Menu } from "@tauri-apps/api/menu/menu";
+import { CheckMenuItem } from "@tauri-apps/api/menu/checkMenuItem";
+import type { DocumentStats } from "@/lib/document-stats";
+
+/**
+ * Registry of the footer metrics: which stat each one shows, the label
+ * rendered in the footer, the label shown in the context menu, and the
+ * setting key that controls its visibility. The footer and its context menu
+ * both iterate this list — add a metric here and both stay in sync.
+ */
+export const FOOTER_METRICS = [
+  {
+    settingKey: "statusbar.show-words",
+    statKey: "words",
+    footerLabel: "words",
+    menuLabel: "Words",
+  },
+  {
+    settingKey: "statusbar.show-characters",
+    statKey: "characters",
+    footerLabel: "characters",
+    menuLabel: "Characters",
+  },
+  {
+    settingKey: "statusbar.show-paragraphs",
+    statKey: "paragraphs",
+    footerLabel: "paragraphs",
+    menuLabel: "Paragraphs",
+  },
+] as const satisfies ReadonlyArray<{
+  settingKey: string;
+  statKey: keyof DocumentStats;
+  footerLabel: string;
+  menuLabel: string;
+}>;
+
+export type FooterMetricSettingKey = (typeof FOOTER_METRICS)[number]["settingKey"];
+
+export interface FooterContextMenuState {
+  /** Current visibility per metric setting key. */
+  visibility: Record<FooterMetricSettingKey, boolean>;
+  /** Called with the setting key and the new visibility value. */
+  onToggle: (key: FooterMetricSettingKey, visible: boolean) => void;
+}
+
+/**
+ * Build the check-item entries for the footer context menu. Every metric is
+ * always listed (checked = currently visible) so a hidden metric can be
+ * re-shown from the same menu. Pulled out from `showFooterContextMenu` so it
+ * can be unit-tested without the Tauri runtime.
+ */
+export function buildFooterMenuItemsSpec(
+  state: FooterContextMenuState,
+): Array<{ id: FooterMetricSettingKey; text: string; checked: boolean; action: () => void }> {
+  return FOOTER_METRICS.map(({ settingKey, menuLabel }) => ({
+    id: settingKey,
+    text: menuLabel,
+    checked: state.visibility[settingKey],
+    action: () => state.onToggle(settingKey, !state.visibility[settingKey]),
+  }));
+}
+
+/**
+ * Build a Tauri native menu of check items and pop it up at the cursor.
+ * The menu dismisses through the OS, not via JS.
+ */
+export async function showFooterContextMenu(state: FooterContextMenuState): Promise<void> {
+  const spec = buildFooterMenuItemsSpec(state);
+
+  const items = await Promise.all(
+    spec.map((entry) =>
+      CheckMenuItem.new({
+        id: entry.id,
+        text: entry.text,
+        checked: entry.checked,
+        action: entry.action,
+      }),
+    ),
+  );
+
+  const menu = await Menu.new({ items });
+  await menu.popup();
+}

--- a/apps/desktop/src/components/sidebar/file-browser.tsx
+++ b/apps/desktop/src/components/sidebar/file-browser.tsx
@@ -1,38 +1,64 @@
+import type { MouseEvent } from "react";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { Search01Icon } from "@hugeicons/core-free-icons";
 import { useOpenCommandPalette } from "@/hooks/use-command-palette";
+import { useBooleanSetting, useSetSetting } from "@/hooks/use-settings";
 import { ScrollFade } from "@/components/scroll-fade";
 import { SidebarNavigator } from "./sidebar-navigator";
+import { showSidebarSurfaceContextMenu } from "./sidebar-surface-context-menu";
 
 export function FileBrowser() {
   const openCommandPalette = useOpenCommandPalette();
+  const setSetting = useSetSetting();
+  const showSearch = useBooleanSetting("appearance.sidebar-show-search");
+  const showRecents = useBooleanSetting("appearance.sidebar-show-recents");
+
+  // File and folder rows stop propagation from their own context menus, so
+  // this only fires for the sidebar surface: empty space, section headers,
+  // and the search button.
+  const handleSurfaceContextMenu = (event: MouseEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    void showSidebarSurfaceContextMenu({
+      showSearch,
+      showRecents,
+      onToggleSearch: (visible) => {
+        void setSetting("appearance.sidebar-show-search", visible);
+      },
+      onToggleRecents: (visible) => {
+        void setSetting("appearance.sidebar-show-recents", visible);
+      },
+    });
+  };
 
   return (
-    <div className="flex h-full min-h-0 flex-col px-3">
-      <div
-        className="flex items-center"
-        style={{
-          height: "calc(var(--chrome-control-height) + var(--chrome-control-padding) * 2)",
-          padding: "var(--chrome-control-padding) 0",
-        }}
-      >
-        <button
-          type="button"
-          onClick={() => openCommandPalette()}
-          className="relative flex w-full items-center rounded-lg border border-transparent bg-[var(--surface-input)] pl-[34px] pr-3 text-[13px] text-[var(--text-muted)] transition-colors hover:text-[var(--fg-base)] h-[var(--chrome-control-height)]"
+    <div className="flex h-full min-h-0 flex-col px-3" onContextMenu={handleSurfaceContextMenu}>
+      {showSearch && (
+        <div
+          className="flex items-center"
+          style={{
+            height: "calc(var(--chrome-control-height) + var(--chrome-control-padding) * 2)",
+            padding: "var(--chrome-control-padding) 0",
+          }}
         >
-          <span
-            aria-hidden="true"
-            className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-current"
+          <button
+            type="button"
+            data-sidebar-search-button
+            onClick={() => openCommandPalette()}
+            className="relative flex w-full items-center rounded-lg border border-transparent bg-[var(--surface-input)] pl-[34px] pr-3 text-[13px] text-[var(--text-muted)] transition-colors hover:text-[var(--fg-base)] h-[var(--chrome-control-height)]"
           >
-            <HugeiconsIcon icon={Search01Icon} size={16} color="currentColor" strokeWidth={2} />
-          </span>
-          Search
-          <kbd className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 text-[11px] text-current">
-            ⌘<span className="ml-0.5">P</span>
-          </kbd>
-        </button>
-      </div>
+            <span
+              aria-hidden="true"
+              className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-current"
+            >
+              <HugeiconsIcon icon={Search01Icon} size={16} color="currentColor" strokeWidth={2} />
+            </span>
+            Search
+            <kbd className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 text-[11px] text-current">
+              ⌘<span className="ml-0.5">P</span>
+            </kbd>
+          </button>
+        </div>
+      )}
 
       <ScrollFade className="min-h-0 flex-1 overflow-y-scroll scrollbar-none">
         <SidebarNavigator />

--- a/apps/desktop/src/components/sidebar/sidebar-navigator.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar-navigator.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useState, type MouseEvent } from "react";
 import { writeText } from "@tauri-apps/plugin-clipboard-manager";
 import { useWorkspace } from "@/hooks/use-workspace";
-import { useSetting } from "@/hooks/use-settings";
+import { useBooleanSetting, useSetting } from "@/hooks/use-settings";
 import {
   usePinnedFiles,
   useRefreshDirectory,
@@ -54,6 +54,7 @@ export function SidebarNavigator({
   const openFile = openFileOverride ?? defaultOpenFile;
   const refreshDirectory = useRefreshDirectory();
   const fileLabelMode = useSetting("appearance.sidebar-file-label");
+  const showRecents = useBooleanSetting("appearance.sidebar-show-recents");
   const pinnedPaths = usePinnedFiles();
   const togglePinnedFile = useTogglePinnedFile();
   const removePinnedFile = useRemovePinnedFile();
@@ -220,7 +221,7 @@ export function SidebarNavigator({
         </SidebarSection>
       )}
 
-      {recentFiles.files.length > 0 && (
+      {showRecents && recentFiles.files.length > 0 && (
         <SidebarSection title="Recents">
           <div role="tree" aria-label="Recents" className="flex flex-col gap-px">
             {recentFiles.files.map((entry) => (

--- a/apps/desktop/src/components/sidebar/sidebar-surface-context-menu.ts
+++ b/apps/desktop/src/components/sidebar/sidebar-surface-context-menu.ts
@@ -1,0 +1,59 @@
+import { Menu } from "@tauri-apps/api/menu/menu";
+import { CheckMenuItem } from "@tauri-apps/api/menu/checkMenuItem";
+
+export type SidebarSurfaceToggleId = "toggle-search" | "toggle-recents";
+
+export interface SidebarSurfaceMenuState {
+  showSearch: boolean;
+  showRecents: boolean;
+  onToggleSearch: (visible: boolean) => void;
+  onToggleRecents: (visible: boolean) => void;
+}
+
+/**
+ * Build the check-item entries for the sidebar surface context menu (shown on
+ * right-clicking empty sidebar space or section headers). Both toggles are
+ * always listed (checked = currently visible) so a hidden one can be re-shown
+ * from the same menu. Pulled out from `showSidebarSurfaceContextMenu` so it
+ * can be unit-tested without the Tauri runtime.
+ */
+export function buildSidebarSurfaceMenuItemsSpec(
+  state: SidebarSurfaceMenuState,
+): Array<{ id: SidebarSurfaceToggleId; text: string; checked: boolean; action: () => void }> {
+  return [
+    {
+      id: "toggle-search",
+      text: "Search",
+      checked: state.showSearch,
+      action: () => state.onToggleSearch(!state.showSearch),
+    },
+    {
+      id: "toggle-recents",
+      text: "Recents",
+      checked: state.showRecents,
+      action: () => state.onToggleRecents(!state.showRecents),
+    },
+  ];
+}
+
+/**
+ * Build a Tauri native menu of check items and pop it up at the cursor.
+ * The menu dismisses through the OS, not via JS.
+ */
+export async function showSidebarSurfaceContextMenu(state: SidebarSurfaceMenuState): Promise<void> {
+  const spec = buildSidebarSurfaceMenuItemsSpec(state);
+
+  const items = await Promise.all(
+    spec.map((entry) =>
+      CheckMenuItem.new({
+        id: entry.id,
+        text: entry.text,
+        checked: entry.checked,
+        action: entry.action,
+      }),
+    ),
+  );
+
+  const menu = await Menu.new({ items });
+  await menu.popup();
+}

--- a/apps/desktop/src/hooks/use-settings.ts
+++ b/apps/desktop/src/hooks/use-settings.ts
@@ -10,6 +10,16 @@ export function useSetting<K extends SettingKey>(key: K): SettingsMap[K] | undef
   return useSettingsStore((state) => state.settings[key as string]) as SettingsMap[K] | undefined;
 }
 
+/** Subscribe to a boolean setting. TypeScript widens JSON imports, so the
+ *  schema-derived `SettingsMap` can't give boolean settings a boolean type —
+ *  narrow at runtime instead and fall back for missing or mistyped values
+ *  (settings hydrate from the backend before first render, so the fallback
+ *  only covers transient gaps). */
+export function useBooleanSetting(key: SettingKey, fallback = true): boolean {
+  const value = useSettingsStore((state) => state.settings[key as string]);
+  return typeof value === "boolean" ? value : fallback;
+}
+
 /** Stable function reference for writing a setting. Function identity in the
  *  store doesn't change, so this hook never causes re-renders. */
 export function useSetSetting() {

--- a/apps/desktop/tests/footer-context-menu.test.ts
+++ b/apps/desktop/tests/footer-context-menu.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test, vi } from "vite-plus/test";
+
+// The Tauri menu modules pull in `@tauri-apps/api/core` at import time, so we
+// stub them up front. The pure helper under test (`buildFooterMenuItemsSpec`)
+// never touches these stubs.
+vi.mock("@tauri-apps/api/menu/menu", () => ({ Menu: { new: vi.fn() } }));
+vi.mock("@tauri-apps/api/menu/checkMenuItem", () => ({ CheckMenuItem: { new: vi.fn() } }));
+
+import {
+  buildFooterMenuItemsSpec,
+  FOOTER_METRICS,
+  type FooterContextMenuState,
+  type FooterMetricSettingKey,
+} from "../src/components/editor-area/footer-context-menu";
+
+function makeState(
+  visibility: Record<FooterMetricSettingKey, boolean>,
+): FooterContextMenuState & { toggles: Array<[FooterMetricSettingKey, boolean]> } {
+  const toggles: Array<[FooterMetricSettingKey, boolean]> = [];
+  return {
+    toggles,
+    visibility,
+    onToggle: (key, visible) => toggles.push([key, visible]),
+  };
+}
+
+describe("buildFooterMenuItemsSpec", () => {
+  test("lists every metric even when hidden, with checked reflecting visibility", () => {
+    const state = makeState({
+      "statusbar.show-words": true,
+      "statusbar.show-characters": false,
+      "statusbar.show-paragraphs": true,
+    });
+
+    const spec = buildFooterMenuItemsSpec(state);
+
+    expect(spec.map((entry) => [entry.id, entry.text, entry.checked])).toEqual([
+      ["statusbar.show-words", "Words", true],
+      ["statusbar.show-characters", "Characters", false],
+      ["statusbar.show-paragraphs", "Paragraphs", true],
+    ]);
+  });
+
+  test("toggling a visible metric requests hiding it, and vice versa", () => {
+    const state = makeState({
+      "statusbar.show-words": true,
+      "statusbar.show-characters": false,
+      "statusbar.show-paragraphs": true,
+    });
+
+    const spec = buildFooterMenuItemsSpec(state);
+    for (const entry of spec) entry.action();
+
+    expect(state.toggles).toEqual([
+      ["statusbar.show-words", false],
+      ["statusbar.show-characters", true],
+      ["statusbar.show-paragraphs", false],
+    ]);
+  });
+
+  test("registry stat keys stay aligned with the DocumentStats shape", () => {
+    expect(FOOTER_METRICS.map((metric) => metric.statKey)).toEqual([
+      "words",
+      "characters",
+      "paragraphs",
+    ]);
+  });
+});

--- a/apps/desktop/tests/sidebar-surface-context-menu.test.ts
+++ b/apps/desktop/tests/sidebar-surface-context-menu.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test, vi } from "vite-plus/test";
+
+// The Tauri menu modules pull in `@tauri-apps/api/core` at import time, so we
+// stub them up front. The pure helper under test
+// (`buildSidebarSurfaceMenuItemsSpec`) never touches these stubs.
+vi.mock("@tauri-apps/api/menu/menu", () => ({ Menu: { new: vi.fn() } }));
+vi.mock("@tauri-apps/api/menu/checkMenuItem", () => ({ CheckMenuItem: { new: vi.fn() } }));
+
+import {
+  buildSidebarSurfaceMenuItemsSpec,
+  type SidebarSurfaceMenuState,
+} from "../src/components/sidebar/sidebar-surface-context-menu";
+
+function makeState(
+  showSearch: boolean,
+  showRecents: boolean,
+): SidebarSurfaceMenuState & { toggles: Array<[string, boolean]> } {
+  const toggles: Array<[string, boolean]> = [];
+  return {
+    toggles,
+    showSearch,
+    showRecents,
+    onToggleSearch: (visible) => toggles.push(["search", visible]),
+    onToggleRecents: (visible) => toggles.push(["recents", visible]),
+  };
+}
+
+describe("buildSidebarSurfaceMenuItemsSpec", () => {
+  test("lists both toggles with checked reflecting visibility", () => {
+    const spec = buildSidebarSurfaceMenuItemsSpec(makeState(true, false));
+
+    expect(spec.map((entry) => [entry.id, entry.text, entry.checked])).toEqual([
+      ["toggle-search", "Search", true],
+      ["toggle-recents", "Recents", false],
+    ]);
+  });
+
+  test("toggling flips the current visibility", () => {
+    const state = makeState(true, false);
+
+    const spec = buildSidebarSurfaceMenuItemsSpec(state);
+    for (const entry of spec) entry.action();
+
+    expect(state.toggles).toEqual([
+      ["search", false],
+      ["recents", true],
+    ]);
+  });
+});


### PR DESCRIPTION
## What

Adds user-controllable visibility for the bottom status bar metrics and two sidebar surfaces ([spec](SPECs/statusbar-sidebar-visibility-spec.md)):

- **Status bar**: right-click the footer for a native check-item menu toggling the word, character, and paragraph counts individually. All three off → the bar is not rendered. Toggles also render in Preferences under a new **Status Bar** section.
- **Sidebar**: right-click empty sidebar space or a section title for a menu toggling the **Search** button and the **Recents** section. Also in Preferences under **Appearance**. File/folder rows keep their existing context menus (they stop propagation).
- Every menu lists hidden items as unchecked entries, so anything hidden can be re-shown from the same menu, not only from Settings.

## How

- Five new boolean settings in `settings.schema.json` (default `true`, global scope) — the schema-driven Preferences panel renders them with no panel code.
- The metric list (setting key ↔ stat key ↔ labels) lives once in `FOOTER_METRICS`; the footer and its menu both iterate it.
- Both menus follow the existing native-menu pattern: pure `build…Spec` functions (unit-tested) + `Menu.popup()`, using `CheckMenuItem`.
- New `useBooleanSetting(key, fallback)` hook: TypeScript widens JSON imports, so the schema-derived `SettingsMap` can't type booleans — the hook narrows at runtime, replacing ad-hoc casts.

## Testing

- Unit tests for both menu spec builders (`footer-context-menu.test.ts`, `sidebar-surface-context-menu.test.ts`); `vp check` / `vp test` (522) and `cargo test` (123) / clippy / fmt all green.
- New e2e spec `visibility-settings.spec.js` drives the built app: default metric set, single-metric hide, all-hidden footer removal, Search hide, Recents hide, and all five toggles rendering in Preferences — 6/6 passing. Native menu popups are OS-level and not WebDriver-drivable; their actions share the `setSetting` write path the spec exercises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGQdp3kFPTEZWHkbHDtCfN