### PR TITLE
Improve sidebar background context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-08-09
+
+- Right-click the sidebar background to create a new Markdown file or folder directly in the workspace root, alongside the existing Search and Recents visibility toggles. Both actions immediately create the next available untitled entry and start safe basename-only inline rename, matching folder-row creation. Newly created empty folders remain visible in Everything while folders containing only non-Markdown content stay filtered.
+
 ## 2026-07-20
 
 - Hide status bar metrics and sidebar sections. Right-click the bottom status bar to toggle the word, character, and paragraph counts individually (the bar disappears when all three are off); right-click the sidebar background or a section title to toggle the Search button and the Recents section. All five toggles also live in Preferences — the metric toggles under a new "Status Bar" section, the sidebar ones under Appearance — and every menu lists hidden items as unchecked entries so they can be re-shown from the same place.

--- a/SPECs/Agent/worksheet-sidebar-empty-space-context-menu.md
+++ b/SPECs/Agent/worksheet-sidebar-empty-space-context-menu.md
@@ -1,0 +1,72 @@
+# Sidebar empty-space context menu worksheet
+
+## References
+
+- TODO: `Sidebar empty-space context menu` in `TODOS.md`
+- Spec: `SPECs/statusbar-sidebar-visibility-spec.md`
+- User request: empty-space right-click creates files/folders at the workspace root and toggles Recents.
+
+## Reviewed
+
+- `AGENTS.md`, `docs/workflows/agent-loop.md`, `docs/workflows/agent-review.md`
+- `docs/consolidation.md`, `docs/react-guidelines.md`
+- `apps/desktop/src/components/sidebar/file-browser.tsx`
+- `apps/desktop/src/components/sidebar/sidebar-surface-context-menu.ts`
+- `apps/desktop/src/components/sidebar/{folder-context-menu,use-file-tree-context-menus}.ts{,x}`
+- `apps/desktop/src/components/command-palette/index.tsx`
+- `apps/desktop/src/{hooks/use-command-palette.ts,stores/ui-store.ts}`
+- Existing surface/folder context-menu and UI-store tests
+
+## Starting state
+
+- Worktree was clean on branch `esquel-glacier`; the branch already contains the Search/Recents visibility menu merged in PR #107.
+- `vp install` completed with the lockfile unchanged.
+- Baseline `vp test`, `cargo test`, `cargo clippy`, and `cargo fmt --check` passed. Rust reported existing warnings only.
+- Baseline `vp check` failed because `apps/desktop/e2e/specs/visibility-settings.spec.js` needs formatting; this is pre-existing on the clean branch and will be formatted in this task so final validation can pass.
+
+## Plan
+
+1. Extend the surface-menu spec with New File, New Folder, and a separator before the existing visibility check items. Keep one ordered menu-spec builder and teach the native renderer to construct normal items, separators, and check items from it.
+2. Route New File through the existing command-palette naming flow. Add a parallel `create-folder` intent so New Folder gets the same focused naming experience. Consolidate both intents behind a typed entry-creation hook/module that validates one visible basename, derives the path beneath its parent directory, owns IPC/refresh/file-opening order, and suppresses stale-workspace UI effects.
+3. Keep the naming flow open with its input and an inline error when creation fails. Use intent-specific File/Folder copy. Make truly empty, non-ignored directories visible in the backend directory listing so a newly created folder does not disappear; continue filtering directories that contain only non-Markdown content.
+4. Extend unit coverage for menu order/dispatch, the mixed native renderer, intent state, root-name validation, and injected file/folder creation sequences. Add Rust coverage for empty-directory visibility. Update user-facing docs/changelog and tracking.
+5. Run targeted tests while implementing, then `vp check`, `vp test`, and the Rust validation suite. Runtime-check the web UI where the native-menu boundary permits it; manually verify native-menu target propagation in the built app.
+
+## Risks and edge cases
+
+- File names retain the existing `.md` normalization; folder names must not gain an extension.
+- Folder creation is workspace-only and should not appear in standalone compact windows.
+- Failed creation must not silently disappear or discard the entered name.
+- Existing file/folder row menus must continue to stop propagation and retain their specialized actions.
+
+## Plan review
+
+- UX, React, and QA reviewers all identified two blocking gaps in the first plan: raw input could escape/nest below the root, and empty folders are filtered from Everything. The revised plan enforces basename-only input and makes truly empty directories visible without exposing directories that contain only non-Markdown content.
+- React/QA requested one consolidated, injectable create pipeline rather than parallel side effects inside `CommandPalette`; the revised plan moves creation ownership to a focused hook/module and tests success/failure sequencing.
+- QA requested native-renderer coverage in addition to the pure menu spec and an explicit propagation checklist; both are now part of verification.
+- UX requested intent-specific copy and retry behavior; failures will remain in the naming flow with the input intact.
+
+## Implementation and results
+
+- The native sidebar-surface menu now renders New File, New Folder, a separator, then the existing Search and Recents check items from one discriminated spec.
+- The root actions immediately create the next available `Untitled.md` or `Untitled Folder`, refresh Everything, and start inline rename. `sidebar-entry-creation.ts` shares unique-name and creation behavior with folder-row menus and suppresses root follow-up effects after a workspace switch.
+- The existing command-palette New File flow uses `entry-creation.ts` for basename validation, Markdown extension normalization, and workspace/standalone create sequencing. Once creation succeeds, refresh/open failures close the naming flow and surface separately so retry cannot collide with the already-created entry. `refreshDirectory` also drops responses that complete after a workspace switch.
+- `read_directory_impl` now includes truly empty directories while retaining the filter for directories containing only non-Markdown content, so a new folder is immediately visible.
+- Targeted TypeScript tests cover menu order/dispatch/native construction, root unique-name creation and refresh/rename sequencing, safe command-palette path planning, async file creation and failure paths, UI-store intents, and stale refresh responses. Rust tests cover empty-directory listing with and without the ready index.
+- Runtime: a release-style E2E build verified both native root actions create on disk and enter inline rename. The macOS popup requires physical mouse injection and proved nondeterministic under WebDriver, so the flaky harness is not part of the committed suite; deterministic tests cover the shared coordinator and native-menu construction boundary.
+- Runtime also exposed pre-existing Radix dialog title/description warnings. Recorded as a separate backlog item rather than expanding this task.
+- Final validation: `vp check` (one pre-existing `wdio.conf.js` warning), `vp test` (39 files / 555 tests), `cargo test` (123 tests), `cargo clippy` (pre-existing warnings only), and `cargo fmt --check` all passed.
+
+## Implementation review
+
+- Standards review found three P2 ownership/error issues and two P3 modeling/name concerns. The follow-up funnels workspace and compact creation through `useCreateEntry`, keys create-error state by intent without a component effect, propagates empty-directory read failures, derives paths from parent+name, and uses general entry/parent terminology.
+- Spec review found one P2 false-retry path when creation succeeded but refresh failed. The pipeline now rejects only creation failures; refresh/open failures are returned as follow-up failures, the palette closes, files still attempt to open, and the user gets a separate warning instead of an AlreadyExists retry trap.
+- A second standards pass found that a slow create request could update a newly reopened palette. Palette sessions now invalidate stale completions, with deferred success and failure tests covering both cases.
+- Final correction review found no remaining P0-P2 issues after root and nested creation were moved to the shared immediate-create coordinator, workspace identity checks gained an epoch, and nested reveal became an idempotent guarded store action.
+
+## PR feedback correction
+
+- PR feedback showed that routing the root actions through a second command-palette naming step did not feel like creation. The final interaction now matches folder-row context menus: choosing New File or New Folder immediately creates the next available `Untitled.md` or `Untitled Folder`, refreshes Everything, and starts inline rename.
+- `sidebar-entry-creation.ts` is the shared unique-name/create/reveal/rename boundary for root and folder-row actions. `use-root-sidebar-entry-creation.ts` owns root IPC and error presentation; both root and nested follow-up work check the active workspace identity before touching the tree. Nested creation uses an idempotent `ensureDirectoryExpanded` store action, whose root/epoch guard prevents a delayed directory read from expanding or overwriting a newer workspace.
+- A release-style E2E build created both root entry kinds and entered inline rename through the native popup. The native popup is not exposed reliably to WebDriver, so the committed deterministic regression tests cover the shared creation coordinator, unique-name sequencing, refresh/rename order, and workspace-switch suppression; the flaky OS-coordinate harness was removed.
+- Final review additionally caught trailing-root path joins and unsafe inline rename input. Separator-aware joins now keep `/Untitled.md` canonical, and inline rename shares the same basename-only validation as command-palette creation so traversal, separators, and hidden names remain in the rename flow instead of escaping the workspace or disappearing.

--- a/SPECs/statusbar-sidebar-visibility-spec.md
+++ b/SPECs/statusbar-sidebar-visibility-spec.md
@@ -41,9 +41,19 @@ No settings-panel code changes: the generic boolean control renders them.
   (regardless of recent files existing).
 - Right-clicking the sidebar surface — empty space, section headers
   (including the Recents title), or the search button — opens a native
-  context menu with two check items, Search and Recents. File and folder rows
-  keep their existing menus (they stop propagation, so the surface menu never
-  fires for them).
+  context menu with root-level **New File** and **New Folder** actions,
+  followed by the Search and Recents check items. Each create action
+  immediately creates the next available `Untitled.md` or `Untitled Folder`
+  directly under the current workspace root, refreshes Everything, and starts
+  inline rename. File and folder rows keep their existing menus (they stop
+  propagation, so the surface menu never fires for them).
+- Inline rename accepts one visible basename only. Path separators, traversal
+  names, and leading-dot names remain in the rename flow with an explicit
+  validation error instead of moving the entry outside the workspace or
+  hiding it from the tree.
+- Newly created empty folders remain visible in Everything so the action has
+  an immediately usable result. Directories containing only non-Markdown
+  content remain filtered as before.
 - Hiding Recents does not clear recents metadata; re-enabling restores the
   section as it was.
 
@@ -57,7 +67,9 @@ narrows at runtime, replacing ad-hoc `as boolean | undefined` casts.
 ## Verification
 
 - Unit tests for both menu spec builders (`footer-context-menu.test.ts`,
-  `sidebar-surface-context-menu.test.ts`).
+  `sidebar-surface-context-menu.test.ts`), including surface-menu action order
+  and handler dispatch; the mixed native item renderer; root-name validation;
+  and the file/folder create, refresh, open, and failure sequences.
 - Runtime: `e2e/specs/visibility-settings.spec.js` drives the built app —
   default metric set, single-metric hide, all-hidden footer removal, Search
   button hide, Recents section hide. Native menu popups themselves are

--- a/TODOS.md
+++ b/TODOS.md
@@ -6,6 +6,7 @@
 
 ## Done
 
+- Sidebar empty-space context menu: [`SPECs/statusbar-sidebar-visibility-spec.md`](SPECs/statusbar-sidebar-visibility-spec.md) — root New File and New Folder actions immediately create an available untitled entry and start inline rename; Search and Recents remain checked visibility items.
 - Status bar + sidebar visibility toggles: [`SPECs/statusbar-sidebar-visibility-spec.md`](SPECs/statusbar-sidebar-visibility-spec.md) — hide/show each footer metric (words, characters, paragraphs) and the sidebar Search button and Recents section, via five new boolean settings and native right-click check-item menus on the footer and sidebar surface.
 - Select-only Typography font controls: [`SPECs/font-select-spec.md`](SPECs/font-select-spec.md) — replace the AppKit Font panel and editable stack field with a standard installed-family `<select>` matching the other settings controls; default UI/editor to SF Pro and the renamed Code font setting to SF Mono.
 - Native macOS font picker + Typography settings: [`SPECs/native-font-picker-spec.md`](SPECs/native-font-picker-spec.md) — replace the custom installed-font combobox with AppKit's system Font panel, route selections back to the originating settings row/window, preserve editable CSS fallback stacks, and rename the settings section from Fonts to Typography.
@@ -72,6 +73,7 @@ Previously-triaged work organized by phase. Pull into `Up Next` as capacity open
 #### Visual and media polish
 
 - [ ] Inline media preview: [`SPECs/inline-media-preview-spec.md`](SPECs/inline-media-preview-spec.md)
+- [ ] Command palette dialog accessibility metadata — add the required dialog title/description wiring so opening the palette no longer emits Radix accessibility warnings at runtime.
 
 #### Architectural bets
 

--- a/apps/desktop/e2e/specs/visibility-settings.spec.js
+++ b/apps/desktop/e2e/specs/visibility-settings.spec.js
@@ -126,14 +126,14 @@ describe("status bar and sidebar visibility settings", function () {
     await $("[data-settings-panel]").waitForExist({ timeout: 5_000 });
 
     const rows = await browser.execute(() => {
-      const labels = Array.from(
-        document.querySelectorAll("[data-settings-panel] section"),
-      ).flatMap((section) => {
-        const heading = section.querySelector("h2")?.textContent ?? "";
-        return Array.from(section.querySelectorAll("div.text-\\[13px\\].font-medium")).map(
-          (label) => `${heading}: ${label.textContent}`,
-        );
-      });
+      const labels = Array.from(document.querySelectorAll("[data-settings-panel] section")).flatMap(
+        (section) => {
+          const heading = section.querySelector("h2")?.textContent ?? "";
+          return Array.from(section.querySelectorAll("div.text-\\[13px\\].font-medium")).map(
+            (label) => `${heading}: ${label.textContent}`,
+          );
+        },
+      );
       return labels;
     });
     for (const expected of [

--- a/apps/desktop/src-tauri/src/commands/fs.rs
+++ b/apps/desktop/src-tauri/src/commands/fs.rs
@@ -163,6 +163,10 @@ fn dir_contains_markdown(path: &Path, state: Option<&WorkspaceState>) -> bool {
     dir_contains_markdown_recursive(path, None)
 }
 
+fn dir_is_empty(path: &Path) -> Result<bool, AppError> {
+    Ok(fs::read_dir(path)?.next().is_none())
+}
+
 pub fn read_directory_impl(
     path: &str,
     state: Option<&WorkspaceState>,
@@ -204,7 +208,7 @@ pub fn read_directory_impl(
         }
 
         if file_type.is_dir() {
-            if dir_contains_markdown(&entry_path, state) {
+            if dir_contains_markdown(&entry_path, state) || dir_is_empty(&entry_path)? {
                 dirs.push(DirEntry {
                     name,
                     path: entry_path.to_string_lossy().to_string(),
@@ -530,6 +534,8 @@ mod tests {
         // Create a subdirectory without markdown (should be filtered)
         fs::create_dir(dir.path().join("empty")).unwrap();
         fs::write(dir.path().join("empty").join("data.txt"), "data").unwrap();
+        // Truly empty directories stay visible so they can be populated.
+        fs::create_dir(dir.path().join("truly-empty")).unwrap();
         dir
     }
 
@@ -538,17 +544,19 @@ mod tests {
         let dir = setup_test_dir();
         let result = read_directory_impl(&dir.path().to_string_lossy(), None).unwrap();
 
-        // First entry should be the dir (notes), then files
+        // Directories come first, then files.
         assert!(result[0].is_dir);
         assert_eq!(result[0].name, "notes");
         assert!(result[0].title.is_none());
-        // Remaining should be files, sorted alphabetically
-        assert!(!result[1].is_dir);
-        assert_eq!(result[1].name, "hello.md");
-        assert_eq!(result[1].title.as_deref(), Some("Hello"));
+        assert!(result[1].is_dir);
+        assert_eq!(result[1].name, "truly-empty");
+        // Remaining files are sorted alphabetically.
         assert!(!result[2].is_dir);
-        assert_eq!(result[2].name, "world.md");
-        assert_eq!(result[2].title.as_deref(), Some("World"));
+        assert_eq!(result[2].name, "hello.md");
+        assert_eq!(result[2].title.as_deref(), Some("Hello"));
+        assert!(!result[3].is_dir);
+        assert_eq!(result[3].name, "world.md");
+        assert_eq!(result[3].title.as_deref(), Some("World"));
     }
 
     #[test]
@@ -556,9 +564,9 @@ mod tests {
         let dir = setup_test_dir();
         let result = read_directory_impl(&dir.path().to_string_lossy(), None).unwrap();
 
-        // Should have: notes/ dir, hello.md, world.md (3 total)
-        // NOT: readme.txt, empty/ dir
-        assert_eq!(result.len(), 3);
+        // Should have: notes/ dir, truly-empty/ dir, hello.md, world.md (4 total)
+        // NOT: readme.txt, empty/ dir (contains only non-Markdown content)
+        assert_eq!(result.len(), 4);
         for entry in &result {
             assert!(entry.is_dir || entry.is_markdown);
         }
@@ -578,9 +586,11 @@ mod tests {
 
         let result = read_directory_impl(&dir.path().to_string_lossy(), Some(&state)).unwrap();
 
-        assert_eq!(result.len(), 3);
+        assert_eq!(result.len(), 4);
         assert!(result[0].is_dir);
         assert_eq!(result[0].name, "notes");
+        assert!(result[1].is_dir);
+        assert_eq!(result[1].name, "truly-empty");
     }
 
     fn indexed_file(root: &Path, name: &str, modified_at: u64) -> crate::state::IndexedFile {

--- a/apps/desktop/src/components/command-palette/index.tsx
+++ b/apps/desktop/src/components/command-palette/index.tsx
@@ -12,6 +12,7 @@ import {
   useCloseCommandPalette,
   useCommandPaletteIntent,
   useCommandPaletteSearch,
+  useCommandPaletteSession,
   useIsCommandPaletteOpen,
   useOpenCommandPalette,
   useSetCommandPaletteSearch,
@@ -31,16 +32,14 @@ import { useTheme } from "@/hooks/use-theme";
 import { useFuzzySearch } from "./use-fuzzy-search";
 import { useGlobalRecentFiles } from "@/hooks/use-global-recent-files";
 import { openStandaloneFile } from "@/hooks/use-open-drop";
+import { useCreateEntry } from "@/hooks/use-create-entry";
+import { getCommandPaletteSession } from "@/hooks/command-palette-api";
+import { runCreateRequest } from "./run-create-request";
 import { settingsKind } from "@/components/editor-area/page-kinds/settings";
 import { getFileName, getFileStem, getParentDir } from "@/lib/paths";
+import { getEntryCreationPath, planEntryCreation } from "@/lib/entry-creation";
 import * as tauri from "@/lib/tauri";
 import type { RecentFile } from "@/lib/tauri";
-
-function toCreatePath(root: string, rawName: string) {
-  const trimmed = rawName.trim();
-  const fileName = trimmed.endsWith(".md") ? trimmed : `${trimmed}.md`;
-  return `${root}/${fileName}`;
-}
 
 function matchesSearch(text: string, q: string) {
   return text.toLowerCase().includes(q.toLowerCase());
@@ -65,6 +64,7 @@ export function CommandPalette() {
   const openCommandPalette = useOpenCommandPalette();
   const intent = useCommandPaletteIntent();
   const search = useCommandPaletteSearch();
+  const paletteSession = useCommandPaletteSession();
   const setSearch = useSetCommandPaletteSearch();
   const { toggleSidebar } = useSidebar();
   const { root, isIndexing, openWorkspace, closeWorkspace } = useWorkspace();
@@ -77,8 +77,10 @@ export function CommandPalette() {
   const { toggleTheme } = useTheme();
   const openSettingsTab = useOpenSettingsTab();
   const isCompactFileMode = useIsCompactFileMode();
+  const createEntry = useCreateEntry();
 
-  const isCreateIntent = intent === "create-file";
+  const createKind = intent === "create-file" ? "file" : null;
+  const isCreateIntent = createKind !== null;
   const trimmedSearch = search.trim();
   const fileQuery = isCreateIntent ? "" : search;
   // Standalone compact windows have no workspace index — search filters the
@@ -87,8 +89,16 @@ export function CommandPalette() {
   const { files: globalRecents } = useGlobalRecentFiles(30, isOpen && isCompactFileMode);
   // In standalone mode new files are created next to the active file.
   const createBaseDir = root ?? (activeFilePath ? getParentDir(activeFilePath) : null);
-  const createPath =
-    createBaseDir && trimmedSearch ? toCreatePath(createBaseDir, trimmedSearch) : null;
+  const createPlan =
+    createBaseDir && createKind ? planEntryCreation(createBaseDir, search, createKind) : null;
+  const createTarget = createPlan?.ok ? createPlan.target : null;
+  const createPath = createTarget ? getEntryCreationPath(createTarget) : null;
+  const [createErrorState, setCreateErrorState] = useState<{
+    session: number;
+    message: string;
+  } | null>(null);
+  const createError =
+    createErrorState?.session === paletteSession ? createErrorState.message : null;
 
   function handleSelect(path: string) {
     void (isCompactFileMode ? openStandaloneFile(path) : openFile(path));
@@ -96,17 +106,42 @@ export function CommandPalette() {
   }
 
   function handleCreate() {
-    if (!createPath) return;
+    if (!createTarget) return;
 
-    close();
-    void (async () => {
-      await tauri.createFile(createPath);
-      if (isCompactFileMode) {
-        await openStandaloneFile(createPath);
-      } else {
-        await openFile(createPath);
-      }
-    })();
+    const requestSession = paletteSession;
+    setCreateErrorState(null);
+    void runCreateRequest({
+      create: () => createEntry(createTarget, isCompactFileMode ? "standalone" : "workspace"),
+      isCurrent: () => getCommandPaletteSession() === requestSession,
+      onCreated: (result) => {
+        close();
+
+        if (result.followUpFailures.length > 0) {
+          const failedSteps = [
+            result.followUpFailures.some((failure) => failure.step === "refresh")
+              ? "refresh the sidebar"
+              : null,
+            result.followUpFailures.some((failure) => failure.step === "open")
+              ? "open the file"
+              : null,
+          ].filter((step): step is string => Boolean(step));
+          const details = result.followUpFailures
+            .map((failure) =>
+              failure.error instanceof Error ? failure.error.message : String(failure.error),
+            )
+            .join("\n");
+          window.alert(
+            `Created "${createTarget.name}", but Writer could not ${failedSteps.join(" or ")}.\n${details}`,
+          );
+        }
+      },
+      onCreationError: (error) => {
+        setCreateErrorState({
+          session: requestSession,
+          message: error instanceof Error ? error.message : String(error),
+        });
+      },
+    });
   }
 
   async function handleOpenWorkspace() {
@@ -222,8 +257,9 @@ export function CommandPalette() {
     : trimmedSearch
       ? commands.filter((c) => matchesSearch(c.label, trimmedSearch))
       : commands;
-  const firstValue =
-    visibleCommands[0]?.id ?? visibleFiles[0]?.path ?? visibleRecents[0]?.path ?? "";
+  const firstValue = isCreateIntent
+    ? (createPath ?? "")
+    : (visibleCommands[0]?.id ?? visibleFiles[0]?.path ?? visibleRecents[0]?.path ?? "");
 
   const listRef = useRef<HTMLDivElement>(null);
   const [selectedValue, setSelectedValue] = useState(firstValue);
@@ -239,7 +275,8 @@ export function CommandPalette() {
   }, [search, intent, firstValue]);
   /* eslint-enable react-doctor/no-derived-state */
 
-  const placeholder = isCreateIntent ? "Create a new note..." : "Search...";
+  const createLabel = "file";
+  const placeholder = isCreateIntent ? `Create a new ${createLabel}...` : "Search...";
 
   return (
     <CommandDialog
@@ -252,13 +289,23 @@ export function CommandPalette() {
       value={selectedValue}
       onValueChange={setSelectedValue}
     >
-      <CommandInput placeholder={placeholder} value={search} onValueChange={setSearch} />
+      <CommandInput
+        placeholder={placeholder}
+        value={search}
+        onValueChange={(value) => {
+          setCreateErrorState(null);
+          setSearch(value);
+        }}
+      />
       <CommandList ref={listRef}>
         {isCreateIntent ? (
           <>
-            {!trimmedSearch && <CommandEmpty>Type a note name to create it.</CommandEmpty>}
-            {createPath && (
-              <CommandGroup heading="Create note">
+            {createError && <CommandEmpty>{createError}</CommandEmpty>}
+            {!createError && createPlan && !createPlan.ok && (
+              <CommandEmpty>{createPlan.error}</CommandEmpty>
+            )}
+            {!createError && createTarget && createPath && (
+              <CommandGroup heading={`Create ${createLabel}`}>
                 <CommandItem value={createPath} onSelect={handleCreate}>
                   Create: {getFileName(createPath)}
                 </CommandItem>

--- a/apps/desktop/src/components/command-palette/run-create-request.ts
+++ b/apps/desktop/src/components/command-palette/run-create-request.ts
@@ -1,0 +1,25 @@
+interface RunCreateRequestOptions<TResult> {
+  create: () => Promise<TResult>;
+  isCurrent: () => boolean;
+  onCreated: (result: TResult) => void;
+  onCreationError: (error: unknown) => void;
+}
+
+/**
+ * Complete one palette creation request only if its opening session is still
+ * current. A dismissed-and-reopened palette belongs to a new session and must
+ * not be closed or receive errors from an older IPC request.
+ */
+export async function runCreateRequest<TResult>({
+  create,
+  isCurrent,
+  onCreated,
+  onCreationError,
+}: RunCreateRequestOptions<TResult>): Promise<void> {
+  try {
+    const result = await create();
+    if (isCurrent()) onCreated(result);
+  } catch (error) {
+    if (isCurrent()) onCreationError(error);
+  }
+}

--- a/apps/desktop/src/components/sidebar/file-browser.tsx
+++ b/apps/desktop/src/components/sidebar/file-browser.tsx
@@ -1,4 +1,4 @@
-import type { MouseEvent } from "react";
+import { useState, type MouseEvent } from "react";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { Search01Icon } from "@hugeicons/core-free-icons";
 import { useOpenCommandPalette } from "@/hooks/use-command-palette";
@@ -6,12 +6,15 @@ import { useBooleanSetting, useSetSetting } from "@/hooks/use-settings";
 import { ScrollFade } from "@/components/scroll-fade";
 import { SidebarNavigator } from "./sidebar-navigator";
 import { showSidebarSurfaceContextMenu } from "./sidebar-surface-context-menu";
+import { useRootSidebarEntryCreation } from "./use-root-sidebar-entry-creation";
 
 export function FileBrowser() {
   const openCommandPalette = useOpenCommandPalette();
   const setSetting = useSetSetting();
   const showSearch = useBooleanSetting("appearance.sidebar-show-search");
   const showRecents = useBooleanSetting("appearance.sidebar-show-recents");
+  const [renamingPath, setRenamingPath] = useState<string | null>(null);
+  const createRootEntry = useRootSidebarEntryCreation(setRenamingPath);
 
   // File and folder rows stop propagation from their own context menus, so
   // this only fires for the sidebar surface: empty space, section headers,
@@ -21,6 +24,8 @@ export function FileBrowser() {
     void showSidebarSurfaceContextMenu({
       showSearch,
       showRecents,
+      onNewFile: () => createRootEntry("file"),
+      onNewFolder: () => createRootEntry("folder"),
       onToggleSearch: (visible) => {
         void setSetting("appearance.sidebar-show-search", visible);
       },
@@ -61,7 +66,7 @@ export function FileBrowser() {
       )}
 
       <ScrollFade className="min-h-0 flex-1 overflow-y-scroll scrollbar-none">
-        <SidebarNavigator />
+        <SidebarNavigator renamingPath={renamingPath} setRenamingPath={setRenamingPath} />
       </ScrollFade>
     </div>
   );

--- a/apps/desktop/src/components/sidebar/file-tree.tsx
+++ b/apps/desktop/src/components/sidebar/file-tree.tsx
@@ -10,6 +10,7 @@ import {
 import { createPortal } from "react-dom";
 import {
   useDirectoryCache,
+  useEnsureDirectoryExpanded,
   useExpandedDirs,
   useInvalidatePath,
   usePinnedFiles,
@@ -23,6 +24,7 @@ import { useOpenFile } from "@/hooks/use-tabs";
 import { useSetting } from "@/hooks/use-settings";
 import { useWorkspaceRoot } from "@/hooks/use-workspace";
 import * as tauri from "@/lib/tauri";
+import { validateEntryName } from "@/lib/entry-creation";
 import { getFileStem, getParentDir } from "@/lib/paths";
 import { useMoveEntry } from "./use-move-entry";
 import { useTreeDrag } from "./use-tree-drag";
@@ -37,6 +39,8 @@ interface FileTreeProps {
   rootPath: string;
   openFile?: (path: string) => Promise<void>;
   enableContextMenus?: boolean;
+  renamingPath: string | null;
+  setRenamingPath: (path: string | null) => void;
 }
 
 function getExtension(name: string): string {
@@ -49,6 +53,8 @@ export function FileTree({
   rootPath,
   openFile: openFileOverride,
   enableContextMenus = true,
+  renamingPath,
+  setRenamingPath,
 }: FileTreeProps) {
   const directoryCache = useDirectoryCache();
   const expandedDirs = useExpandedDirs();
@@ -56,6 +62,7 @@ export function FileTree({
   const defaultOpenFile = useOpenFile();
   const openFile = openFileOverride ?? defaultOpenFile;
   const refreshDirectory = useRefreshDirectory();
+  const ensureDirectoryExpanded = useEnsureDirectoryExpanded();
   const invalidatePath = useInvalidatePath();
   const { applyPathChange, moveEntry } = useMoveEntry();
   const removePinnedFile = useRemovePinnedFile();
@@ -64,7 +71,6 @@ export function FileTree({
   const togglePinnedFile = useTogglePinnedFile();
   const workspaceRoot = useWorkspaceRoot();
   const fileLabelMode = useSetting("appearance.sidebar-file-label");
-  const [renamingPath, setRenamingPath] = useState<string | null>(null);
   const [selectedPaths, setSelectedPaths] = useState<Set<string>>(new Set());
   // Anchor for shift range-select. Only read inside handlers, never rendered,
   // so a ref avoids re-renders that a useState would trigger on every change.
@@ -186,10 +192,19 @@ export function FileTree({
 
   const handleRenameSubmit = useCallback(
     async (entry: DirEntry, nextValue: string) => {
-      setRenamingPath(null);
-
       const trimmed = nextValue.trim();
-      if (!trimmed) return;
+      if (!trimmed) {
+        setRenamingPath(null);
+        return;
+      }
+
+      const kind = entry.is_dir ? "folder" : "file";
+      const validation = validateEntryName(trimmed, kind);
+      if (!validation.ok) {
+        window.alert(validation.error);
+        return;
+      }
+      setRenamingPath(null);
 
       const parent = getParentDir(entry.path);
       let newPath: string;
@@ -234,8 +249,7 @@ export function FileTree({
       togglePinnedFile,
       removePinnedFile,
       removePinnedFilesWithPrefix,
-      expandedDirs,
-      toggleDirectory,
+      ensureDirectoryExpanded,
       refreshDirectory,
       invalidatePath,
       setRenamingPath,

--- a/apps/desktop/src/components/sidebar/sidebar-entry-creation.ts
+++ b/apps/desktop/src/components/sidebar/sidebar-entry-creation.ts
@@ -1,0 +1,74 @@
+export type SidebarEntryKind = "file" | "folder";
+
+interface SidebarEntryCreationDependencies {
+  fileExists: (path: string) => Promise<boolean>;
+  createFile: (path: string) => Promise<unknown>;
+  createFolder: (path: string) => Promise<unknown>;
+  isCurrent: () => boolean;
+  revealEntry: (path: string) => Promise<unknown>;
+  beginRenaming: (path: string) => void;
+}
+
+interface SidebarEntryCreationResult {
+  path: string;
+  followUpFailure?: unknown;
+}
+
+export function getSidebarCreationErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  return JSON.stringify(error) ?? "Unknown error";
+}
+
+export async function resolveUniqueEntryPath(
+  parentPath: string,
+  baseName: string,
+  extension: string,
+  fileExists: (path: string) => Promise<boolean>,
+): Promise<string> {
+  const separator = /[\\/]$/.test(parentPath) ? "" : "/";
+  const first = `${parentPath}${separator}${baseName}${extension}`;
+  if (!(await fileExists(first))) return first;
+
+  for (let n = 2; n < 1000; n += 1) {
+    const candidate = `${parentPath}${separator}${baseName} ${n}${extension}`;
+    if (!(await fileExists(candidate))) return candidate;
+  }
+
+  throw new Error(`Could not find an available name for "${baseName}" in ${parentPath}`);
+}
+
+/**
+ * Create the next available untitled entry, reveal it in the current tree,
+ * and begin inline rename. Creation failures reject; a post-create reveal
+ * failure is returned separately so callers never report a successful write
+ * as a failed creation.
+ */
+export async function createUntitledSidebarEntry(
+  parentPath: string,
+  kind: SidebarEntryKind,
+  dependencies: SidebarEntryCreationDependencies,
+): Promise<SidebarEntryCreationResult> {
+  const isFile = kind === "file";
+  const path = await resolveUniqueEntryPath(
+    parentPath,
+    isFile ? "Untitled" : "Untitled Folder",
+    isFile ? ".md" : "",
+    dependencies.fileExists,
+  );
+
+  if (isFile) {
+    await dependencies.createFile(path);
+  } else {
+    await dependencies.createFolder(path);
+  }
+  if (!dependencies.isCurrent()) return { path };
+
+  try {
+    await dependencies.revealEntry(path);
+  } catch (followUpFailure) {
+    return dependencies.isCurrent() ? { path, followUpFailure } : { path };
+  }
+  if (dependencies.isCurrent()) dependencies.beginRenaming(path);
+  return { path };
+}

--- a/apps/desktop/src/components/sidebar/sidebar-navigator.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar-navigator.tsx
@@ -35,6 +35,8 @@ interface SidebarNavigatorProps {
   enableContextMenus?: boolean;
   onOpenFileComplete?: () => void;
   className?: string;
+  renamingPath: string | null;
+  setRenamingPath: (path: string | null) => void;
 }
 
 function getExtension(name: string): string {
@@ -48,6 +50,8 @@ export function SidebarNavigator({
   enableContextMenus = true,
   onOpenFileComplete,
   className = "flex flex-col gap-4 py-2",
+  renamingPath,
+  setRenamingPath,
 }: SidebarNavigatorProps) {
   const { root } = useWorkspace();
   const defaultOpenFile = useOpenFile();
@@ -252,6 +256,8 @@ export function SidebarNavigator({
           rootPath={root}
           openFile={openFileAndComplete}
           enableContextMenus={enableContextMenus}
+          renamingPath={renamingPath}
+          setRenamingPath={setRenamingPath}
         />
       </SidebarSection>
     </div>

--- a/apps/desktop/src/components/sidebar/sidebar-surface-context-menu.ts
+++ b/apps/desktop/src/components/sidebar/sidebar-surface-context-menu.ts
@@ -1,33 +1,55 @@
 import { Menu } from "@tauri-apps/api/menu/menu";
 import { CheckMenuItem } from "@tauri-apps/api/menu/checkMenuItem";
+import { MenuItem } from "@tauri-apps/api/menu/menuItem";
+import { PredefinedMenuItem } from "@tauri-apps/api/menu/predefinedMenuItem";
 
 export type SidebarSurfaceToggleId = "toggle-search" | "toggle-recents";
+export type SidebarSurfaceActionId = "new-file" | "new-folder";
+
+export type SidebarSurfaceMenuItemSpec =
+  | { kind: "item"; id: SidebarSurfaceActionId; text: string; action: () => void }
+  | {
+      kind: "check";
+      id: SidebarSurfaceToggleId;
+      text: string;
+      checked: boolean;
+      action: () => void;
+    }
+  | { kind: "separator" };
 
 export interface SidebarSurfaceMenuState {
   showSearch: boolean;
   showRecents: boolean;
+  onNewFile: () => void;
+  onNewFolder: () => void;
   onToggleSearch: (visible: boolean) => void;
   onToggleRecents: (visible: boolean) => void;
 }
 
 /**
  * Build the check-item entries for the sidebar surface context menu (shown on
- * right-clicking empty sidebar space or section headers). Both toggles are
- * always listed (checked = currently visible) so a hidden one can be re-shown
- * from the same menu. Pulled out from `showSidebarSurfaceContextMenu` so it
- * can be unit-tested without the Tauri runtime.
+ * right-clicking empty sidebar space or section headers). Root creation comes
+ * first, then both toggles are always listed (checked = currently visible) so
+ * a hidden item can be re-shown from the same menu. Pulled out from
+ * `showSidebarSurfaceContextMenu` so it can be unit-tested without the Tauri
+ * runtime.
  */
 export function buildSidebarSurfaceMenuItemsSpec(
   state: SidebarSurfaceMenuState,
-): Array<{ id: SidebarSurfaceToggleId; text: string; checked: boolean; action: () => void }> {
+): SidebarSurfaceMenuItemSpec[] {
   return [
+    { kind: "item", id: "new-file", text: "New File", action: state.onNewFile },
+    { kind: "item", id: "new-folder", text: "New Folder", action: state.onNewFolder },
+    { kind: "separator" },
     {
+      kind: "check",
       id: "toggle-search",
       text: "Search",
       checked: state.showSearch,
       action: () => state.onToggleSearch(!state.showSearch),
     },
     {
+      kind: "check",
       id: "toggle-recents",
       text: "Recents",
       checked: state.showRecents,
@@ -44,14 +66,20 @@ export async function showSidebarSurfaceContextMenu(state: SidebarSurfaceMenuSta
   const spec = buildSidebarSurfaceMenuItemsSpec(state);
 
   const items = await Promise.all(
-    spec.map((entry) =>
-      CheckMenuItem.new({
-        id: entry.id,
-        text: entry.text,
-        checked: entry.checked,
-        action: entry.action,
-      }),
-    ),
+    spec.map((entry) => {
+      if (entry.kind === "separator") {
+        return PredefinedMenuItem.new({ item: "Separator" });
+      }
+      if (entry.kind === "check") {
+        return CheckMenuItem.new({
+          id: entry.id,
+          text: entry.text,
+          checked: entry.checked,
+          action: entry.action,
+        });
+      }
+      return MenuItem.new({ id: entry.id, text: entry.text, action: entry.action });
+    }),
   );
 
   const menu = await Menu.new({ items });

--- a/apps/desktop/src/components/sidebar/use-file-tree-context-menus.ts
+++ b/apps/desktop/src/components/sidebar/use-file-tree-context-menus.ts
@@ -7,29 +7,19 @@ import {
   removePathReferences,
   removePathsWithPrefix,
 } from "@/hooks/editor-api";
+import { getWorkspaceEpoch, getWorkspaceRoot } from "@/hooks/workspace-api";
 import * as tauri from "@/lib/tauri";
-import { getParentDir, getRelativePath } from "@/lib/paths";
+import { getFileName, getParentDir, getRelativePath } from "@/lib/paths";
 import { duplicateFile } from "./duplicate-file";
+import {
+  createUntitledSidebarEntry,
+  getSidebarCreationErrorMessage,
+  type SidebarEntryKind,
+} from "./sidebar-entry-creation";
 import { showFileContextMenu } from "./file-context-menu";
 import { showFolderContextMenu } from "./folder-context-menu";
 import { showBulkContextMenu } from "./bulk-context-menu";
 import type { DirEntry } from "@/types/fs";
-
-async function resolveUniqueName(
-  parentPath: string,
-  baseName: string,
-  extension: string,
-): Promise<string> {
-  const first = `${parentPath}/${baseName}${extension}`;
-  if (!(await tauri.fileExists(first))) return first;
-
-  for (let n = 2; n < 1000; n += 1) {
-    const candidate = `${parentPath}/${baseName} ${n}${extension}`;
-    if (!(await tauri.fileExists(candidate))) return candidate;
-  }
-
-  throw new Error(`Could not find an available name for "${baseName}" in ${parentPath}`);
-}
 
 interface UseFileTreeContextMenusArgs {
   openFile: (path: string) => Promise<void>;
@@ -38,8 +28,7 @@ interface UseFileTreeContextMenusArgs {
   togglePinnedFile: (path: string) => void;
   removePinnedFile: (path: string) => void;
   removePinnedFilesWithPrefix: (prefix: string) => void;
-  expandedDirs: Set<string>;
-  toggleDirectory: (path: string) => Promise<void>;
+  ensureDirectoryExpanded: (path: string) => Promise<void>;
   refreshDirectory: (path: string) => Promise<void>;
   invalidatePath: (path: string) => void;
   setRenamingPath: (path: string | null) => void;
@@ -53,8 +42,7 @@ export function useFileTreeContextMenus({
   togglePinnedFile,
   removePinnedFile,
   removePinnedFilesWithPrefix,
-  expandedDirs,
-  toggleDirectory,
+  ensureDirectoryExpanded,
   refreshDirectory,
   invalidatePath,
   setRenamingPath,
@@ -143,6 +131,39 @@ export function useFileTreeContextMenus({
     ],
   );
 
+  const createEntryInFolder = useCallback(
+    (entry: DirEntry, kind: SidebarEntryKind) => {
+      const activeRoot = workspaceRoot;
+      if (!activeRoot) return;
+      const activeEpoch = getWorkspaceEpoch();
+      const isCurrent = () =>
+        getWorkspaceRoot() === activeRoot && getWorkspaceEpoch() === activeEpoch;
+
+      void (async () => {
+        try {
+          const result = await createUntitledSidebarEntry(entry.path, kind, {
+            fileExists: tauri.fileExists,
+            createFile: tauri.createFile,
+            createFolder: tauri.createDirectory,
+            isCurrent,
+            revealEntry: () => ensureDirectoryExpanded(entry.path),
+            beginRenaming: setRenamingPath,
+          });
+          if ("followUpFailure" in result) {
+            window.alert(
+              `Created "${getFileName(result.path)}", but Writer could not update the sidebar: ${getSidebarCreationErrorMessage(result.followUpFailure)}`,
+            );
+          }
+        } catch (error) {
+          if (isCurrent()) {
+            window.alert(`Failed to create ${kind}: ${getSidebarCreationErrorMessage(error)}`);
+          }
+        }
+      })();
+    },
+    [ensureDirectoryExpanded, setRenamingPath, workspaceRoot],
+  );
+
   const handleFolderContextMenu = useCallback(
     (entry: DirEntry) => {
       const parent = getParentDir(entry.path);
@@ -150,42 +171,10 @@ export function useFileTreeContextMenus({
 
       void showFolderContextMenu({
         onNewFile: () => {
-          void (async () => {
-            try {
-              const filePath = await resolveUniqueName(entry.path, "Untitled", ".md");
-              await tauri.createFile(filePath);
-              // Expand the folder so the new file is visible
-              if (!expandedDirs.has(entry.path)) {
-                await toggleDirectory(entry.path);
-              } else {
-                await refreshDirectory(entry.path);
-              }
-              setRenamingPath(filePath);
-            } catch (error) {
-              window.alert(
-                `Failed to create file: ${error instanceof Error ? error.message : String(error)}`,
-              );
-            }
-          })();
+          createEntryInFolder(entry, "file");
         },
         onNewFolder: () => {
-          void (async () => {
-            try {
-              const folderPath = await resolveUniqueName(entry.path, "Untitled Folder", "");
-              await tauri.createDirectory(folderPath);
-              // Expand the parent folder so the new folder is visible
-              if (!expandedDirs.has(entry.path)) {
-                await toggleDirectory(entry.path);
-              } else {
-                await refreshDirectory(entry.path);
-              }
-              setRenamingPath(folderPath);
-            } catch (error) {
-              window.alert(
-                `Failed to create folder: ${error instanceof Error ? error.message : String(error)}`,
-              );
-            }
-          })();
+          createEntryInFolder(entry, "folder");
         },
         onCopyRelativePath: () => {
           void writeText(relative);
@@ -238,12 +227,11 @@ export function useFileTreeContextMenus({
       });
     },
     [
-      expandedDirs,
+      createEntryInFolder,
       invalidatePath,
       refreshDirectory,
       removePinnedFilesWithPrefix,
       setRenamingPath,
-      toggleDirectory,
       workspaceRoot,
     ],
   );

--- a/apps/desktop/src/components/sidebar/use-root-sidebar-entry-creation.ts
+++ b/apps/desktop/src/components/sidebar/use-root-sidebar-entry-creation.ts
@@ -1,0 +1,49 @@
+import { useCallback } from "react";
+import { useRefreshDirectory } from "@/hooks/use-file-tree";
+import { getWorkspaceEpoch, getWorkspaceRoot } from "@/hooks/workspace-api";
+import { useWorkspaceRoot } from "@/hooks/use-workspace";
+import { getFileName } from "@/lib/paths";
+import * as tauri from "@/lib/tauri";
+import {
+  createUntitledSidebarEntry,
+  getSidebarCreationErrorMessage,
+  type SidebarEntryKind,
+} from "./sidebar-entry-creation";
+
+export function useRootSidebarEntryCreation(beginRenaming: (path: string) => void) {
+  const root = useWorkspaceRoot();
+  const refreshDirectory = useRefreshDirectory();
+
+  return useCallback(
+    (kind: SidebarEntryKind) => {
+      if (!root) return;
+      const targetRoot = root;
+      const targetEpoch = getWorkspaceEpoch();
+      const isCurrent = () =>
+        getWorkspaceRoot() === targetRoot && getWorkspaceEpoch() === targetEpoch;
+
+      void (async () => {
+        try {
+          const result = await createUntitledSidebarEntry(targetRoot, kind, {
+            fileExists: tauri.fileExists,
+            createFile: tauri.createFile,
+            createFolder: tauri.createDirectory,
+            isCurrent,
+            revealEntry: () => refreshDirectory(targetRoot),
+            beginRenaming,
+          });
+          if ("followUpFailure" in result) {
+            window.alert(
+              `Created "${getFileName(result.path)}", but Writer could not refresh the sidebar: ${getSidebarCreationErrorMessage(result.followUpFailure)}`,
+            );
+          }
+        } catch (error) {
+          if (isCurrent()) {
+            window.alert(`Failed to create ${kind}: ${getSidebarCreationErrorMessage(error)}`);
+          }
+        }
+      })();
+    },
+    [beginRenaming, refreshDirectory, root],
+  );
+}

--- a/apps/desktop/src/hooks/command-palette-api.ts
+++ b/apps/desktop/src/hooks/command-palette-api.ts
@@ -1,0 +1,5 @@
+import { useUIStore } from "@/stores/ui-store";
+
+export function getCommandPaletteSession() {
+  return useUIStore.getState().commandPaletteSession;
+}

--- a/apps/desktop/src/hooks/use-command-palette.ts
+++ b/apps/desktop/src/hooks/use-command-palette.ts
@@ -22,6 +22,10 @@ export function useCommandPaletteSearch() {
   return useUIStore((s) => s.commandPaletteSearch);
 }
 
+export function useCommandPaletteSession() {
+  return useUIStore((s) => s.commandPaletteSession);
+}
+
 export function useSetCommandPaletteSearch() {
   return useUIStore((s) => s.setCommandPaletteSearch);
 }

--- a/apps/desktop/src/hooks/use-create-entry.ts
+++ b/apps/desktop/src/hooks/use-create-entry.ts
@@ -1,0 +1,29 @@
+import { useCallback } from "react";
+import { getWorkspaceRoot } from "@/hooks/workspace-api";
+import { useRefreshDirectory } from "@/hooks/use-file-tree";
+import { openStandaloneFile } from "@/hooks/use-open-drop";
+import { useOpenFile } from "@/hooks/use-tabs";
+import {
+  executeEntryCreation,
+  type EntryCreationDestination,
+  type EntryCreationTarget,
+} from "@/lib/entry-creation";
+import * as tauri from "@/lib/tauri";
+
+export function useCreateEntry() {
+  const refreshDirectory = useRefreshDirectory();
+  const openWorkspaceFile = useOpenFile();
+
+  return useCallback(
+    (target: EntryCreationTarget, destination: EntryCreationDestination) =>
+      executeEntryCreation(target, destination, {
+        createFile: tauri.createFile,
+        createFolder: tauri.createDirectory,
+        refreshDirectory,
+        openWorkspaceFile,
+        openStandaloneFile,
+        getCurrentRoot: getWorkspaceRoot,
+      }),
+    [openWorkspaceFile, refreshDirectory],
+  );
+}

--- a/apps/desktop/src/hooks/use-file-tree.ts
+++ b/apps/desktop/src/hooks/use-file-tree.ts
@@ -16,6 +16,10 @@ export function useRefreshDirectory() {
   return useWorkspaceStore((s) => s.refreshDirectory);
 }
 
+export function useEnsureDirectoryExpanded() {
+  return useWorkspaceStore((s) => s.ensureDirectoryExpanded);
+}
+
 export function useInvalidatePath() {
   return useWorkspaceStore((s) => s.invalidatePath);
 }

--- a/apps/desktop/src/hooks/workspace-api.ts
+++ b/apps/desktop/src/hooks/workspace-api.ts
@@ -3,3 +3,7 @@ import { useWorkspaceStore } from "@/stores/workspace-store";
 export function getWorkspaceRoot() {
   return useWorkspaceStore.getState().root;
 }
+
+export function getWorkspaceEpoch() {
+  return useWorkspaceStore.getState().workspaceEpoch;
+}

--- a/apps/desktop/src/lib/entry-creation.ts
+++ b/apps/desktop/src/lib/entry-creation.ts
@@ -1,0 +1,134 @@
+export type EntryKind = "file" | "folder";
+export type EntryCreationDestination = "workspace" | "standalone";
+
+export interface EntryCreationTarget {
+  kind: EntryKind;
+  parentDirectory: string;
+  name: string;
+}
+
+export type EntryCreationPlan =
+  | { ok: true; target: EntryCreationTarget }
+  | { ok: false; error: string };
+
+export type EntryNameValidation = { ok: true; name: string } | { ok: false; error: string };
+
+export interface EntryCreationDependencies {
+  createFile: (path: string) => Promise<unknown>;
+  createFolder: (path: string) => Promise<unknown>;
+  refreshDirectory: (path: string) => Promise<unknown>;
+  openWorkspaceFile: (path: string) => Promise<unknown>;
+  openStandaloneFile: (path: string) => Promise<unknown>;
+  getCurrentRoot: () => string | null;
+}
+
+export interface EntryCreationFollowUpFailure {
+  step: "refresh" | "open";
+  error: unknown;
+}
+
+export interface EntryCreationResult {
+  followUpFailures: EntryCreationFollowUpFailure[];
+}
+
+export function validateEntryName(rawName: string, kind: EntryKind): EntryNameValidation {
+  const name = rawName.trim();
+  const label = kind === "file" ? "file" : "folder";
+
+  if (!name) {
+    return { ok: false, error: `Type a ${label} name to create it.` };
+  }
+  if (
+    name === "." ||
+    name === ".." ||
+    name.startsWith(".") ||
+    name.includes("/") ||
+    name.includes("\\") ||
+    name.includes("\0")
+  ) {
+    return { ok: false, error: `Use a single visible ${label} name without a path.` };
+  }
+
+  return { ok: true, name };
+}
+
+/**
+ * Validate a user-entered entry name as one visible basename. The backend
+ * accepts arbitrary paths, so callers must plan the target before IPC.
+ */
+export function planEntryCreation(
+  parentDirectory: string,
+  rawName: string,
+  kind: EntryKind,
+): EntryCreationPlan {
+  const validation = validateEntryName(rawName, kind);
+  if (!validation.ok) return validation;
+  const trimmed = validation.name;
+
+  const name =
+    kind === "file"
+      ? trimmed.toLowerCase().endsWith(".md")
+        ? `${trimmed.slice(0, -3)}.md`
+        : `${trimmed}.md`
+      : trimmed;
+
+  return { ok: true, target: { kind, parentDirectory, name } };
+}
+
+export function getEntryCreationPath(target: EntryCreationTarget): string {
+  const separator = /[\\/]$/.test(target.parentDirectory) ? "" : "/";
+  return `${target.parentDirectory}${separator}${target.name}`;
+}
+
+/**
+ * Own the create operation and its follow-up UI effects. Creation failures
+ * reject so the naming flow can offer a retry. Once the disk write succeeds,
+ * refresh/open failures are returned separately: recreating the same entry
+ * would only produce an AlreadyExists error.
+ */
+export async function executeEntryCreation(
+  target: EntryCreationTarget,
+  destination: EntryCreationDestination,
+  dependencies: EntryCreationDependencies,
+): Promise<EntryCreationResult> {
+  if (destination === "standalone" && target.kind !== "file") {
+    throw new Error("Standalone creation only supports files");
+  }
+
+  const path = getEntryCreationPath(target);
+  if (target.kind === "file") {
+    await dependencies.createFile(path);
+  } else {
+    await dependencies.createFolder(path);
+  }
+
+  const followUpFailures: EntryCreationFollowUpFailure[] = [];
+  if (destination === "standalone") {
+    try {
+      await dependencies.openStandaloneFile(path);
+    } catch (error) {
+      followUpFailures.push({ step: "open", error });
+    }
+    return { followUpFailures };
+  }
+
+  if (dependencies.getCurrentRoot() !== target.parentDirectory) {
+    return { followUpFailures };
+  }
+
+  try {
+    await dependencies.refreshDirectory(target.parentDirectory);
+  } catch (error) {
+    followUpFailures.push({ step: "refresh", error });
+  }
+
+  if (target.kind === "file" && dependencies.getCurrentRoot() === target.parentDirectory) {
+    try {
+      await dependencies.openWorkspaceFile(path);
+    } catch (error) {
+      followUpFailures.push({ step: "open", error });
+    }
+  }
+
+  return { followUpFailures };
+}

--- a/apps/desktop/src/stores/ui-store.ts
+++ b/apps/desktop/src/stores/ui-store.ts
@@ -6,6 +6,7 @@ interface UIState {
   isCommandPaletteOpen: boolean;
   commandPaletteIntent: CommandPaletteIntent;
   commandPaletteSearch: string;
+  commandPaletteSession: number;
 
   openCommandPalette: (intent?: CommandPaletteIntent) => void;
   closeCommandPalette: () => void;
@@ -16,9 +17,15 @@ export const useUIStore = create<UIState>((set) => ({
   isCommandPaletteOpen: false,
   commandPaletteIntent: "search",
   commandPaletteSearch: "",
+  commandPaletteSession: 0,
 
   openCommandPalette: (intent = "search") =>
-    set({ isCommandPaletteOpen: true, commandPaletteIntent: intent, commandPaletteSearch: "" }),
+    set((state) => ({
+      isCommandPaletteOpen: true,
+      commandPaletteIntent: intent,
+      commandPaletteSearch: "",
+      commandPaletteSession: state.commandPaletteSession + 1,
+    })),
   closeCommandPalette: () =>
     set({
       isCommandPaletteOpen: false,

--- a/apps/desktop/src/stores/workspace-store.ts
+++ b/apps/desktop/src/stores/workspace-store.ts
@@ -10,6 +10,7 @@ export type WorkspaceChromeMode = "workspace" | "compact-file";
 
 interface WorkspaceState {
   root: string | null;
+  workspaceEpoch: number;
   chromeMode: WorkspaceChromeMode;
   fileCount: number;
   isIndexing: boolean;
@@ -28,6 +29,7 @@ interface WorkspaceState {
   setChromeMode: (mode: WorkspaceChromeMode) => void;
   setStartupResolved: () => void;
   refreshDirectory: (path: string) => Promise<void>;
+  ensureDirectoryExpanded: (path: string) => Promise<void>;
   toggleDirectory: (path: string) => Promise<void>;
   invalidatePath: (path: string) => void;
   rewriteExpandedDir: (oldPath: string, newPath: string) => void;
@@ -78,6 +80,7 @@ function dedupe(paths: string[]) {
 
 export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
   root: null,
+  workspaceEpoch: 0,
   chromeMode: "workspace",
   fileCount: 0,
   isIndexing: false,
@@ -119,8 +122,9 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       tauri.readDirectory(info.root),
       tauri.getRecentWorkspaces(),
     ]);
-    set({
+    set((state) => ({
       root: info.root,
+      workspaceEpoch: state.workspaceEpoch + 1,
       chromeMode: "workspace",
       fileCount: info.file_count,
       isIndexing: true,
@@ -129,7 +133,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       pinnedFiles: [],
       sidebarMetadataVersion: 0,
       recentWorkspaces: recents,
-    });
+    }));
     void get().hydratePinnedFiles(info.root);
 
     const session = await loadSession(info.root);
@@ -152,8 +156,9 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       activeTabId: null,
       activeFilePath: null,
     });
-    set({
+    set((state) => ({
       root: null,
+      workspaceEpoch: state.workspaceEpoch + 1,
       chromeMode: "workspace",
       fileCount: 0,
       directoryCache: new Map(),
@@ -161,7 +166,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       pinnedFiles: [],
       sidebarMetadataVersion: 0,
       isIndexing: false,
-    });
+    }));
   },
 
   restoreFromBundle: async (bundle) => {
@@ -173,8 +178,9 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       activeFilePath: null,
     });
 
-    set({
+    set((state) => ({
       root: bundle.workspace.root,
+      workspaceEpoch: state.workspaceEpoch + 1,
       chromeMode: "workspace",
       fileCount: bundle.workspace.file_count,
       isIndexing: true,
@@ -183,7 +189,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       pinnedFiles: [],
       sidebarMetadataVersion: 0,
       recentWorkspaces: bundle.recent_workspaces,
-    });
+    }));
     void get().hydratePinnedFiles(bundle.workspace.root);
 
     if (bundle.session && bundle.session.tabs && bundle.session.tabs.length > 0) {
@@ -220,11 +226,26 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
   setStartupResolved: () => set({ isStartupResolved: true }),
 
   refreshDirectory: async (path: string) => {
+    const { root: rootAtStart, workspaceEpoch: epochAtStart } = get();
     const entries = await tauri.readDirectory(path);
     set((state) => {
+      if (state.root !== rootAtStart || state.workspaceEpoch !== epochAtStart) return state;
       const cache = new Map(state.directoryCache);
       cache.set(path, entries);
       return { directoryCache: cache };
+    });
+  },
+
+  ensureDirectoryExpanded: async (path: string) => {
+    const { root: rootAtStart, workspaceEpoch: epochAtStart } = get();
+    const entries = await tauri.readDirectory(path);
+    set((state) => {
+      if (state.root !== rootAtStart || state.workspaceEpoch !== epochAtStart) return state;
+      const cache = new Map(state.directoryCache);
+      cache.set(path, entries);
+      const expandedDirs = new Set(state.expandedDirs);
+      expandedDirs.add(path);
+      return { directoryCache: cache, expandedDirs };
     });
   },
 

--- a/apps/desktop/tests/command-palette-create-request.test.ts
+++ b/apps/desktop/tests/command-palette-create-request.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test, vi } from "vite-plus/test";
+import { runCreateRequest } from "../src/components/command-palette/run-create-request";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("runCreateRequest", () => {
+  test("ignores success after a new palette session opens", async () => {
+    const pending = deferred<string>();
+    let currentSession = 1;
+    const onCreated = vi.fn();
+    const onCreationError = vi.fn();
+    const request = runCreateRequest({
+      create: () => pending.promise,
+      isCurrent: () => currentSession === 1,
+      onCreated,
+      onCreationError,
+    });
+
+    currentSession = 2;
+    pending.resolve("created");
+    await request;
+
+    expect(onCreated).not.toHaveBeenCalled();
+    expect(onCreationError).not.toHaveBeenCalled();
+  });
+
+  test("ignores failure after a new palette session opens", async () => {
+    const pending = deferred<string>();
+    let currentSession = 1;
+    const onCreated = vi.fn();
+    const onCreationError = vi.fn();
+    const request = runCreateRequest({
+      create: () => pending.promise,
+      isCurrent: () => currentSession === 1,
+      onCreated,
+      onCreationError,
+    });
+
+    currentSession = 2;
+    pending.reject(new Error("stale failure"));
+    await request;
+
+    expect(onCreated).not.toHaveBeenCalled();
+    expect(onCreationError).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/tests/entry-creation.test.ts
+++ b/apps/desktop/tests/entry-creation.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test, vi } from "vite-plus/test";
+import {
+  executeEntryCreation,
+  getEntryCreationPath,
+  planEntryCreation,
+  validateEntryName,
+  type EntryCreationDependencies,
+  type EntryCreationTarget,
+} from "../src/lib/entry-creation";
+
+function plannedTarget(
+  parentDirectory: string,
+  rawName: string,
+  kind: "file" | "folder",
+): EntryCreationTarget {
+  const plan = planEntryCreation(parentDirectory, rawName, kind);
+  if (!plan.ok) throw new Error(plan.error);
+  return plan.target;
+}
+
+describe("planEntryCreation", () => {
+  test("creates files and folders as immediate children of the parent", () => {
+    const file = plannedTarget("/vault", " Draft ", "file");
+    expect(file).toEqual({ kind: "file", parentDirectory: "/vault", name: "Draft.md" });
+    expect(getEntryCreationPath(file)).toBe("/vault/Draft.md");
+
+    const folder = plannedTarget("/vault/", "Archive", "folder");
+    expect(folder).toEqual({ kind: "folder", parentDirectory: "/vault/", name: "Archive" });
+    expect(getEntryCreationPath(folder)).toBe("/vault/Archive");
+
+    const rootFile = plannedTarget("/", "Root note", "file");
+    expect(getEntryCreationPath(rootFile)).toBe("/Root note.md");
+  });
+
+  test("normalizes an existing markdown extension case-insensitively", () => {
+    expect(plannedTarget("/vault", "Draft.MD", "file").name).toBe("Draft.md");
+  });
+
+  test.each(["", "   ", ".", "..", ".hidden", "nested/file", "nested\\file"])(
+    "rejects a non-basename input: %j",
+    (rawName) => {
+      expect(planEntryCreation("/vault", rawName, "folder").ok).toBe(false);
+    },
+  );
+});
+
+describe("validateEntryName", () => {
+  test.each(["../Outside", "nested/file", "nested\\file", ".hidden"])(
+    "rejects an unsafe inline rename: %j",
+    (rawName) => {
+      expect(validateEntryName(rawName, "folder").ok).toBe(false);
+    },
+  );
+});
+
+function makeDependencies(currentRoot: string | null = "/vault") {
+  const calls: string[] = [];
+  const dependencies: EntryCreationDependencies = {
+    createFile: vi.fn(async (path) => {
+      calls.push(`create-file:${path}`);
+    }),
+    createFolder: vi.fn(async (path) => {
+      calls.push(`create-folder:${path}`);
+    }),
+    refreshDirectory: vi.fn(async (path) => {
+      calls.push(`refresh:${path}`);
+    }),
+    openWorkspaceFile: vi.fn(async (path) => {
+      calls.push(`open-workspace:${path}`);
+    }),
+    openStandaloneFile: vi.fn(async (path) => {
+      calls.push(`open-standalone:${path}`);
+    }),
+    getCurrentRoot: () => currentRoot,
+  };
+  return { calls, dependencies };
+}
+
+describe("executeEntryCreation", () => {
+  test("creates, refreshes, then opens a workspace file", async () => {
+    const { calls, dependencies } = makeDependencies();
+    const result = await executeEntryCreation(
+      plannedTarget("/vault", "Draft", "file"),
+      "workspace",
+      dependencies,
+    );
+
+    expect(result.followUpFailures).toEqual([]);
+    expect(calls).toEqual([
+      "create-file:/vault/Draft.md",
+      "refresh:/vault",
+      "open-workspace:/vault/Draft.md",
+    ]);
+  });
+
+  test("creates and refreshes a workspace folder without opening it", async () => {
+    const { calls, dependencies } = makeDependencies();
+    const result = await executeEntryCreation(
+      plannedTarget("/vault", "Archive", "folder"),
+      "workspace",
+      dependencies,
+    );
+
+    expect(result.followUpFailures).toEqual([]);
+    expect(calls).toEqual(["create-folder:/vault/Archive", "refresh:/vault"]);
+  });
+
+  test("creates and opens a standalone file through the same pipeline", async () => {
+    const { calls, dependencies } = makeDependencies(null);
+    const result = await executeEntryCreation(
+      plannedTarget("/notes", "Draft", "file"),
+      "standalone",
+      dependencies,
+    );
+
+    expect(result.followUpFailures).toEqual([]);
+    expect(calls).toEqual(["create-file:/notes/Draft.md", "open-standalone:/notes/Draft.md"]);
+  });
+
+  test("does not run follow-up effects when creation fails", async () => {
+    const { calls, dependencies } = makeDependencies();
+    vi.mocked(dependencies.createFolder).mockRejectedValueOnce(new Error("already exists"));
+
+    await expect(
+      executeEntryCreation(plannedTarget("/vault", "Archive", "folder"), "workspace", dependencies),
+    ).rejects.toThrow("already exists");
+    expect(calls).toEqual([]);
+  });
+
+  test("opens a created file and reports refresh failure without inviting recreation", async () => {
+    const { calls, dependencies } = makeDependencies();
+    const refreshError = new Error("refresh failed");
+    vi.mocked(dependencies.refreshDirectory).mockImplementationOnce(async (path) => {
+      calls.push(`refresh:${path}`);
+      throw refreshError;
+    });
+
+    const result = await executeEntryCreation(
+      plannedTarget("/vault", "Draft", "file"),
+      "workspace",
+      dependencies,
+    );
+
+    expect(calls).toEqual([
+      "create-file:/vault/Draft.md",
+      "refresh:/vault",
+      "open-workspace:/vault/Draft.md",
+    ]);
+    expect(result.followUpFailures).toEqual([{ step: "refresh", error: refreshError }]);
+  });
+
+  test("does not refresh or open after the workspace changes", async () => {
+    const { calls, dependencies } = makeDependencies("/other-vault");
+    const result = await executeEntryCreation(
+      plannedTarget("/vault", "Draft", "file"),
+      "workspace",
+      dependencies,
+    );
+
+    expect(result.followUpFailures).toEqual([]);
+    expect(calls).toEqual(["create-file:/vault/Draft.md"]);
+  });
+});

--- a/apps/desktop/tests/sidebar-entry-creation.test.ts
+++ b/apps/desktop/tests/sidebar-entry-creation.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test, vi } from "vite-plus/test";
+import { createUntitledSidebarEntry } from "../src/components/sidebar/sidebar-entry-creation";
+
+function makeDependencies(calls: string[]) {
+  return {
+    fileExists: vi.fn(async () => false),
+    createFile: vi.fn(async (path: string) => {
+      calls.push(`create-file:${path}`);
+    }),
+    createFolder: vi.fn(async (path: string) => {
+      calls.push(`create-folder:${path}`);
+    }),
+    isCurrent: () => true,
+    revealEntry: vi.fn(async (path: string) => {
+      calls.push(`reveal:${path}`);
+    }),
+    beginRenaming: vi.fn((path: string) => calls.push(`rename:${path}`)),
+  };
+}
+
+describe("createUntitledSidebarEntry", () => {
+  test.each([
+    ["file", "/vault/Untitled.md", "create-file:/vault/Untitled.md"],
+    ["folder", "/vault/Untitled Folder", "create-folder:/vault/Untitled Folder"],
+  ] as const)("creates, reveals, and begins renaming an untitled %s", async (kind, path, call) => {
+    const calls: string[] = [];
+    const result = await createUntitledSidebarEntry("/vault", kind, makeDependencies(calls));
+
+    expect(result).toEqual({ path });
+    expect(calls).toEqual([call, `reveal:${path}`, `rename:${path}`]);
+  });
+
+  test("increments the default name until it is available", async () => {
+    const calls: string[] = [];
+    const dependencies = makeDependencies(calls);
+    dependencies.fileExists
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+
+    const result = await createUntitledSidebarEntry("/vault", "file", dependencies);
+
+    expect(result.path).toBe("/vault/Untitled 3.md");
+    expect(dependencies.createFile).toHaveBeenCalledWith("/vault/Untitled 3.md");
+  });
+
+  test("does not duplicate a workspace root separator", async () => {
+    const dependencies = makeDependencies([]);
+
+    const result = await createUntitledSidebarEntry("/", "file", dependencies);
+
+    expect(result.path).toBe("/Untitled.md");
+    expect(dependencies.createFile).toHaveBeenCalledWith("/Untitled.md");
+  });
+
+  test("does not create when no available default name can be found", async () => {
+    const dependencies = makeDependencies([]);
+    dependencies.fileExists.mockResolvedValue(true);
+
+    await expect(createUntitledSidebarEntry("/vault", "file", dependencies)).rejects.toThrow(
+      'Could not find an available name for "Untitled" in /vault',
+    );
+    expect(dependencies.createFile).not.toHaveBeenCalled();
+  });
+
+  test("does not reveal or rename after the workspace changes", async () => {
+    const dependencies = makeDependencies([]);
+    dependencies.isCurrent = () => false;
+
+    await createUntitledSidebarEntry("/vault", "file", dependencies);
+
+    expect(dependencies.revealEntry).not.toHaveBeenCalled();
+    expect(dependencies.beginRenaming).not.toHaveBeenCalled();
+  });
+
+  test("reports a reveal failure after creation without starting rename", async () => {
+    const dependencies = makeDependencies([]);
+    const followUpFailure = new Error("refresh failed");
+    dependencies.revealEntry.mockRejectedValue(followUpFailure);
+
+    const result = await createUntitledSidebarEntry("/vault", "file", dependencies);
+
+    expect(result).toEqual({ path: "/vault/Untitled.md", followUpFailure });
+    expect(dependencies.beginRenaming).not.toHaveBeenCalled();
+  });
+
+  test("does not rename when the workspace changes during reveal", async () => {
+    const dependencies = makeDependencies([]);
+    let isCurrent = true;
+    dependencies.isCurrent = () => isCurrent;
+    dependencies.revealEntry.mockImplementationOnce(async () => {
+      isCurrent = false;
+    });
+
+    await createUntitledSidebarEntry("/vault", "folder", dependencies);
+
+    expect(dependencies.revealEntry).toHaveBeenCalledOnce();
+    expect(dependencies.beginRenaming).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/tests/sidebar-surface-context-menu.test.ts
+++ b/apps/desktop/tests/sidebar-surface-context-menu.test.ts
@@ -3,47 +3,132 @@ import { describe, expect, test, vi } from "vite-plus/test";
 // The Tauri menu modules pull in `@tauri-apps/api/core` at import time, so we
 // stub them up front. The pure helper under test
 // (`buildSidebarSurfaceMenuItemsSpec`) never touches these stubs.
-vi.mock("@tauri-apps/api/menu/menu", () => ({ Menu: { new: vi.fn() } }));
-vi.mock("@tauri-apps/api/menu/checkMenuItem", () => ({ CheckMenuItem: { new: vi.fn() } }));
+const nativeMenuMocks = vi.hoisted(() => ({
+  menuNew: vi.fn(),
+  checkItemNew: vi.fn(),
+  itemNew: vi.fn(),
+  predefinedItemNew: vi.fn(),
+}));
+vi.mock("@tauri-apps/api/menu/menu", () => ({ Menu: { new: nativeMenuMocks.menuNew } }));
+vi.mock("@tauri-apps/api/menu/checkMenuItem", () => ({
+  CheckMenuItem: { new: nativeMenuMocks.checkItemNew },
+}));
+vi.mock("@tauri-apps/api/menu/menuItem", () => ({
+  MenuItem: { new: nativeMenuMocks.itemNew },
+}));
+vi.mock("@tauri-apps/api/menu/predefinedMenuItem", () => ({
+  PredefinedMenuItem: { new: nativeMenuMocks.predefinedItemNew },
+}));
 
 import {
   buildSidebarSurfaceMenuItemsSpec,
+  showSidebarSurfaceContextMenu,
   type SidebarSurfaceMenuState,
 } from "../src/components/sidebar/sidebar-surface-context-menu";
 
 function makeState(
   showSearch: boolean,
   showRecents: boolean,
-): SidebarSurfaceMenuState & { toggles: Array<[string, boolean]> } {
+): SidebarSurfaceMenuState & { actions: string[]; toggles: Array<[string, boolean]> } {
   const toggles: Array<[string, boolean]> = [];
+  const actions: string[] = [];
   return {
+    actions,
     toggles,
     showSearch,
     showRecents,
+    onNewFile: () => actions.push("new-file"),
+    onNewFolder: () => actions.push("new-folder"),
     onToggleSearch: (visible) => toggles.push(["search", visible]),
     onToggleRecents: (visible) => toggles.push(["recents", visible]),
   };
 }
 
 describe("buildSidebarSurfaceMenuItemsSpec", () => {
-  test("lists both toggles with checked reflecting visibility", () => {
+  test("lists root actions before both visibility toggles", () => {
     const spec = buildSidebarSurfaceMenuItemsSpec(makeState(true, false));
 
-    expect(spec.map((entry) => [entry.id, entry.text, entry.checked])).toEqual([
-      ["toggle-search", "Search", true],
-      ["toggle-recents", "Recents", false],
+    expect(
+      spec.map((entry) =>
+        entry.kind === "separator"
+          ? "---"
+          : `${entry.kind}:${entry.id}:${entry.text}${entry.kind === "check" ? `:${entry.checked}` : ""}`,
+      ),
+    ).toEqual([
+      "item:new-file:New File",
+      "item:new-folder:New Folder",
+      "---",
+      "check:toggle-search:Search:true",
+      "check:toggle-recents:Recents:false",
     ]);
   });
 
-  test("toggling flips the current visibility", () => {
+  test("actions dispatch and toggles flip the current visibility", () => {
     const state = makeState(true, false);
 
     const spec = buildSidebarSurfaceMenuItemsSpec(state);
-    for (const entry of spec) entry.action();
+    for (const entry of spec) {
+      if (entry.kind !== "separator") entry.action();
+    }
 
+    expect(state.actions).toEqual(["new-file", "new-folder"]);
     expect(state.toggles).toEqual([
       ["search", false],
       ["recents", true],
     ]);
+  });
+
+  test("renders each native item kind in order and opens the menu", async () => {
+    const nativeItems = {
+      file: { type: "file" },
+      folder: { type: "folder" },
+      separator: { type: "separator" },
+      search: { type: "search" },
+      recents: { type: "recents" },
+    };
+    nativeMenuMocks.itemNew
+      .mockResolvedValueOnce(nativeItems.file as never)
+      .mockResolvedValueOnce(nativeItems.folder as never);
+    nativeMenuMocks.predefinedItemNew.mockResolvedValue(nativeItems.separator as never);
+    nativeMenuMocks.checkItemNew
+      .mockResolvedValueOnce(nativeItems.search as never)
+      .mockResolvedValueOnce(nativeItems.recents as never);
+    const popup = vi.fn().mockResolvedValue(undefined);
+    nativeMenuMocks.menuNew.mockResolvedValue({ popup } as never);
+
+    const state = makeState(true, false);
+    await showSidebarSurfaceContextMenu(state);
+
+    expect(nativeMenuMocks.itemNew).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ id: "new-file", text: "New File", action: expect.any(Function) }),
+    );
+    expect(nativeMenuMocks.itemNew).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        id: "new-folder",
+        text: "New Folder",
+        action: expect.any(Function),
+      }),
+    );
+    expect(nativeMenuMocks.predefinedItemNew).toHaveBeenCalledWith({ item: "Separator" });
+    expect(nativeMenuMocks.checkItemNew).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ id: "toggle-search", checked: true }),
+    );
+    expect(nativeMenuMocks.checkItemNew).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ id: "toggle-recents", checked: false }),
+    );
+    expect(nativeMenuMocks.menuNew).toHaveBeenCalledWith({
+      items: [
+        nativeItems.file,
+        nativeItems.folder,
+        nativeItems.separator,
+        nativeItems.search,
+        nativeItems.recents,
+      ],
+    });
+    expect(popup).toHaveBeenCalledOnce();
   });
 });

--- a/apps/desktop/tests/stores.test.ts
+++ b/apps/desktop/tests/stores.test.ts
@@ -58,6 +58,7 @@ describe("workspace-store", () => {
     vi.clearAllMocks();
     useWorkspaceStore.setState({
       root: null,
+      workspaceEpoch: 0,
       chromeMode: "workspace",
       directoryCache: new Map(),
       expandedDirs: new Set(),
@@ -105,6 +106,109 @@ describe("workspace-store", () => {
     // Collapse
     await useWorkspaceStore.getState().toggleDirectory("/test/dir");
     expect(useWorkspaceStore.getState().expandedDirs.has("/test/dir")).toBe(false);
+  });
+
+  test("refreshDirectory ignores a response after the workspace changes", async () => {
+    const deferred = createDeferred<
+      Array<{
+        name: string;
+        path: string;
+        is_dir: boolean;
+        is_markdown: boolean;
+        modified_at: number;
+      }>
+    >();
+    mockedInvoke.mockImplementation((cmd: string) =>
+      cmd === "read_directory" ? deferred.promise : Promise.resolve(null),
+    );
+    useWorkspaceStore.setState({ root: "/old", workspaceEpoch: 1, directoryCache: new Map() });
+
+    const refresh = useWorkspaceStore.getState().refreshDirectory("/old");
+    useWorkspaceStore.setState({
+      root: "/new",
+      workspaceEpoch: 2,
+      directoryCache: new Map([["/new", []]]),
+    });
+    deferred.resolve([
+      {
+        name: "stale.md",
+        path: "/old/stale.md",
+        is_dir: false,
+        is_markdown: true,
+        modified_at: 0,
+      },
+    ]);
+    await refresh;
+
+    const cache = useWorkspaceStore.getState().directoryCache;
+    expect(cache.has("/old")).toBe(false);
+    expect(cache.has("/new")).toBe(true);
+  });
+
+  test("ensureDirectoryExpanded refreshes a directory without collapsing it", async () => {
+    const freshEntry = {
+      name: "fresh.md",
+      path: "/test/dir/fresh.md",
+      is_dir: false,
+      is_markdown: true,
+      modified_at: 0,
+    };
+    mockedInvoke.mockResolvedValue([freshEntry]);
+    useWorkspaceStore.setState({
+      root: "/test",
+      workspaceEpoch: 1,
+      directoryCache: new Map([["/test/dir", []]]),
+      expandedDirs: new Set(["/test/dir"]),
+    });
+
+    await useWorkspaceStore.getState().ensureDirectoryExpanded("/test/dir");
+
+    expect(useWorkspaceStore.getState().directoryCache.get("/test/dir")).toEqual([freshEntry]);
+    expect(useWorkspaceStore.getState().expandedDirs).toEqual(new Set(["/test/dir"]));
+  });
+
+  test("ensureDirectoryExpanded ignores a response after the workspace changes", async () => {
+    const deferred = createDeferred<
+      Array<{
+        name: string;
+        path: string;
+        is_dir: boolean;
+        is_markdown: boolean;
+        modified_at: number;
+      }>
+    >();
+    mockedInvoke.mockImplementation((cmd: string) =>
+      cmd === "read_directory" ? deferred.promise : Promise.resolve(null),
+    );
+    useWorkspaceStore.setState({
+      root: "/old",
+      workspaceEpoch: 1,
+      directoryCache: new Map(),
+      expandedDirs: new Set(),
+    });
+
+    const ensureExpanded = useWorkspaceStore.getState().ensureDirectoryExpanded("/old/folder");
+    useWorkspaceStore.setState({
+      root: "/new",
+      workspaceEpoch: 2,
+      directoryCache: new Map([["/new", []]]),
+      expandedDirs: new Set(["/new/kept"]),
+    });
+    deferred.resolve([
+      {
+        name: "stale.md",
+        path: "/old/folder/stale.md",
+        is_dir: false,
+        is_markdown: true,
+        modified_at: 0,
+      },
+    ]);
+    await ensureExpanded;
+
+    const state = useWorkspaceStore.getState();
+    expect(state.directoryCache.has("/old/folder")).toBe(false);
+    expect(state.directoryCache.has("/new")).toBe(true);
+    expect(state.expandedDirs).toEqual(new Set(["/new/kept"]));
   });
 
   test("invalidatePath removes from cache", () => {
@@ -727,6 +831,7 @@ describe("ui-store", () => {
       isCommandPaletteOpen: false,
       commandPaletteIntent: "search",
       commandPaletteSearch: "",
+      commandPaletteSession: 0,
     });
 
     useSettingsStore.setState({
@@ -752,9 +857,11 @@ describe("ui-store", () => {
     useUIStore.getState().openCommandPalette();
     expect(useUIStore.getState().isCommandPaletteOpen).toBe(true);
     expect(useUIStore.getState().commandPaletteIntent).toBe("search");
+    expect(useUIStore.getState().commandPaletteSession).toBe(1);
 
     useUIStore.getState().openCommandPalette("create-file");
     expect(useUIStore.getState().commandPaletteIntent).toBe("create-file");
+    expect(useUIStore.getState().commandPaletteSession).toBe(2);
 
     useUIStore.getState().closeCommandPalette();
     expect(useUIStore.getState().isCommandPaletteOpen).toBe(false);


### PR DESCRIPTION
## Summary

- add root-level New File and New Folder actions to the sidebar empty-space context menu
- create the next available Untitled entry immediately, reveal it, and start inline rename
- add a checked Recents toggle alongside the existing Search visibility toggle
- share safe basename validation and race-resistant creation behavior across root and folder menus
- keep truly empty folders visible without exposing directories that contain only non-Markdown content

## Validation

- `vp check` (passes; one pre-existing `wdio.conf.js` warning)
- `vp test` (39 files, 555 tests)
- `cargo test` (123 tests)
- `cargo clippy` (passes; pre-existing warnings only)
- `cargo fmt --check`
- release-style Tauri runtime verification for both native root creation actions and inline rename
- independent spec and standards reviews (no remaining P0-P2 findings)