### PR TITLE
Harden sidebar workspace actions after code review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2026-08-10
 
+- Make the sidebar background menu available across the full non-row surface, including the top drag gap, bottom workspace-switcher padding, and the no-workspace welcome shell. Workspace creation and external launch actions now abort safely during a workspace switch, and settings saved from an older window preserve newer global preferences from other windows.
 - Add a global **Default Terminal** preference under Workspace. Leave it blank for Writer's platform default, or enter a macOS application name / Windows or Linux executable to choose what the sidebar's **Open in Terminal** action launches. Values are trimmed, passed without shell interpretation, and invalid custom choices explain how to reset the preference.
 - Add **Open in Terminal** to folder row context menus so the selected directory opens in the configured terminal, with workspace containment and stale-path validation before launch.
 

--- a/SPECs/Agent/worksheet-pr111-review-fixes.md
+++ b/SPECs/Agent/worksheet-pr111-review-fixes.md
@@ -1,0 +1,69 @@
+# Worksheet: PR #111 Review Fixes
+
+## References
+
+- Review fixed point: `origin/master` / merge-base `eef8455`
+- Specs: [`../sidebar-empty-area-context-menu-spec.md`](../sidebar-empty-area-context-menu-spec.md), [`../configurable-default-terminal-spec.md`](../configurable-default-terminal-spec.md)
+- PR: #111
+
+## Reviewed
+
+- `AGENTS.md`; `docs/workflows/agent-loop.md`; `docs/workflows/agent-review.md`
+- `docs/consolidation.md`; `docs/react-guidelines.md`; `docs/zustand.md`
+- Rust workspace state, sidebar creation, file-manager/terminal launch, settings persistence, app/sidebar layout, surface-menu routing, and focused tests
+
+## Baseline
+
+- Clean branch tracking the open PR branch at `3cc11a0`.
+- Prior final validation: `vp check` passed with one existing warning; 38 frontend files / 545 tests and 142 Rust tests passed; clippy and formatting passed with existing warnings only.
+
+## Plan
+
+1. Add a guarded workspace-snapshot execution primitive that keeps the root read lock across a sensitive synchronous operation. Use it around each exclusive sidebar-entry create attempt, validated file-manager launch, and each terminal process spawn; stale root/epoch operations must fail before their side-effect callbacks run. Release the guard before waiting for macOS `open` status.
+2. Add an `AppState` global-settings write lock. Inside it, fallibly reload the latest global config before every set/reset so independently hydrated windows merge one mutation instead of rewriting a stale snapshot. Treat `NotFound` as empty and propagate every other read error without changing memory or disk. Initialize/migrate per-window settings under the same lock and make construction failures explicit.
+3. Replace parallel platform label switches with one typed label registry.
+4. Move sidebar-surface menu ownership from `FileBrowser` to a generation-keyed outer sidebar surface, lifting rename/collapse state with it. Attach context-menu routing to the outer boundary while row menus retain propagation stops, and start the layout's global drag overlay after the expanded sidebar so its own top drag region receives the event.
+5. Render the normal workspace layout for rootless non-compact windows, showing `WelcomeScreen` in the editor region and keeping the sidebar/no-workspace toggle menu reachable. Compact-file behavior remains unchanged. Drive the three root/chrome combinations through a pure view-routing seam.
+6. Validate through red→green tests at the settings two-instance seam, guarded Rust side-effect seams, platform-label seam, menu-state seam, and available app/layout integration seams. Run full gates, desktop smoke, independent review, docs/changelog, one commit, and push to PR #111.
+
+## Risks / Edge Cases
+
+- Workspace switching must not block on long work; hold the root read guard only across one exclusive create or immediate opener/process-spawn call, never while waiting for macOS launcher status.
+- Collision retries must re-check the captured workspace before every candidate.
+- Global lock order is app-level global-config lock before a window settings write lock; no reverse acquisition is allowed.
+- Rootless standard windows show the sidebar; compact-file windows must not regress into workspace chrome.
+- Moving menu ownership must reset transient rename/collapse state on workspace generation changes and preserve row/bulk menu propagation.
+
+## Test Seams
+
+- Rust `Settings` instances sharing one config directory for lost-update regression.
+- Guarded callback helpers proving stale creation/file-manager/terminal callbacks never execute and `try_write` fails while a side-effect callback is active.
+- Fallible settings load/reload tests plus shared-lock concurrency coverage for mutation and initialization/migration.
+- Pure platform label registry and sidebar menu specs.
+- Pure root/chrome app-view routing assertions. Native menu smoke covers top/content/bottom surface zones, row/bulk propagation, rootless visibility-only actions, compact sidebar absence, and A→B plus same-root/ABA transient-state reset where DOM infrastructure is unavailable.
+
+## Implementation
+
+- Added one `WorkspaceState::with_workspace_snapshot` boundary that holds the root read guard through a single side effect. Sidebar entry creation uses it for every collision attempt; file-manager open and each terminal spawn use it after live filesystem validation. macOS launcher status waits happen after the guard is released.
+- Added an awaited backend close transition that increments the epoch, clears the root and workspace-owned state atomically, and rejects a stale expected root before the frontend clears. This closes the A→no-workspace stale-action case.
+- Routed open and close through one workspace-runtime reset funnel. Bootstrap indexing, explicit indexing, ignore rebuilds, and queued watcher batches retain a validated root snapshot through their final state writes, so stale background publishers cannot repopulate a closed workspace.
+- Made global settings construction/reload fallible, with `NotFound` mapped to an empty layer and all other read failures propagated before mutation. Global set/reset reload from disk and only publish the in-memory snapshot after a successful write.
+- Added the process-wide global-settings mutex and enforced `global lock → window settings lock` for initialization/migrations and global mutations.
+- Consolidated platform menu labels into one typed registry.
+- Moved surface menu and rename/collapse state into a full sidebar subtree keyed by workspace generation. The outer surface owns top/content/bottom routing; the workspace drag overlay begins at the live sidebar width.
+- Added a pure app-view resolver. Rootless standard windows now render the workspace shell with welcome content, while compact-file windows remain sidebar-free.
+
+## Red → Green / Focused Validation
+
+- Reproduced the lost-update bug with two stale `Settings` instances: the second write erased `workspace.default-terminal`; the test passes after latest-disk merge semantics.
+- Added settings read-error/missing-file coverage and deterministic shared-lock coverage proving initialization waits behind a global mutation.
+- Added stale/ABA workspace and guard-duration coverage for creation, file-manager, and terminal side-effect seams.
+- Added root/chrome view routing tests; existing menu-label and surface-menu suites cover the typed registry and rootless visibility-only menu spec.
+- Focused and full tests pass: 40 frontend files / 552 tests and 153 Rust tests. Workspace watcher notifications carry their originating root/epoch identity and stale A→B, A→none, and same-root/ABA payloads are rejected by the frontend; a shared cross-language fixture enforces the serialized identity contract, and revision-checked index publication rejects stale prepared results. `vp check` passes with the existing `wdio.conf.js` warning only.
+- Desktop development startup smoke reached the running Tauri app. The native E2E sweep was attempted, but its release bundle stops before compilation on the pre-existing Tauri JS/Rust version mismatch (`tauri` 2.11.2 vs API 2.10.1; dialog 2.7.1 vs 2.6.0). The new E2E geometry check therefore remains source-reviewed rather than locally executed.
+
+## Review
+
+- Plan review passed after tightening fallible config reads, guarded terminal spawning, global-lock concurrency coverage, and titlebar hit routing.
+- Fresh Rust/Tauri, React/UX, and QA implementation reviews passed after fixes for replaced-root creation containment, the pointer-capturing toggle overlay, rootless tab chrome, focused selectors, and rooted E2E setup.
+- The final two-axis review found and closed A→no-workspace backend invalidation and stale background publishing, moved sidebar orchestration behind a co-located hook, derived frontend setting metadata from the JSON source, enforced the shared sidebar-entry-kind contract, centralized close feedback, and consolidated platform launch selection.

--- a/SPECs/configurable-default-terminal-spec.md
+++ b/SPECs/configurable-default-terminal-spec.md
@@ -10,6 +10,7 @@ Let users choose which terminal Writer opens from the sidebar's **Open in Termin
 - Its exact description is: **Terminal application name on macOS, or executable name/full path on Windows and Linux. Leave blank for Writer's platform default; arguments are not supported.**
 - The input placeholder is **Platform default**.
 - The setting persists at global scope through the existing settings pipeline. Like other global settings in the current multi-window architecture, each already-open window uses its independently hydrated value until that window reloads settings; new windows read the latest persisted value.
+- Global writes are serialized process-wide and merge against the latest on-disk config, so a stale already-open window cannot erase preferences written by another window.
 - A manually authored workspace override does not replace this app-level preference.
 - An empty value keeps Writer's current platform behavior:
   - macOS opens Terminal.app.
@@ -30,10 +31,12 @@ Let users choose which terminal Writer opens from the sidebar's **Open in Termin
 - The generic settings panel renders and persists the text field without terminal-specific frontend state.
 - The Rust settings boundary snapshots the invoking window's global/default value without holding the lock during launch; the workspace command owns platform-specific construction and execution.
 - Schema-aware config parsing preserves the raw lexical value of declared string settings before boolean/number inference, so executable names such as `TRUE`, `00123`, and `1e3` round-trip exactly.
+- The process-wide app state owns global-config write serialization; initialization/migrations and each writer refresh the per-window global layer from disk inside that critical section before applying one mutation. Global reads are fallible: a missing file becomes an empty layer, while any other read error aborts without mutating memory or writing a replacement config.
 
 ## Tests
 
 - TypeScript schema coverage asserts the setting contract shown by Preferences.
 - Rust tests cover exact default/custom launch specs on every modeled platform, settings-boundary trimming, shell-free argument construction, global/default lookup, macOS launcher-status failure mapping, and custom-preference reset/reload round trips (including lexically sensitive boolean- and number-looking strings such as `TRUE`, `00123`, and `1e3`).
+- Rust tests use two independently hydrated settings instances to prove later unrelated writes and resets preserve the first window's terminal preference, cover missing/read-error reload behavior, and exercise the shared serialization lock concurrently with initialization/migration.
 - Run `vp check`, `vp test`, `cargo test`, `cargo clippy`, and `cargo fmt --check`.
 - Launch the desktop app in development to verify the row renders in Preferences when the GUI environment permits.

--- a/SPECs/sidebar-empty-area-context-menu-spec.md
+++ b/SPECs/sidebar-empty-area-context-menu-spec.md
@@ -22,14 +22,18 @@ Right-clicking non-row space anywhere in the workspace sidebar exposes workspace
 - The sidebar-surface Open in Terminal action starts the platform terminal with the workspace root as its working directory; the folder-row action uses the selected folder.
 - Open in Finder opens the workspace directory itself rather than revealing it in its parent.
 - When no workspace is open, the workspace actions are omitted and the visibility checks remain available.
+- The rootless window keeps the normal sidebar shell beside the welcome content so that no-workspace menu is reachable; compact-file windows remain sidebar-free.
 
 ## Design
 
-- Keep `FileBrowser` as the owner of the sidebar-surface menu and lift the tree's transient rename target to it so root creation can reuse inline rename.
+- The outer `Sidebar` surface owns context-menu routing and the tree's transient rename/collapse state so root creation can reuse inline rename and workspace-generation changes reset the whole surface. Its top drag region, content gaps, section headers, and bottom workspace-switcher padding all reach the same menu; the workspace layout's global drag overlay starts after the expanded sidebar so it cannot intercept that top region, and file/folder rows continue stopping propagation.
 - Share unique-name creation between folder-row and workspace-root actions through one sidebar entry-creation module.
 - Consolidate unique-name selection and atomic creation in a workspace-scoped Rust command. Files use `create_new`; folders use exclusive leaf creation. Existing exact-path creation primitives adopt the same non-overwriting semantics.
 - Add workspace-scoped Tauri commands for file-manager and terminal launch. File-manager launch derives the current window's root. The single terminal command accepts an optional selected directory, then canonicalizes it and verifies it remains inside the invoking window's workspace; omitting the directory launches the workspace root.
-- Terminal launch captures the invoking window's workspace root and epoch, performs filesystem validation off-thread, then immediately before process creation revalidates that the live root and epoch still match. Replaced-root symlinks, external symlink targets, stale A→B launches, and same-root/ABA reopen cycles are rejected.
+- Terminal launch captures the invoking window's workspace root and epoch, performs filesystem validation off-thread, then holds the root read guard across final revalidation and each process spawn attempt. The guard is released before waiting for the short-lived macOS `open` launcher to exit. Replaced-root symlinks, external symlink targets, stale A→B launches, and same-root/ABA reopen cycles are rejected.
+- Sidebar entry creation and file-manager launch use the same per-window root/epoch snapshot discipline; stale operations are rejected before filesystem mutation or external launch.
+- Closing a workspace first invalidates and clears its backend root/epoch under the workspace guard, then clears frontend state. A stale close cannot clear a newly opened workspace, and after close resolves no captured create or launcher action can remain valid.
+- Background indexing and watcher discovery run without the workspace root guard; only revision-checked final state swaps are guarded. Workspace notifications carry one shared root/epoch identity, and the frontend rejects stale A→B, A→none, and same-root/ABA events.
 - One frontend terminal-action helper owns the neutral **Failed to open terminal** prefix for both root and folder actions. Backend details distinguish missing/invalid targets, while configured-terminal failures retain the Preferences reset guidance.
 - The file-manager command uses the installed Rust opener plugin directly, requiring no broad frontend `open_path` permission.
 - Terminal launch avoids shell interpolation: Terminal.app on macOS, a new-console `cmd.exe` inheriting the workspace working directory on Windows, and `$TERMINAL`/known terminal-emulator executable fallbacks inheriting that directory on Linux.
@@ -40,6 +44,9 @@ Right-clicking non-row space anywhere in the workspace sidebar exposes workspace
 - Unit-test the folder-row terminal item and its handler routing, plus IPC argument forwarding.
 - Unit-test the folder-action seam forwarding the selected row's exact path and surfacing rejected launches through the shared error helper.
 - Unit-test atomic collision handling, durable empty-folder-tree visibility, and terminal launch specification/target containment in Rust without launching an external application. Target tests cover root/nested directories, missing/files/siblings, internal/external symlinks, root replacement, A→B switches, and same-root/ABA epoch changes.
+- Unit-test stale workspace rejection before sidebar entry creation, file-manager launch, and terminal spawn, including proof that their mutation/launch callbacks are not invoked and that the workspace read guard remains held through each callback. Cover A→no-workspace invalidation and stale-close rejection after A→B.
+- Unit-test root/epoch notification routing and revision-checked watcher index publication so stale background work cannot repopulate or notify a replaced workspace without holding transition guards across filesystem scans.
+- Unit-test the pure app-view routing seam for rootless standard, rootless compact-file, and rooted windows. Smoke-test top/content/bottom surface zones, row/bulk propagation, rootless visibility-only actions, compact sidebar absence, and transient-state reset after A→B and same-root/ABA generation changes.
 - Test the root-creation orchestration order (expand Everything, create, await refresh, then enter rename) through an explicit dependency seam.
 - Run `vp check`, `vp test`, `cargo test`, `cargo clippy`, and `cargo fmt --check`.
 - Repair the baseline formatting-only failure in `apps/desktop/e2e/specs/visibility-settings.spec.js` so final `vp check` is green.

--- a/TODOS.md
+++ b/TODOS.md
@@ -6,6 +6,7 @@
 
 ## Done
 
+- PR #111 review fixes: [`SPECs/Agent/worksheet-pr111-review-fixes.md`](SPECs/Agent/worksheet-pr111-review-fixes.md) — guard creation and external launches against workspace switches, closes, and replaced roots; preserve cross-window global settings writes; and route the sidebar background menu through the full surface and rootless shell.
 - Folder-row Open in Terminal: [`SPECs/sidebar-empty-area-context-menu-spec.md`](SPECs/sidebar-empty-area-context-menu-spec.md) — add an Open in Terminal action to folder row context menus, launching the selected in-workspace directory with the configured terminal.
 - Configurable default terminal: [`SPECs/configurable-default-terminal-spec.md`](SPECs/configurable-default-terminal-spec.md) — add a global Workspace preference for the terminal app/executable used by the sidebar's Open in Terminal action, preserving the platform default when unset.
 - Sidebar empty-area workspace actions: [`SPECs/sidebar-empty-area-context-menu-spec.md`](SPECs/sidebar-empty-area-context-menu-spec.md) — right-click sidebar gaps and section headers to create a root file/folder, open the workspace in Terminal or Finder, and retain the existing Search/Recents visibility toggles.

--- a/apps/desktop/e2e/specs/font-picker.spec.js
+++ b/apps/desktop/e2e/specs/font-picker.spec.js
@@ -8,7 +8,7 @@ const SELECTED_STACK = 'Menlo, Georgia, "Times New Roman", serif';
 
 describe("Settings font selects", function () {
   before(async function () {
-    const workspaceRestored = await $('button[aria-label="Hide sidebar"]')
+    const workspaceRestored = await $('[data-sidebar-surface][data-workspace-open="true"]')
       .waitForExist({ timeout: 3_000 })
       .catch(() => false);
     if (!workspaceRestored) {
@@ -28,6 +28,7 @@ describe("Settings font selects", function () {
     }, INITIAL_STACK);
     await browser.refresh();
     await $('button[aria-label="Hide sidebar"]').waitForExist({ timeout: 15_000 });
+    await $('[data-sidebar-surface][data-workspace-open="true"]').waitForExist({ timeout: 15_000 });
   });
 
   async function pressCmd(key) {

--- a/apps/desktop/e2e/specs/latex-math.spec.js
+++ b/apps/desktop/e2e/specs/latex-math.spec.js
@@ -41,7 +41,7 @@ describe("LaTeX math rendering", function () {
   }
 
   before(async function () {
-    workspaceRestored = await $('button[aria-label="Hide sidebar"]')
+    workspaceRestored = await $('[data-sidebar-surface][data-workspace-open="true"]')
       .waitForExist({ timeout: 15_000 })
       .catch(() => false);
     if (!workspaceRestored) return;

--- a/apps/desktop/e2e/specs/visibility-settings.spec.js
+++ b/apps/desktop/e2e/specs/visibility-settings.spec.js
@@ -62,13 +62,15 @@ async function footerMetricLabels() {
 
 describe("status bar and sidebar visibility settings", function () {
   before(async function () {
-    const workspaceRestored = await $('button[aria-label="Hide sidebar"]')
+    const workspaceRestored = await $('[data-sidebar-surface][data-workspace-open="true"]')
       .waitForExist({ timeout: 3_000 })
       .catch(() => false);
     if (!workspaceRestored) {
       await invoke("open_workspace", { path: E2E_WORKSPACE });
+      await browser.refresh();
     }
     await waitForMount();
+    await $('[data-sidebar-surface][data-workspace-open="true"]').waitForExist({ timeout: 15_000 });
     await resetVisibilitySettings();
     await browser.refresh();
     await waitForMount();
@@ -112,6 +114,29 @@ describe("status bar and sidebar visibility settings", function () {
     await browser.refresh();
     await waitForMount();
     strictEqual(await $("[data-sidebar-search-button]").isExisting(), false);
+  });
+
+  it("keeps top, content, and bottom sidebar zones on the surface hit path", async function () {
+    const hitPaths = await browser.execute(() => {
+      const surface = document.querySelector("[data-sidebar-surface]");
+      if (!(surface instanceof HTMLElement)) return null;
+      const surfaceRect = surface.getBoundingClientRect();
+      const zones = [
+        document.querySelector("[data-sidebar-surface-top]"),
+        document.querySelector("[data-sidebar-surface-content]"),
+        document.querySelector("[data-sidebar-surface-bottom]"),
+      ];
+      return zones.map((zone) => {
+        if (!(zone instanceof HTMLElement)) return false;
+        const rect = zone.getBoundingClientRect();
+        const x = Math.min(surfaceRect.right - 8, rect.left + Math.max(8, rect.width / 4));
+        const y = rect.top + Math.max(1, Math.min(rect.height - 1, rect.height / 2));
+        const hit = document.elementFromPoint(x, y);
+        return hit?.closest("[data-sidebar-surface]") === surface;
+      });
+    });
+
+    strictEqual(JSON.stringify(hitPaths), JSON.stringify([true, true, true]));
   });
 
   it("renders visibility toggles and the Default Terminal preference", async function () {

--- a/apps/desktop/shared/sidebar-entry-kinds.json
+++ b/apps/desktop/shared/sidebar-entry-kinds.json
@@ -1,0 +1,4 @@
+{
+  "file": true,
+  "folder": true
+}

--- a/apps/desktop/shared/workspace-identity.contract.json
+++ b/apps/desktop/shared/workspace-identity.contract.json
@@ -1,0 +1,4 @@
+{
+  "root": "/workspace",
+  "epoch": 7
+}

--- a/apps/desktop/src-tauri/src/commands/fs.rs
+++ b/apps/desktop/src-tauri/src/commands/fs.rs
@@ -503,17 +503,40 @@ pub async fn create_directory(path: String) -> Result<DirEntry, AppError> {
     blocking(move || create_directory_impl(&path)).await
 }
 
-#[derive(Clone, Copy, Debug, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum SidebarEntryKind {
-    File,
-    Folder,
+macro_rules! sidebar_entry_kinds {
+    ($( $variant:ident => $wire:literal ),+ $(,)?) => {
+        #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+        pub enum SidebarEntryKind {
+            $(#[serde(rename = $wire)] $variant),+
+        }
+
+        impl SidebarEntryKind {
+            #[cfg(test)]
+            const ALL: &'static [Self] = &[$(Self::$variant),+];
+        }
+    };
 }
 
-pub fn create_sidebar_entry_impl(
+sidebar_entry_kinds!(File => "file", Folder => "folder");
+
+fn create_sidebar_candidate(
+    candidate: &Path,
+    kind: SidebarEntryKind,
+) -> Result<DirEntry, AppError> {
+    match kind {
+        SidebarEntryKind::File => create_file_impl(&candidate.to_string_lossy()).and_then(|_| {
+            markdown_file_entry(candidate)
+                .ok_or_else(|| AppError::Io("Created Markdown file is unreadable".into()))
+        }),
+        SidebarEntryKind::Folder => create_directory_impl(&candidate.to_string_lossy()),
+    }
+}
+
+fn create_sidebar_entry_with(
     parent_path: &Path,
     workspace_root: &Path,
     kind: SidebarEntryKind,
+    mut create_candidate: impl FnMut(&Path, SidebarEntryKind) -> Result<DirEntry, AppError>,
 ) -> Result<DirEntry, AppError> {
     let root = workspace_root
         .canonicalize()
@@ -540,15 +563,7 @@ pub fn create_sidebar_entry_impl(
             SidebarEntryKind::File => parent.join(format!("{}.md", numbered("Untitled"))),
             SidebarEntryKind::Folder => parent.join(numbered("Untitled Folder")),
         };
-        let result = match kind {
-            SidebarEntryKind::File => {
-                create_file_impl(&candidate.to_string_lossy()).and_then(|_| {
-                    markdown_file_entry(&candidate)
-                        .ok_or_else(|| AppError::Io("Created Markdown file is unreadable".into()))
-                })
-            }
-            SidebarEntryKind::Folder => create_directory_impl(&candidate.to_string_lossy()),
-        };
+        let result = create_candidate(&candidate, kind);
         match result {
             Ok(entry) => return Ok(entry),
             Err(AppError::AlreadyExists(_)) => {
@@ -561,6 +576,54 @@ pub fn create_sidebar_entry_impl(
     }
 }
 
+#[cfg(test)]
+pub fn create_sidebar_entry_impl(
+    parent_path: &Path,
+    workspace_root: &Path,
+    kind: SidebarEntryKind,
+) -> Result<DirEntry, AppError> {
+    create_sidebar_entry_with(parent_path, workspace_root, kind, create_sidebar_candidate)
+}
+
+fn create_sidebar_entry_for_snapshot(
+    state: &WorkspaceState,
+    parent_path: &Path,
+    workspace_root: &Path,
+    workspace_epoch: u64,
+    kind: SidebarEntryKind,
+) -> Result<DirEntry, AppError> {
+    create_sidebar_entry_with(parent_path, workspace_root, kind, |candidate, kind| {
+        state
+            .with_workspace_snapshot(workspace_root, workspace_epoch, || {
+                let live_root = workspace_root
+                    .canonicalize()
+                    .map_err(|error| AppError::Io(error.to_string()))?;
+                if live_root != workspace_root {
+                    return Err(AppError::InvalidPath(
+                        "Workspace folder changed before the sidebar entry could be created".into(),
+                    ));
+                }
+                let live_parent = parent_path
+                    .canonicalize()
+                    .map_err(|_| AppError::NotFound(parent_path.to_string_lossy().into_owned()))?;
+                if !live_parent.is_dir() || !live_parent.starts_with(&live_root) {
+                    return Err(AppError::InvalidPath(
+                        parent_path.to_string_lossy().into_owned(),
+                    ));
+                }
+                let file_name = candidate.file_name().ok_or_else(|| {
+                    AppError::InvalidPath(candidate.to_string_lossy().into_owned())
+                })?;
+                create_sidebar_candidate(&live_parent.join(file_name), kind)
+            })
+            .ok_or_else(|| {
+                AppError::InvalidPath(
+                    "Workspace changed before the sidebar entry could be created".into(),
+                )
+            })?
+    })
+}
+
 #[tauri::command]
 pub async fn create_sidebar_entry(
     parent_path: String,
@@ -569,12 +632,11 @@ pub async fn create_sidebar_entry(
     app: tauri::AppHandle,
 ) -> Result<DirEntry, AppError> {
     let state = app.state::<AppState>().get_or_create(webview.label());
-    let root = state
-        .workspace_root
-        .read()
-        .clone()
-        .ok_or(AppError::NoWorkspace)?;
-    blocking(move || create_sidebar_entry_impl(Path::new(&parent_path), &root, kind)).await
+    let (root, epoch) = state.workspace_snapshot().ok_or(AppError::NoWorkspace)?;
+    blocking(move || {
+        create_sidebar_entry_for_snapshot(&state, Path::new(&parent_path), &root, epoch, kind)
+    })
+    .await
 }
 
 pub fn rename_entry_impl(old_path: &str, new_path: &str) -> Result<(), AppError> {
@@ -947,6 +1009,77 @@ mod tests {
             create_sidebar_entry_impl(outside.path(), workspace.path(), SidebarEntryKind::Folder);
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn sidebar_entry_kind_serialization_matches_the_shared_contract() {
+        let contract: std::collections::HashMap<String, bool> =
+            serde_json::from_str(include_str!("../../../shared/sidebar-entry-kinds.json")).unwrap();
+        let serialized = SidebarEntryKind::ALL
+            .iter()
+            .copied()
+            .map(|kind| {
+                serde_json::to_value(kind)
+                    .unwrap()
+                    .as_str()
+                    .unwrap()
+                    .to_string()
+            })
+            .collect::<std::collections::HashSet<_>>();
+
+        assert_eq!(
+            serialized,
+            contract
+                .into_keys()
+                .collect::<std::collections::HashSet<_>>()
+        );
+    }
+
+    #[test]
+    fn create_sidebar_entry_rejects_stale_workspace_before_mutation() {
+        let workspace = TempDir::new().unwrap();
+        let replacement = TempDir::new().unwrap();
+        let root = workspace.path().canonicalize().unwrap();
+        let state = WorkspaceState::default();
+        let epoch = state.replace_workspace_root(root.clone());
+        state.replace_workspace_root(replacement.path().canonicalize().unwrap());
+
+        assert!(matches!(
+            create_sidebar_entry_for_snapshot(&state, &root, &root, epoch, SidebarEntryKind::File,)
+                .unwrap_err(),
+            AppError::InvalidPath(_)
+        ));
+        assert!(!root.join("Untitled.md").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn create_sidebar_entry_rejects_a_replaced_workspace_root() {
+        use std::os::unix::fs::symlink;
+
+        let parent = TempDir::new().unwrap();
+        let workspace_path = parent.path().join("workspace");
+        fs::create_dir(&workspace_path).unwrap();
+        let root = workspace_path.canonicalize().unwrap();
+        let state = WorkspaceState::default();
+        let epoch = state.replace_workspace_root(root.clone());
+
+        fs::rename(&workspace_path, parent.path().join("moved-workspace")).unwrap();
+        let outside = TempDir::new().unwrap();
+        symlink(outside.path(), &workspace_path).unwrap();
+
+        assert!(matches!(
+            create_sidebar_entry_for_snapshot(
+                &state,
+                &workspace_path,
+                &root,
+                epoch,
+                SidebarEntryKind::File,
+            )
+            .unwrap_err(),
+            AppError::InvalidPath(_)
+        ));
+        assert!(!outside.path().join("Untitled.md").exists());
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/commands/search.rs
+++ b/apps/desktop/src-tauri/src/commands/search.rs
@@ -30,33 +30,29 @@ pub fn index_workspace(
     app: tauri::AppHandle,
 ) -> Result<IndexStats, AppError> {
     let state = app.state::<AppState>().get_or_create(webview.label());
-    let root = state
-        .workspace_root
-        .read()
-        .clone()
-        .ok_or(AppError::NoWorkspace)?;
+    let (root, epoch) = state.workspace_snapshot().ok_or(AppError::NoWorkspace)?;
     let cancel = Arc::clone(&state.cancel_index.read());
-    // Capture the epoch before the (potentially multi-second) walk. If the
-    // user switches workspaces while we run, the epoch advances and we drop
-    // our results on the floor rather than overwriting the new workspace.
-    let epoch = state.workspace_epoch.load(Ordering::SeqCst);
 
     let start = std::time::Instant::now();
     let (indexed, dirs) = index_workspace_impl(&root, cancel);
     let file_count = indexed.len();
     let duration_ms = start.elapsed().as_millis() as u64;
 
-    if state.workspace_epoch.load(Ordering::SeqCst) != epoch {
+    let displaced = state.with_workspace_snapshot(&root, epoch, || {
+        let old_index = std::mem::replace(&mut *state.file_index.write(), indexed);
+        let old_cache = state.recent_files_cache.write().take();
+        let old_dirs = std::mem::replace(&mut *state.dirs_with_markdown.write(), dirs);
+        state.file_index_revision.fetch_add(1, Ordering::SeqCst);
+        state.index_ready.store(true, Ordering::Relaxed);
+        (old_index, old_cache, old_dirs)
+    });
+    let Some(displaced) = displaced else {
         return Ok(IndexStats {
             file_count: 0,
             duration_ms,
         });
-    }
-
-    *state.file_index.write() = indexed;
-    state.invalidate_recent_files_cache();
-    *state.dirs_with_markdown.write() = dirs;
-    state.index_ready.store(true, Ordering::Relaxed);
+    };
+    drop(displaced);
 
     Ok(IndexStats {
         file_count,

--- a/apps/desktop/src-tauri/src/commands/settings.rs
+++ b/apps/desktop/src-tauri/src/commands/settings.rs
@@ -32,6 +32,30 @@ fn with_settings_mut<T>(
     }
 }
 
+fn with_global_settings_mut<T>(
+    app_state: &AppState,
+    state: &WorkspaceState,
+    f: impl FnOnce(&mut Settings) -> Result<T, AppError>,
+) -> Result<T, AppError> {
+    let _global_guard = app_state.global_settings_file_lock.lock();
+    let mut settings_guard = state.settings.write();
+    let settings = settings_guard
+        .as_mut()
+        .ok_or_else(|| AppError::Io("Settings not initialized".into()))?;
+    f(settings)
+}
+
+fn init_window_settings_at(
+    app_state: &AppState,
+    state: &WorkspaceState,
+    config_dir: std::path::PathBuf,
+) -> Result<(), AppError> {
+    let _global_guard = app_state.global_settings_file_lock.lock();
+    let settings = Settings::new(config_dir).map_err(|error| AppError::Io(error.to_string()))?;
+    *state.settings.write() = Some(settings);
+    Ok(())
+}
+
 pub(crate) fn get_global_string_setting(
     app: &tauri::AppHandle,
     label: &str,
@@ -51,12 +75,15 @@ pub(crate) fn get_global_string_setting(
 /// (main window in `setup`, secondary windows in `open_workspace_in_new_window`
 /// and the single-instance handler) so every window has its own merged view
 /// of defaults + global + workspace settings.
-pub fn init_window_settings(app: &tauri::AppHandle, state: &Arc<WorkspaceState>) {
+pub fn init_window_settings(
+    app: &tauri::AppHandle,
+    state: &Arc<WorkspaceState>,
+) -> Result<(), AppError> {
     let config_dir = app
         .path()
         .app_data_dir()
         .expect("failed to get app data dir");
-    *state.settings.write() = Some(Settings::new(config_dir));
+    init_window_settings_at(app.state::<AppState>().inner(), state, config_dir)
 }
 
 pub fn config_value_to_json(v: &ConfigValue) -> Value {
@@ -125,7 +152,8 @@ pub fn set_setting(
     let config_value =
         json_to_config_value(&value).ok_or_else(|| AppError::Io("Invalid value type".into()))?;
 
-    let persisted = with_settings_mut(&app, webview.label(), |settings| {
+    let state = app.state::<AppState>().get_or_create(webview.label());
+    let persist = |settings: &mut Settings| {
         let result = match scope.as_str() {
             "workspace" => settings.set_workspace(&key, config_value),
             _ => settings.set_global(&key, config_value),
@@ -138,7 +166,12 @@ pub fn set_setting(
         value
             .cloned()
             .ok_or_else(|| AppError::Io(format!("Missing setting after write: {key}")))
-    })??;
+    };
+    let persisted = if scope == "workspace" {
+        with_settings_mut(&app, webview.label(), persist)??
+    } else {
+        with_global_settings_mut(app.state::<AppState>().inner(), &state, persist)?
+    };
     Ok(config_value_to_json(&persisted))
 }
 
@@ -149,11 +182,81 @@ pub fn reset_setting(
     webview: tauri::Webview,
     app: tauri::AppHandle,
 ) -> Result<(), AppError> {
-    with_settings_mut(&app, webview.label(), |settings| {
+    let state = app.state::<AppState>().get_or_create(webview.label());
+    let reset = |settings: &mut Settings| {
         let result = match scope.as_str() {
             "workspace" => settings.reset_workspace(&key),
             _ => settings.reset_global(&key),
         };
         result.map_err(|e| AppError::Io(e.to_string()))
-    })?
+    };
+    if scope == "workspace" {
+        with_settings_mut(&app, webview.label(), reset)?
+    } else {
+        with_global_settings_mut(app.state::<AppState>().inner(), &state, reset)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    #[test]
+    fn global_mutation_and_window_initialization_share_one_process_lock() {
+        let config_dir = tempfile::tempdir().unwrap();
+        let app_state = Arc::new(AppState::new());
+        let writer_state = Arc::new(WorkspaceState::default());
+        *writer_state.settings.write() =
+            Some(Settings::new(config_dir.path().to_path_buf()).unwrap());
+        let initializing_state = Arc::new(WorkspaceState::default());
+
+        let (writer_entered_tx, writer_entered_rx) = mpsc::channel();
+        let (release_writer_tx, release_writer_rx) = mpsc::channel();
+        let writer_app_state = app_state.clone();
+        let writer_window_state = writer_state.clone();
+        let writer = std::thread::spawn(move || {
+            with_global_settings_mut(&writer_app_state, &writer_window_state, |settings| {
+                writer_entered_tx.send(()).unwrap();
+                release_writer_rx.recv().unwrap();
+                settings
+                    .set_global(
+                        "workspace.default-terminal",
+                        ConfigValue::String("Ghostty".into()),
+                    )
+                    .map_err(|error| AppError::Io(error.to_string()))
+            })
+            .unwrap();
+        });
+        writer_entered_rx.recv().unwrap();
+
+        let (initialized_tx, initialized_rx) = mpsc::channel();
+        let init_app_state = app_state.clone();
+        let init_window_state = initializing_state.clone();
+        let init_config_dir = config_dir.path().to_path_buf();
+        let initializer = std::thread::spawn(move || {
+            init_window_settings_at(&init_app_state, &init_window_state, init_config_dir).unwrap();
+            initialized_tx.send(()).unwrap();
+        });
+
+        assert!(initialized_rx
+            .recv_timeout(Duration::from_millis(50))
+            .is_err());
+        assert!(initializing_state.settings.read().is_none());
+
+        release_writer_tx.send(()).unwrap();
+        writer.join().unwrap();
+        initialized_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        initializer.join().unwrap();
+
+        let initialized = initializing_state.settings.read();
+        assert_eq!(
+            initialized
+                .as_ref()
+                .unwrap()
+                .get("workspace.default-terminal"),
+            Some(&ConfigValue::String("Ghostty".into()))
+        );
+    }
 }

--- a/apps/desktop/src-tauri/src/commands/workspace.rs
+++ b/apps/desktop/src-tauri/src/commands/workspace.rs
@@ -3,13 +3,13 @@ use crate::commands::search::index_workspace_impl;
 use crate::commands::settings::get_global_string_setting;
 use crate::error::AppError;
 use crate::ignore::WorkspaceIgnore;
-use crate::state::{AppState, WorkspaceState};
+use crate::state::{AppState, WorkspaceRuntimeDrop, WorkspaceState};
 use crate::watcher::drop_watcher_off_thread;
 use crate::PendingOpenPayload;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tauri::{Emitter, Manager};
@@ -20,6 +20,14 @@ pub struct WorkspaceInfo {
     pub root: String,
     pub name: String,
     pub file_count: usize,
+    pub epoch: u64,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct IndexCompleteEvent {
+    workspace: crate::watcher::WorkspaceIdentity,
+    file_count: usize,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -46,9 +54,13 @@ enum TerminalExecution {
 
 const DEFAULT_TERMINAL_SETTING_KEY: &str = "workspace.default-terminal";
 
+fn drop_workspace_runtime_off_thread(runtime: WorkspaceRuntimeDrop) {
+    std::thread::spawn(move || drop(runtime));
+}
+
 fn terminal_launch_specs(
     platform: LaunchPlatform,
-    root: &Path,
+    target_dir: &Path,
     preferred_terminal: Option<&str>,
     terminal_env: Option<&str>,
 ) -> Vec<TerminalLaunchSpec> {
@@ -58,53 +70,48 @@ fn terminal_launch_specs(
                 execution: TerminalExecution| TerminalLaunchSpec {
         program: program.to_string(),
         args,
-        current_dir: root.to_path_buf(),
+        current_dir: target_dir.to_path_buf(),
         new_console,
         execution,
     };
 
-    if let Some(program) = preferred_terminal {
-        return match platform {
-            LaunchPlatform::MacOs => vec![spec(
-                "open",
-                vec![
-                    "-a".into(),
-                    program.into(),
-                    root.to_string_lossy().into_owned(),
-                ],
-                false,
-                TerminalExecution::WaitForSuccess,
-            )],
-            LaunchPlatform::Windows => {
-                vec![spec(program, Vec::new(), true, TerminalExecution::Detached)]
-            }
-            LaunchPlatform::Linux => vec![spec(
-                program,
-                Vec::new(),
-                false,
-                TerminalExecution::Detached,
-            )],
-        };
-    }
-
-    match platform {
-        LaunchPlatform::MacOs => vec![spec(
+    match (platform, preferred_terminal) {
+        (LaunchPlatform::MacOs, Some(program)) => vec![spec(
             "open",
             vec![
                 "-a".into(),
-                "Terminal".into(),
-                root.to_string_lossy().into_owned(),
+                program.into(),
+                target_dir.to_string_lossy().into_owned(),
             ],
             false,
             TerminalExecution::WaitForSuccess,
         )],
-        LaunchPlatform::Windows => vec![spec(
+        (LaunchPlatform::MacOs, None) => vec![spec(
+            "open",
+            vec![
+                "-a".into(),
+                "Terminal".into(),
+                target_dir.to_string_lossy().into_owned(),
+            ],
+            false,
+            TerminalExecution::WaitForSuccess,
+        )],
+        (LaunchPlatform::Windows, Some(program)) => {
+            vec![spec(program, Vec::new(), true, TerminalExecution::Detached)]
+        }
+        (LaunchPlatform::Windows, None) => vec![spec(
             "cmd.exe",
             vec!["/K".into()],
             true,
             TerminalExecution::Detached,
         )],
-        LaunchPlatform::Linux => {
+        (LaunchPlatform::Linux, Some(program)) => vec![spec(
+            program,
+            Vec::new(),
+            false,
+            TerminalExecution::Detached,
+        )],
+        (LaunchPlatform::Linux, None) => {
             let mut programs = Vec::new();
             if let Some(program) = terminal_env
                 .map(str::trim)
@@ -168,6 +175,7 @@ fn validate_terminal_target(
     Ok(target)
 }
 
+#[cfg(test)]
 fn validate_terminal_launch_snapshot(
     state: &WorkspaceState,
     captured_root: &Path,
@@ -189,6 +197,7 @@ fn validate_terminal_launch_snapshot(
     Ok(())
 }
 
+#[cfg(test)]
 fn validate_terminal_launch_boundary(
     state: &WorkspaceState,
     captured_root: &Path,
@@ -196,23 +205,58 @@ fn validate_terminal_launch_boundary(
     requested_path: Option<&Path>,
     captured_target: &Path,
 ) -> Result<(), AppError> {
-    validate_terminal_launch_snapshot(state, captured_root, captured_epoch)?;
-    let live_target = validate_terminal_target(captured_root, requested_path)?;
-    if live_target != captured_target {
-        return Err(AppError::InvalidPath(
-            "Selected folder changed before the terminal could be opened".into(),
-        ));
-    }
-    Ok(())
+    with_terminal_launch_snapshot(
+        state,
+        captured_root,
+        captured_epoch,
+        requested_path,
+        captured_target,
+        || Ok(()),
+    )
 }
 
-fn workspace_root_for_window(app: &tauri::AppHandle, label: &str) -> Result<PathBuf, AppError> {
-    app.state::<AppState>()
-        .get_or_create(label)
-        .workspace_root
-        .read()
-        .clone()
-        .ok_or(AppError::NoWorkspace)
+fn with_terminal_launch_snapshot<T>(
+    state: &WorkspaceState,
+    captured_root: &Path,
+    captured_epoch: u64,
+    requested_path: Option<&Path>,
+    captured_target: &Path,
+    launch: impl FnOnce() -> Result<T, AppError>,
+) -> Result<T, AppError> {
+    state
+        .with_workspace_snapshot(captured_root, captured_epoch, || {
+            let live_target = validate_terminal_target(captured_root, requested_path)?;
+            if live_target != captured_target {
+                return Err(AppError::InvalidPath(
+                    "Selected folder changed before the terminal could be opened".into(),
+                ));
+            }
+            launch()
+        })
+        .ok_or_else(|| {
+            AppError::InvalidPath("Workspace changed before the terminal could be opened".into())
+        })?
+}
+
+fn open_workspace_in_file_manager_for_snapshot<T>(
+    state: &WorkspaceState,
+    captured_root: &Path,
+    captured_epoch: u64,
+    open: impl FnOnce(&Path) -> Result<T, AppError>,
+) -> Result<T, AppError> {
+    state
+        .with_workspace_snapshot(captured_root, captured_epoch, || {
+            let live_root = validate_workspace_launch_root(captured_root)?;
+            if live_root != captured_root {
+                return Err(AppError::InvalidPath(
+                    "Workspace folder changed before it could be opened".into(),
+                ));
+            }
+            open(&live_root)
+        })
+        .ok_or_else(|| {
+            AppError::InvalidPath("Workspace changed before it could be opened".into())
+        })?
 }
 
 fn terminal_launch_error(preferred_terminal: Option<&str>, reason: &str) -> AppError {
@@ -226,15 +270,15 @@ fn terminal_launch_error(preferred_terminal: Option<&str>, reason: &str) -> AppE
 }
 
 fn launch_terminal(
-    root: &Path,
+    target_dir: &Path,
     preferred_terminal: &str,
-    validate_before_launch: impl Fn() -> Result<(), AppError>,
+    mut spawn_command: impl FnMut(&mut Command) -> Result<Result<Child, String>, AppError>,
 ) -> Result<(), AppError> {
     let preferred_terminal = (!preferred_terminal.is_empty()).then_some(preferred_terminal);
     let terminal_env = std::env::var("TERMINAL").ok();
     let specs = terminal_launch_specs(
         current_launch_platform(),
-        root,
+        target_dir,
         preferred_terminal,
         terminal_env.as_deref(),
     );
@@ -253,25 +297,36 @@ fn launch_terminal(
         #[cfg(not(target_os = "windows"))]
         let _ = launch.new_console;
 
-        validate_before_launch()?;
         match launch.execution {
-            TerminalExecution::Detached => match command.spawn() {
-                Ok(_) => return Ok(()),
-                Err(error) => last_error = Some(error.to_string()),
+            TerminalExecution::Detached => match spawn_command(&mut command) {
+                Ok(Ok(_)) => return Ok(()),
+                Ok(Err(error)) => last_error = Some(error),
+                Err(error) => return Err(error),
             },
-            TerminalExecution::WaitForSuccess => match command.output() {
-                Ok(output) if output.status.success() => return Ok(()),
-                Ok(output) => {
-                    let stderr = String::from_utf8_lossy(&output.stderr);
-                    let stderr = stderr.trim();
-                    last_error = Some(if stderr.is_empty() {
-                        format!("{} exited with {}", launch.program, output.status)
-                    } else {
-                        stderr.to_string()
-                    });
+            TerminalExecution::WaitForSuccess => {
+                command.stdout(Stdio::piped()).stderr(Stdio::piped());
+                let output = match spawn_command(&mut command) {
+                    Ok(Ok(child)) => child.wait_with_output(),
+                    Ok(Err(error)) => {
+                        last_error = Some(error);
+                        continue;
+                    }
+                    Err(error) => return Err(error),
+                };
+                match output {
+                    Ok(output) if output.status.success() => return Ok(()),
+                    Ok(output) => {
+                        let stderr = String::from_utf8_lossy(&output.stderr);
+                        let stderr = stderr.trim();
+                        last_error = Some(if stderr.is_empty() {
+                            format!("{} exited with {}", launch.program, output.status)
+                        } else {
+                            stderr.to_string()
+                        });
+                    }
+                    Err(error) => last_error = Some(error.to_string()),
                 }
-                Err(error) => last_error = Some(error.to_string()),
-            },
+            }
         }
     }
 
@@ -288,13 +343,34 @@ pub async fn open_workspace_in_file_manager(
     webview: tauri::Webview,
     app: tauri::AppHandle,
 ) -> Result<(), AppError> {
-    let root = workspace_root_for_window(&app, webview.label())?;
-    let root = tauri::async_runtime::spawn_blocking(move || validate_workspace_launch_root(&root))
-        .await
-        .map_err(|error| AppError::Io(error.to_string()))??;
-    app.opener()
-        .open_path(root.to_string_lossy().into_owned(), None::<String>)
-        .map_err(|error| AppError::Io(error.to_string()))
+    let state = app.state::<AppState>().get_or_create(webview.label());
+    let (root, epoch) = state.workspace_snapshot().ok_or(AppError::NoWorkspace)?;
+    tauri::async_runtime::spawn_blocking(move || {
+        open_workspace_in_file_manager_for_snapshot(&state, &root, epoch, |live_root| {
+            app.opener()
+                .open_path(live_root.to_string_lossy().into_owned(), None::<String>)
+                .map_err(|error| AppError::Io(error.to_string()))
+        })
+    })
+    .await
+    .map_err(|error| AppError::Io(error.to_string()))?
+}
+
+#[tauri::command]
+pub fn close_workspace(
+    root: String,
+    webview: tauri::Webview,
+    app: tauri::AppHandle,
+) -> Result<(), AppError> {
+    let state = app.state::<AppState>().get_or_create(webview.label());
+    let expected_root = PathBuf::from(&root);
+    let runtime = state
+        .clear_workspace_if_current(&expected_root)
+        .map_err(|()| {
+            AppError::InvalidPath("Workspace changed before it could be closed".into())
+        })?;
+    drop_workspace_runtime_off_thread(runtime);
+    Ok(())
 }
 
 #[tauri::command]
@@ -310,8 +386,10 @@ pub async fn open_workspace_in_terminal(
     tauri::async_runtime::spawn_blocking(move || {
         let requested_path = path.as_deref().map(Path::new);
         let target = validate_terminal_target(&root, requested_path)?;
-        launch_terminal(&target, &preferred_terminal, || {
-            validate_terminal_launch_boundary(&state, &root, epoch, requested_path, &target)
+        launch_terminal(&target, &preferred_terminal, |command| {
+            with_terminal_launch_snapshot(&state, &root, epoch, requested_path, &target, || {
+                Ok(command.spawn().map_err(|error| error.to_string()))
+            })
         })
     })
     .await
@@ -363,46 +441,8 @@ fn prepare_workspace_state(
 
     let state = app.state::<AppState>().get_or_create(label);
 
-    // Publish the new root and epoch under one lock. Every background task
-    // captured the prior epoch and will drop its results on the floor; launch
-    // commands cannot observe a new epoch paired with the outgoing root.
-    let new_epoch = state.replace_workspace_root(root.clone());
-
-    // Signal the outgoing walker to quit, then install a fresh token for the
-    // new workspace. The old `Arc<AtomicBool>` is still held by the in-flight
-    // walker; flipping it propagates to every walker thread within one
-    // directory boundary. Replacing the state slot with a fresh `Arc` leaves
-    // the flipped token alive inside the old walker but gives the new walker
-    // a clean signal.
-    let new_cancel = {
-        let mut guard = state.cancel_index.write();
-        guard.store(true, Ordering::SeqCst);
-        let fresh = Arc::new(AtomicBool::new(false));
-        *guard = Arc::clone(&fresh);
-        fresh
-    };
-
-    // Reset per-workspace state.
-    *state.standalone_file.write() = None;
-    *state.file_index.write() = Vec::new();
-    state.invalidate_recent_files_cache();
-    *state.dirs_with_markdown.write() = Default::default();
-    state.index_ready.store(false, Ordering::Relaxed);
-
-    // Install a cheap bootstrap matcher synchronously so the first
-    // `read_directory` call already hides `node_modules` / `.git`. The full
-    // matcher loads on the background thread below.
-    *state.workspace_ignore.write() = Some(Arc::new(WorkspaceIgnore::bootstrap()));
-
-    // Move the old watcher's `Drop` off the IPC thread — `notify`'s Drop can
-    // briefly block on FSEvents unregistration — so the IPC returns promptly.
-    let old_watcher = state.watcher_handle.write().take();
-    drop_watcher_off_thread(old_watcher);
-
-    // Load workspace-level settings (cheap, reads `.writer/config` on disk).
-    if let Some(settings) = state.settings.write().as_mut() {
-        settings.load_workspace(&root);
-    }
+    let (new_epoch, new_cancel, old_runtime) = state.transition_to_workspace(root.clone());
+    drop_workspace_runtime_off_thread(old_runtime);
 
     // Save to recent workspaces (one small JSON write). The canonical form is
     // stored so opening the same workspace via different aliases dedupes.
@@ -422,6 +462,7 @@ fn prepare_workspace_state(
         root: canonical_path,
         name,
         file_count: 0,
+        epoch: new_epoch,
     })
 }
 
@@ -449,13 +490,15 @@ fn run_workspace_bootstrap(
     // (per-directory inotify watches) — either way it's off the IPC thread.
     match crate::watcher::start_watcher(handle.clone(), label.clone(), &root, epoch) {
         Ok(watcher) => {
-            let mut guard = state.watcher_handle.write();
-            if !epoch_is_current(&state, epoch) {
-                // Don't install a stale watcher; let it drop.
-                drop(watcher);
+            let mut watcher = Some(watcher);
+            if state
+                .with_workspace_snapshot(&root, epoch, || {
+                    *state.watcher_handle.write() = watcher.take();
+                })
+                .is_none()
+            {
                 return;
             }
-            *guard = Some(watcher);
         }
         Err(e) => {
             eprintln!("Failed to start file watcher: {}", e);
@@ -465,21 +508,25 @@ fn run_workspace_bootstrap(
     // Load the full gitignore matcher. Walks every directory looking for
     // `.gitignore` files; bounded but not trivial on large repos.
     let new_ignore = Arc::new(WorkspaceIgnore::load(&root));
+    if state
+        .with_workspace_snapshot(&root, epoch, || {
+            *state.workspace_ignore.write() = Some(new_ignore);
+        })
+        .is_none()
     {
-        if !epoch_is_current(&state, epoch) {
-            return;
-        }
-        *state.workspace_ignore.write() = Some(new_ignore);
+        return;
     }
-
-    // Nudge the sidebar so custom ignore rules take effect immediately
-    // without waiting for a file event.
+    let root_string = root.to_string_lossy().into_owned();
     let _ = handle.emit_to(
         label.clone(),
         "fs:directory-changed",
         crate::watcher::FileChangeEvent {
-            path: root.to_string_lossy().to_string(),
+            path: root_string.clone(),
             kind: "modified".to_string(),
+            workspace: Some(crate::watcher::WorkspaceIdentity {
+                root: root_string.clone(),
+                epoch,
+            }),
         },
     );
 
@@ -491,15 +538,29 @@ fn run_workspace_bootstrap(
     }
     let file_count = indexed.len();
 
-    if !epoch_is_current(&state, epoch) {
+    let displaced = state.with_workspace_snapshot(&root, epoch, || {
+        let old_index = std::mem::replace(&mut *state.file_index.write(), indexed);
+        let old_cache = state.recent_files_cache.write().take();
+        let old_dirs = std::mem::replace(&mut *state.dirs_with_markdown.write(), dirs);
+        state.file_index_revision.fetch_add(1, Ordering::SeqCst);
+        state.index_ready.store(true, Ordering::Relaxed);
+        (old_index, old_cache, old_dirs)
+    });
+    let Some(displaced) = displaced else {
         return;
-    }
-    *state.file_index.write() = indexed;
-    state.invalidate_recent_files_cache();
-    *state.dirs_with_markdown.write() = dirs;
-    state.index_ready.store(true, Ordering::Relaxed);
-
-    let _ = handle.emit_to(label, "index:complete", file_count);
+    };
+    drop(displaced);
+    let _ = handle.emit_to(
+        label,
+        "index:complete",
+        IndexCompleteEvent {
+            workspace: crate::watcher::WorkspaceIdentity {
+                root: root_string,
+                epoch,
+            },
+            file_count,
+        },
+    );
 }
 
 fn epoch_is_current(state: &WorkspaceState, captured: u64) -> bool {
@@ -987,7 +1048,10 @@ mod tests {
     fn macos_invalid_terminal_app_surfaces_the_open_helper_failure() {
         let dir = TempDir::new().unwrap();
         let preference = "Writer Definitely Missing Terminal 8B112EE0";
-        let error = launch_terminal(dir.path(), preference, || Ok(())).unwrap_err();
+        let error = launch_terminal(dir.path(), preference, |command| {
+            Ok(command.spawn().map_err(|error| error.to_string()))
+        })
+        .unwrap_err();
         let message = error.to_string();
 
         assert!(message.contains(preference));
@@ -1153,6 +1217,47 @@ mod tests {
             validate_terminal_launch_snapshot(&state, &first_root, first_epoch).unwrap_err(),
             AppError::InvalidPath(_)
         ));
+    }
+
+    #[test]
+    fn guarded_launch_helpers_reject_stale_callbacks_and_hold_the_workspace_read_guard() {
+        let first = TempDir::new().unwrap();
+        let second = TempDir::new().unwrap();
+        let first_root = first.path().canonicalize().unwrap();
+        let state = WorkspaceState::default();
+        let epoch = state.replace_workspace_root(first_root.clone());
+
+        let terminal_ran = std::cell::Cell::new(false);
+        with_terminal_launch_snapshot(&state, &first_root, epoch, None, &first_root, || {
+            terminal_ran.set(true);
+            assert!(state.workspace_root.try_write().is_none());
+            Ok(())
+        })
+        .unwrap();
+        assert!(terminal_ran.get());
+
+        state.replace_workspace_root(second.path().canonicalize().unwrap());
+        terminal_ran.set(false);
+        assert!(matches!(
+            with_terminal_launch_snapshot(&state, &first_root, epoch, None, &first_root, || {
+                terminal_ran.set(true);
+                Ok(())
+            },)
+            .unwrap_err(),
+            AppError::InvalidPath(_)
+        ));
+        assert!(!terminal_ran.get());
+
+        let file_manager_ran = std::cell::Cell::new(false);
+        assert!(matches!(
+            open_workspace_in_file_manager_for_snapshot(&state, &first_root, epoch, |_| {
+                file_manager_ran.set(true);
+                Ok(())
+            })
+            .unwrap_err(),
+            AppError::InvalidPath(_)
+        ));
+        assert!(!file_manager_ran.get());
     }
 
     #[cfg(target_os = "macos")]

--- a/apps/desktop/src-tauri/src/config.rs
+++ b/apps/desktop/src-tauri/src/config.rs
@@ -295,8 +295,32 @@ pub struct Settings {
     workspace_path: Option<PathBuf>,
 }
 
+pub(crate) struct WorkspaceSettingsLayer {
+    values: HashMap<String, ConfigValue>,
+    raw: String,
+    path: PathBuf,
+}
+
+pub(crate) struct WorkspaceSettingsLoader {
+    defaults: HashMap<String, ConfigValue>,
+}
+
+impl WorkspaceSettingsLoader {
+    pub(crate) fn read(&self, workspace_root: &Path) -> WorkspaceSettingsLayer {
+        let path = workspace_root.join(".writer").join("config");
+        let (raw, values) = if path.exists() {
+            let raw = std::fs::read_to_string(&path).unwrap_or_default();
+            let values = parse_config_with_defaults(&raw, Some(&self.defaults));
+            (raw, values)
+        } else {
+            (String::new(), HashMap::new())
+        };
+        WorkspaceSettingsLayer { values, raw, path }
+    }
+}
+
 impl Settings {
-    pub fn new(global_config_dir: PathBuf) -> Self {
+    pub fn new(global_config_dir: PathBuf) -> std::io::Result<Self> {
         let defaults = default_settings();
         let schema = settings_schema();
         let normalizers = schema
@@ -314,13 +338,7 @@ impl Settings {
             .collect::<HashSet<_>>();
         let global_path = global_config_dir.join("config");
 
-        let (global_raw, global) = if global_path.exists() {
-            let raw = std::fs::read_to_string(&global_path).unwrap_or_default();
-            let parsed = parse_config_with_defaults(&raw, Some(&defaults));
-            (raw, parsed)
-        } else {
-            (String::new(), HashMap::new())
-        };
+        let (global_raw, global) = Self::read_global(&global_path, &defaults)?;
 
         let mut settings = Self {
             defaults,
@@ -335,10 +353,26 @@ impl Settings {
         };
 
         // Migrate from old preferences.json if it exists and config doesn't
-        settings.migrate_from_preferences(&global_config_dir);
-        settings.migrate_theme_fonts();
+        settings.migrate_from_preferences(&global_config_dir)?;
+        settings.migrate_theme_fonts()?;
 
-        settings
+        Ok(settings)
+    }
+
+    fn read_global(
+        path: &Path,
+        defaults: &HashMap<String, ConfigValue>,
+    ) -> std::io::Result<(String, HashMap<String, ConfigValue>)> {
+        match std::fs::read_to_string(path) {
+            Ok(raw) => {
+                let parsed = parse_config_with_defaults(&raw, Some(defaults));
+                Ok((raw, parsed))
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                Ok((String::new(), HashMap::new()))
+            }
+            Err(error) => Err(error),
+        }
     }
 
     /// One-time migration: font stacks used to be per-mode theme primaries
@@ -347,7 +381,7 @@ impl Settings {
     /// light value (dark as fallback) unless the new key is already set, then
     /// drop the old keys from the global config. Old keys are kept on a failed
     /// write so a later launch can retry.
-    fn migrate_theme_fonts(&mut self) {
+    fn migrate_theme_fonts(&mut self) -> std::io::Result<()> {
         const FONT_SLOTS: [(&str, &str, &str); 3] = [
             ("fonts.ui", "theme.light.ui-font", "theme.dark.ui-font"),
             (
@@ -371,57 +405,62 @@ impl Settings {
                 continue;
             };
             if !self.global.contains_key(new_key) {
-                if let Err(error) = self.set_global(new_key, value) {
-                    eprintln!("[config] failed to migrate {new_key}: {error}");
-                    continue;
-                }
+                self.set_global(new_key, value)?;
             }
             for old_key in [light_key, dark_key] {
                 if self.global.contains_key(old_key) {
-                    if let Err(error) = self.reset_global(old_key) {
-                        eprintln!("[config] failed to drop migrated {old_key}: {error}");
-                    }
+                    self.reset_global(old_key)?;
                 }
             }
         }
+        Ok(())
     }
 
     /// One-time migration: read theme from old `preferences.json` (tauri-plugin-store format)
     /// and write it into the new config file. Removes the old file after migration.
-    fn migrate_from_preferences(&mut self, app_data_dir: &Path) {
+    fn migrate_from_preferences(&mut self, app_data_dir: &Path) -> std::io::Result<()> {
         let prefs_path = app_data_dir.join("preferences.json");
-        if !prefs_path.exists() {
-            return;
-        }
         // Only migrate if the global config doesn't already have a theme set
         if self.global.contains_key("appearance.theme") {
             // Old file exists but we already have settings — just clean up
-            let _ = std::fs::remove_file(&prefs_path);
-            return;
+            return match std::fs::remove_file(&prefs_path) {
+                Ok(()) => Ok(()),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+                Err(error) => Err(error),
+            };
         }
-        if let Ok(data) = std::fs::read_to_string(&prefs_path) {
-            if let Ok(json) = serde_json::from_str::<serde_json::Value>(&data) {
-                if let Some(theme) = json.get("theme").and_then(|v| v.as_str()) {
-                    let _ =
-                        self.set_global("appearance.theme", ConfigValue::String(theme.to_string()));
-                }
+        let data = match std::fs::read_to_string(&prefs_path) {
+            Ok(data) => data,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => return Err(error),
+        };
+        if let Ok(json) = serde_json::from_str::<serde_json::Value>(&data) {
+            if let Some(theme) = json.get("theme").and_then(|v| v.as_str()) {
+                self.set_global("appearance.theme", ConfigValue::String(theme.to_string()))?;
             }
         }
-        let _ = std::fs::remove_file(&prefs_path);
+        std::fs::remove_file(&prefs_path)
     }
 
     /// Load workspace-level config from `{workspace_root}/.writer/config`.
+    #[cfg(test)]
     pub fn load_workspace(&mut self, workspace_root: &Path) {
-        let path = workspace_root.join(".writer").join("config");
-        if path.exists() {
-            let raw = std::fs::read_to_string(&path).unwrap_or_default();
-            self.workspace = parse_config_with_defaults(&raw, Some(&self.defaults));
-            self.workspace_raw = raw;
-        } else {
-            self.workspace = HashMap::new();
-            self.workspace_raw = String::new();
+        let layer = self.workspace_loader().read(workspace_root);
+        self.install_workspace_layer(layer);
+    }
+
+    /// Snapshot immutable parser inputs while the settings lock is held; the
+    /// returned loader performs filesystem I/O without retaining that lock.
+    pub(crate) fn workspace_loader(&self) -> WorkspaceSettingsLoader {
+        WorkspaceSettingsLoader {
+            defaults: self.defaults.clone(),
         }
-        self.workspace_path = Some(path);
+    }
+
+    pub(crate) fn install_workspace_layer(&mut self, layer: WorkspaceSettingsLayer) {
+        self.workspace = layer.values;
+        self.workspace_raw = layer.raw;
+        self.workspace_path = Some(layer.path);
     }
 
     /// Clear workspace-level settings.
@@ -463,15 +502,18 @@ impl Settings {
 
     /// Set a value at the global scope, writing to disk.
     pub fn set_global(&mut self, key: &str, value: ConfigValue) -> std::io::Result<()> {
+        self.reload_global()?;
         let value = self.normalize_value(key, value);
-        self.global.insert(key.to_string(), value.clone());
         let mut current = parse_config_with_defaults(&self.global_raw, Some(&self.defaults));
         current.insert(key.to_string(), value);
-        self.global_raw = serialize_config(&current, &self.global_raw);
+        let next_raw = serialize_config(&current, &self.global_raw);
         if let Some(parent) = self.global_path.parent() {
             std::fs::create_dir_all(parent)?;
         }
-        std::fs::write(&self.global_path, &self.global_raw)
+        std::fs::write(&self.global_path, &next_raw)?;
+        self.global = current;
+        self.global_raw = next_raw;
+        Ok(())
     }
 
     /// Set a value at the workspace scope, writing to disk.
@@ -513,12 +555,17 @@ impl Settings {
 
     /// Remove a key override from the global scope.
     pub fn reset_global(&mut self, key: &str) -> std::io::Result<()> {
-        self.global.remove(key);
-        self.global_raw = remove_key_from_config(key, &self.global_raw);
+        self.reload_global()?;
+        let mut current = parse_config_with_defaults(&self.global_raw, Some(&self.defaults));
+        current.remove(key);
+        let next_raw = remove_key_from_config(key, &self.global_raw);
         if let Some(parent) = self.global_path.parent() {
             std::fs::create_dir_all(parent)?;
         }
-        std::fs::write(&self.global_path, &self.global_raw)
+        std::fs::write(&self.global_path, &next_raw)?;
+        self.global = current;
+        self.global_raw = next_raw;
+        Ok(())
     }
 
     /// Remove a key override from the workspace scope.
@@ -538,22 +585,11 @@ impl Settings {
     }
 
     /// Reload global config from disk.
-    pub fn reload_global(&mut self) {
-        if self.global_path.exists() {
-            self.global_raw = std::fs::read_to_string(&self.global_path).unwrap_or_default();
-            self.global = parse_config_with_defaults(&self.global_raw, Some(&self.defaults));
-        }
-    }
-
-    /// Reload workspace config from disk.
-    pub fn reload_workspace(&mut self) {
-        if let Some(ref path) = self.workspace_path {
-            if path.exists() {
-                self.workspace_raw = std::fs::read_to_string(path).unwrap_or_default();
-                self.workspace =
-                    parse_config_with_defaults(&self.workspace_raw, Some(&self.defaults));
-            }
-        }
+    pub fn reload_global(&mut self) -> std::io::Result<()> {
+        let (global_raw, global) = Self::read_global(&self.global_path, &self.defaults)?;
+        self.global_raw = global_raw;
+        self.global = global;
+        Ok(())
     }
 
     /// Path to the global config file.
@@ -668,7 +704,7 @@ mod tests {
     #[test]
     fn test_settings_merge_order() {
         let dir = tempfile::tempdir().unwrap();
-        let mut settings = Settings::new(dir.path().to_path_buf());
+        let mut settings = Settings::new(dir.path().to_path_buf()).unwrap();
 
         // Default
         assert_eq!(
@@ -697,7 +733,7 @@ mod tests {
         )
         .unwrap();
 
-        let settings = Settings::new(dir.path().to_path_buf());
+        let settings = Settings::new(dir.path().to_path_buf()).unwrap();
 
         // Light wins when both modes were customized; dark is the fallback.
         assert_eq!(
@@ -724,7 +760,7 @@ mod tests {
             "fonts.editor = Palatino, serif\ntheme.light.editor-font = Georgia, serif\n",
         )
         .unwrap();
-        let settings = Settings::new(dir.path().to_path_buf());
+        let settings = Settings::new(dir.path().to_path_buf()).unwrap();
         assert_eq!(
             settings.get("fonts.editor"),
             Some(&ConfigValue::String("Palatino, serif".into()))
@@ -735,7 +771,7 @@ mod tests {
     fn test_settings_workspace_override() {
         let dir = tempfile::tempdir().unwrap();
         let ws_dir = tempfile::tempdir().unwrap();
-        let mut settings = Settings::new(dir.path().to_path_buf());
+        let mut settings = Settings::new(dir.path().to_path_buf()).unwrap();
 
         settings
             .set_global("editor.font-size", ConfigValue::Number(18.0))
@@ -754,7 +790,7 @@ mod tests {
     #[test]
     fn test_settings_reset() {
         let dir = tempfile::tempdir().unwrap();
-        let mut settings = Settings::new(dir.path().to_path_buf());
+        let mut settings = Settings::new(dir.path().to_path_buf()).unwrap();
 
         settings
             .set_global("editor.font-size", ConfigValue::Number(18.0))
@@ -773,10 +809,84 @@ mod tests {
     }
 
     #[test]
+    fn stale_settings_instances_merge_global_writes_and_resets() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut first_window = Settings::new(dir.path().to_path_buf()).unwrap();
+        let mut second_window = Settings::new(dir.path().to_path_buf()).unwrap();
+
+        first_window
+            .set_global(
+                "workspace.default-terminal",
+                ConfigValue::String("Ghostty".into()),
+            )
+            .unwrap();
+        second_window
+            .set_global("appearance.sidebar-visible", ConfigValue::Bool(false))
+            .unwrap();
+
+        let after_write = Settings::new(dir.path().to_path_buf()).unwrap();
+        assert_eq!(
+            after_write.get("workspace.default-terminal"),
+            Some(&ConfigValue::String("Ghostty".into()))
+        );
+        assert_eq!(
+            after_write.get("appearance.sidebar-visible"),
+            Some(&ConfigValue::Bool(false))
+        );
+
+        second_window
+            .reset_global("appearance.sidebar-visible")
+            .unwrap();
+        let after_reset = Settings::new(dir.path().to_path_buf()).unwrap();
+        assert_eq!(
+            after_reset.get("workspace.default-terminal"),
+            Some(&ConfigValue::String("Ghostty".into()))
+        );
+    }
+
+    #[test]
+    fn reload_global_treats_missing_as_empty_and_preserves_memory_on_read_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut settings = Settings::new(dir.path().to_path_buf()).unwrap();
+        settings
+            .set_global(
+                "workspace.default-terminal",
+                ConfigValue::String("Ghostty".into()),
+            )
+            .unwrap();
+
+        std::fs::remove_file(settings.global_path()).unwrap();
+        settings.reload_global().unwrap();
+        assert_eq!(
+            settings.get("workspace.default-terminal"),
+            Some(&ConfigValue::String(String::new()))
+        );
+
+        settings
+            .set_global(
+                "workspace.default-terminal",
+                ConfigValue::String("Ghostty".into()),
+            )
+            .unwrap();
+        std::fs::remove_file(settings.global_path()).unwrap();
+        std::fs::create_dir(settings.global_path()).unwrap();
+
+        assert!(settings.reload_global().is_err());
+        assert_eq!(
+            settings.get("workspace.default-terminal"),
+            Some(&ConfigValue::String("Ghostty".into()))
+        );
+        assert!(settings
+            .set_global("appearance.sidebar-visible", ConfigValue::Bool(false))
+            .is_err());
+        assert!(settings.global_path().is_dir());
+    }
+
+    #[test]
     fn terminal_string_setting_preserves_lexical_value_across_reload_and_reset() {
         for value in ["TRUE", "00123", "1e3"] {
             let dir = tempfile::tempdir().unwrap();
-            let mut settings = Settings::new(dir.path().to_path_buf());
+            let mut settings = Settings::new(dir.path().to_path_buf()).unwrap();
             settings
                 .set_global(
                     "workspace.default-terminal",
@@ -784,14 +894,14 @@ mod tests {
                 )
                 .unwrap();
 
-            let mut reloaded = Settings::new(dir.path().to_path_buf());
+            let mut reloaded = Settings::new(dir.path().to_path_buf()).unwrap();
             assert_eq!(
                 reloaded.get("workspace.default-terminal"),
                 Some(&ConfigValue::String(value.into()))
             );
 
             reloaded.reset_global("workspace.default-terminal").unwrap();
-            let reset = Settings::new(dir.path().to_path_buf());
+            let reset = Settings::new(dir.path().to_path_buf()).unwrap();
             assert_eq!(
                 reset.get("workspace.default-terminal"),
                 Some(&ConfigValue::String(String::new()))
@@ -802,7 +912,7 @@ mod tests {
     #[test]
     fn terminal_string_setting_trims_at_the_settings_boundary() {
         let dir = tempfile::tempdir().unwrap();
-        let mut settings = Settings::new(dir.path().to_path_buf());
+        let mut settings = Settings::new(dir.path().to_path_buf()).unwrap();
 
         settings
             .set_global(
@@ -831,7 +941,7 @@ mod tests {
     fn global_setting_lookup_ignores_workspace_overrides() {
         let dir = tempfile::tempdir().unwrap();
         let workspace = tempfile::tempdir().unwrap();
-        let mut settings = Settings::new(dir.path().to_path_buf());
+        let mut settings = Settings::new(dir.path().to_path_buf()).unwrap();
         settings
             .set_global(
                 "workspace.default-terminal",

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -114,7 +114,7 @@ pub(crate) fn open_new_workspace_window(
 
     let label = format!("w-{}", uuid::Uuid::new_v4().simple());
     let state = app.state::<AppState>().get_or_create(&label);
-    init_window_settings(app, &state);
+    init_window_settings(app, &state)?;
     state.set_startup_open(PendingOpenPayload {
         workspace: Some(workspace_str),
         file,
@@ -150,7 +150,7 @@ pub(crate) fn open_standalone_file_window(
 
     let label = format!("w-{}", uuid::Uuid::new_v4().simple());
     let state = app.state::<AppState>().get_or_create(&label);
-    init_window_settings(app, &state);
+    init_window_settings(app, &state)?;
     state.set_startup_open(PendingOpenPayload {
         workspace: None,
         file: Some(file.to_string_lossy().to_string()),
@@ -493,7 +493,7 @@ pub fn run() {
             // pending-open queue). `get_or_create` lazily builds the
             // `WorkspaceState` for the `"main"` label.
             let main_state = app.state::<AppState>().get_or_create(MAIN_WINDOW_LABEL);
-            init_window_settings(app.handle(), &main_state);
+            init_window_settings(app.handle(), &main_state)?;
 
             // On macOS, `open -a Writer /path` delivers the path via
             // RunEvent::Opened, not argv. On Linux/Windows the path
@@ -553,6 +553,7 @@ pub fn run() {
             commands::fs::reveal_in_file_manager,
             commands::workspace::open_workspace,
             commands::workspace::open_workspace_in_file_manager,
+            commands::workspace::close_workspace,
             commands::workspace::open_workspace_in_terminal,
             commands::workspace::open_workspace_in_new_window,
             commands::workspace::restore_workspace,

--- a/apps/desktop/src-tauri/src/state.rs
+++ b/apps/desktop/src-tauri/src/state.rs
@@ -18,6 +18,7 @@ use std::time::Instant;
 pub struct WorkspaceState {
     pub workspace_root: RwLock<Option<PathBuf>>,
     pub file_index: RwLock<Vec<IndexedFile>>,
+    pub file_index_revision: AtomicU64,
     pub recent_files_cache: RwLock<Option<Vec<IndexedFile>>>,
     pub dirs_with_markdown: RwLock<HashSet<PathBuf>>,
     /// Set to `true` after the first full index completes.
@@ -74,11 +75,21 @@ pub struct IndexedFile {
     pub modified_at: u64,
 }
 
+pub type WorkspaceRuntimeDrop = (
+    Option<RecommendedWatcher>,
+    Vec<IndexedFile>,
+    Option<Vec<IndexedFile>>,
+    HashSet<PathBuf>,
+    HashMap<PathBuf, Instant>,
+    Option<Arc<WorkspaceIgnore>>,
+);
+
 impl Default for WorkspaceState {
     fn default() -> Self {
         Self {
             workspace_root: RwLock::new(None),
             file_index: RwLock::new(Vec::new()),
+            file_index_revision: AtomicU64::new(0),
             recent_files_cache: RwLock::new(None),
             dirs_with_markdown: RwLock::new(HashSet::new()),
             index_ready: AtomicBool::new(false),
@@ -97,9 +108,62 @@ impl Default for WorkspaceState {
 }
 
 impl WorkspaceState {
+    fn reset_workspace_runtime(&self) -> WorkspaceRuntimeDrop {
+        self.cancel_index.read().store(true, Ordering::SeqCst);
+        *self.standalone_file.write() = None;
+        let file_index = std::mem::take(&mut *self.file_index.write());
+        self.file_index_revision.fetch_add(1, Ordering::SeqCst);
+        let recent_cache = self.recent_files_cache.write().take();
+        let dirs = std::mem::take(&mut *self.dirs_with_markdown.write());
+        self.index_ready.store(false, Ordering::SeqCst);
+        let recent_writes = std::mem::take(&mut *self.recent_writes.write());
+        let ignore = self.workspace_ignore.write().take();
+        if let Some(settings) = self.settings.write().as_mut() {
+            settings.clear_workspace();
+        }
+        (
+            self.watcher_handle.write().take(),
+            file_index,
+            recent_cache,
+            dirs,
+            recent_writes,
+            ignore,
+        )
+    }
+
+    /// Transition to a workspace under the same root write guard used by
+    /// close. This is the single reset funnel for all workspace-owned runtime
+    /// state, so open and close cannot drift into different cleanup rules.
+    pub fn transition_to_workspace(
+        &self,
+        root: PathBuf,
+    ) -> (u64, Arc<AtomicBool>, WorkspaceRuntimeDrop) {
+        let workspace_loader = self
+            .settings
+            .read()
+            .as_ref()
+            .map(|settings| settings.workspace_loader());
+        let workspace_settings = workspace_loader.map(|loader| loader.read(&root));
+        let mut root_guard = self.workspace_root.write();
+        let old_watcher = self.reset_workspace_runtime();
+        let epoch = self.workspace_epoch.fetch_add(1, Ordering::SeqCst) + 1;
+        *root_guard = Some(root.clone());
+
+        let cancel = Arc::new(AtomicBool::new(false));
+        *self.cancel_index.write() = Arc::clone(&cancel);
+        *self.workspace_ignore.write() = Some(Arc::new(WorkspaceIgnore::bootstrap()));
+        if let (Some(settings), Some(layer)) = (self.settings.write().as_mut(), workspace_settings)
+        {
+            settings.install_workspace_layer(layer);
+        }
+
+        (epoch, cancel, old_watcher)
+    }
+
     /// Atomically publish a workspace root together with its new epoch.
     /// Readers that need both values must use [`Self::workspace_snapshot`]
     /// so they cannot observe a new epoch paired with the outgoing root.
+    #[cfg(test)]
     pub fn replace_workspace_root(&self, root: PathBuf) -> u64 {
         let mut root_guard = self.workspace_root.write();
         let epoch = self.workspace_epoch.fetch_add(1, Ordering::SeqCst) + 1;
@@ -111,6 +175,41 @@ impl WorkspaceState {
         let root_guard = self.workspace_root.read();
         let epoch = self.workspace_epoch.load(Ordering::SeqCst);
         root_guard.clone().map(|root| (root, epoch))
+    }
+
+    /// Run one immediate workspace-bound side effect only while a captured
+    /// root/epoch pair is still current. The root read guard remains held for
+    /// the callback, preventing a workspace switch from being published
+    /// between final validation and the side effect itself.
+    pub fn with_workspace_snapshot<T>(
+        &self,
+        captured_root: &Path,
+        captured_epoch: u64,
+        f: impl FnOnce() -> T,
+    ) -> Option<T> {
+        let root_guard = self.workspace_root.read();
+        let epoch = self.workspace_epoch.load(Ordering::SeqCst);
+        if root_guard.as_deref() != Some(captured_root) || epoch != captured_epoch {
+            return None;
+        }
+        Some(f())
+    }
+
+    /// Atomically invalidate and clear the currently hosted workspace. The
+    /// root write guard stays held while workspace-owned state is reset so a
+    /// concurrent open cannot publish its new root before cleanup finishes.
+    pub fn clear_workspace_if_current(
+        &self,
+        expected_root: &Path,
+    ) -> Result<WorkspaceRuntimeDrop, ()> {
+        let mut root_guard = self.workspace_root.write();
+        if root_guard.as_deref() != Some(expected_root) {
+            return Err(());
+        }
+
+        self.workspace_epoch.fetch_add(1, Ordering::SeqCst);
+        *root_guard = None;
+        Ok(self.reset_workspace_runtime())
     }
 
     pub fn set_startup_open(&self, payload: PendingOpenPayload) {
@@ -182,6 +281,7 @@ impl WorkspaceState {
                 if file.modified_at != modified_at {
                     file.modified_at = modified_at;
                     changed = true;
+                    self.file_index_revision.fetch_add(1, Ordering::SeqCst);
                 }
             }
         }
@@ -225,6 +325,10 @@ impl WorkspaceState {
 /// `commands::workspace::open_workspace_in_new_window`.
 pub struct AppState {
     windows: RwLock<HashMap<String, Arc<WorkspaceState>>>,
+    /// Serializes initialization, migrations, and read-modify-write mutations
+    /// of the global config shared by every window. Lock order is this mutex
+    /// first, then an individual window's `settings` lock.
+    pub global_settings_file_lock: Mutex<()>,
     /// Serializes read-modify-write on the shared `sessions.json` file so
     /// two windows can't clobber each other's tab state under the 500 ms
     /// debounce. Held only for the load→save span.
@@ -239,6 +343,7 @@ impl AppState {
     pub fn new() -> Self {
         Self {
             windows: RwLock::new(HashMap::new()),
+            global_settings_file_lock: Mutex::new(()),
             sessions_file_lock: Mutex::new(()),
             recent_files_lock: Mutex::new(()),
         }
@@ -497,5 +602,72 @@ mod tests {
             Err(second)
         );
         assert_eq!(window_state.take_startup_open(), Some(first));
+    }
+
+    #[test]
+    fn guarded_workspace_snapshot_rejects_stale_callbacks_and_holds_read_guard() {
+        let first = tempfile::tempdir().unwrap();
+        let second = tempfile::tempdir().unwrap();
+        let state = WorkspaceState::default();
+        let first_root = first.path().canonicalize().unwrap();
+        let first_epoch = state.replace_workspace_root(first_root.clone());
+
+        let ran = std::cell::Cell::new(false);
+        let result = state.with_workspace_snapshot(&first_root, first_epoch, || {
+            ran.set(true);
+            assert!(state.workspace_root.try_write().is_none());
+            42
+        });
+        assert_eq!(result, Some(42));
+        assert!(ran.get());
+
+        state.replace_workspace_root(second.path().canonicalize().unwrap());
+        ran.set(false);
+        assert_eq!(
+            state.with_workspace_snapshot(&first_root, first_epoch, || ran.set(true)),
+            None
+        );
+        assert!(!ran.get());
+
+        state.replace_workspace_root(first_root.clone());
+        assert_eq!(
+            state.with_workspace_snapshot(&first_root, first_epoch, || ran.set(true)),
+            None
+        );
+        assert!(!ran.get());
+    }
+
+    #[test]
+    fn close_workspace_invalidates_the_snapshot_and_rejects_stale_roots() {
+        let first = tempfile::tempdir().unwrap();
+        let second = tempfile::tempdir().unwrap();
+        let first_root = first.path().canonicalize().unwrap();
+        let second_root = second.path().canonicalize().unwrap();
+        let state = WorkspaceState::default();
+        let (first_epoch, _, _) = state.transition_to_workspace(first_root.clone());
+        state.dirs_with_markdown.write().insert(first_root.clone());
+        state.index_ready.store(true, Ordering::SeqCst);
+        state
+            .recent_writes
+            .write()
+            .insert(first_root.join("old.md"), Instant::now());
+
+        state.clear_workspace_if_current(&first_root).unwrap();
+        assert!(state.workspace_snapshot().is_none());
+        assert!(state.dirs_with_markdown.read().is_empty());
+        assert!(!state.index_ready.load(Ordering::SeqCst));
+        assert!(state.recent_writes.read().is_empty());
+        assert!(state.workspace_ignore.read().is_none());
+        assert!(state
+            .with_workspace_snapshot(&first_root, first_epoch, || ())
+            .is_none());
+
+        state.transition_to_workspace(second_root.clone());
+        assert!(state.workspace_ignore.read().is_some());
+        assert!(state.clear_workspace_if_current(&first_root).is_err());
+        assert_eq!(
+            state.workspace_snapshot().map(|(root, _)| root),
+            Some(second_root)
+        );
     }
 }

--- a/apps/desktop/src-tauri/src/watcher.rs
+++ b/apps/desktop/src-tauri/src/watcher.rs
@@ -30,9 +30,18 @@ macro_rules! wlog {
 }
 
 #[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct FileChangeEvent {
     pub path: String,
     pub kind: String,
+    pub workspace: Option<WorkspaceIdentity>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceIdentity {
+    pub root: String,
+    pub epoch: u64,
 }
 
 /// True if `path` should be dropped before any further processing.
@@ -125,9 +134,15 @@ pub fn record_write(state: &WorkspaceState, path: &Path) {
 /// Push `path` into the file index if not already present, then refresh the
 /// `dirs_with_markdown` ancestry so the sidebar's "directory contains
 /// markdown" check returns true for newly-populated subtrees.
+#[cfg(test)]
 fn add_to_index(state: &WorkspaceState, path: &Path, root: &Path) {
-    let mut index = state.file_index.write();
     let modified_at = crate::commands::fs::modified_time(path);
+    add_to_index_with_modified(state, path, root, modified_at);
+}
+
+#[cfg(test)]
+fn add_to_index_with_modified(state: &WorkspaceState, path: &Path, root: &Path, modified_at: u64) {
+    let mut index = state.file_index.write();
     if let Some(file) = index.iter_mut().find(|f| f.path == path) {
         if file.modified_at != modified_at {
             file.modified_at = modified_at;
@@ -151,30 +166,17 @@ fn add_to_index(state: &WorkspaceState, path: &Path, root: &Path) {
         name,
         modified_at,
     });
+    state.file_index_revision.fetch_add(1, Ordering::SeqCst);
     drop(index);
     state.invalidate_recent_files_cache();
 
     state::register_ancestors(&mut state.dirs_with_markdown.write(), path, root);
 }
 
-/// Drop a single path from the file index and rebuild `dirs_with_markdown`.
-fn remove_from_index(state: &WorkspaceState, path: &Path, root: &Path) {
-    let removed = {
-        let mut index = state.file_index.write();
-        let before = index.len();
-        index.retain(|f| f.path != path);
-        before != index.len()
-    };
-    if removed {
-        state.invalidate_recent_files_cache();
-    }
-    let index = state.file_index.read();
-    *state.dirs_with_markdown.write() = state::rebuild_dirs_from_index(&index, root);
-}
-
 /// Drop every indexed path under `dir` (a removed folder) and rebuild
 /// `dirs_with_markdown`. Needed because FSEvents may report a single
 /// `Remove(Folder)` without per-child Remove events.
+#[cfg(test)]
 fn remove_subtree_from_index(state: &WorkspaceState, dir: &Path, root: &Path) {
     let dir_with_sep = {
         let mut s = dir.to_path_buf();
@@ -185,7 +187,11 @@ fn remove_subtree_from_index(state: &WorkspaceState, dir: &Path, root: &Path) {
         let mut index = state.file_index.write();
         let before = index.len();
         index.retain(|f| !f.path.starts_with(&dir_with_sep) && f.path != dir);
-        before != index.len()
+        let removed = before != index.len();
+        if removed {
+            state.file_index_revision.fetch_add(1, Ordering::SeqCst);
+        }
+        removed
     };
     if removed {
         state.invalidate_recent_files_cache();
@@ -202,48 +208,172 @@ fn remove_subtree_from_index(state: &WorkspaceState, dir: &Path, root: &Path) {
 /// not re-emit per-child Create events for a renamed inode, so without
 /// this walk every file under the new directory would silently disappear
 /// from search results until the workspace is reopened.
-fn add_subtree_to_index(state: &WorkspaceState, dir: &Path, root: &Path) {
+fn discover_subtree(dir: &Path) -> Vec<crate::state::IndexedFile> {
     let cancel = Arc::new(AtomicBool::new(false));
     let (found, _) = crate::commands::search::index_workspace_impl(dir, cancel);
-    if found.is_empty() {
-        return;
-    }
+    found
+}
 
-    let mut added = Vec::new();
-    {
-        let mut index = state.file_index.write();
-        for file in found {
-            if index.iter().any(|f| f.path == file.path) {
+struct PreparedIndexUpdate {
+    revision: u64,
+    index: Vec<crate::state::IndexedFile>,
+    dirs: std::collections::HashSet<std::path::PathBuf>,
+    changed: bool,
+}
+
+struct DeferredIndexDrop {
+    _index: Vec<crate::state::IndexedFile>,
+    _dirs: std::collections::HashSet<std::path::PathBuf>,
+    _recent_cache: Option<Vec<crate::state::IndexedFile>>,
+}
+
+fn prepare_index_removal(
+    state: &WorkspaceState,
+    root: &Path,
+    mut remove: impl FnMut(&crate::state::IndexedFile) -> bool,
+) -> PreparedIndexUpdate {
+    let revision = state.file_index_revision.load(Ordering::SeqCst);
+    let mut index = state.file_index.read().clone();
+    let before = index.len();
+    index.retain(|file| !remove(file));
+    let changed = index.len() != before;
+    let dirs = state::rebuild_dirs_from_index(&index, root);
+    PreparedIndexUpdate {
+        revision,
+        index,
+        dirs,
+        changed,
+    }
+}
+
+fn prepare_mtime_update(
+    state: &WorkspaceState,
+    root: &Path,
+    path: &Path,
+    modified_at: u64,
+) -> PreparedIndexUpdate {
+    let revision = state.file_index_revision.load(Ordering::SeqCst);
+    let mut index = state.file_index.read().clone();
+    let changed = index
+        .iter_mut()
+        .find(|file| file.path == path)
+        .is_some_and(|file| {
+            if file.modified_at == modified_at {
+                return false;
+            }
+            file.modified_at = modified_at;
+            true
+        });
+    let dirs = state::rebuild_dirs_from_index(&index, root);
+    PreparedIndexUpdate {
+        revision,
+        index,
+        dirs,
+        changed,
+    }
+}
+
+fn discovered_file(path: &Path, modified_at: u64) -> crate::state::IndexedFile {
+    crate::state::IndexedFile {
+        path: path.to_path_buf(),
+        relative_path: String::new(),
+        name: path
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_default(),
+        modified_at,
+    }
+}
+
+fn prepare_subtree_merge(
+    state: &WorkspaceState,
+    found: Vec<crate::state::IndexedFile>,
+    root: &Path,
+) -> PreparedIndexUpdate {
+    let revision = state.file_index_revision.load(Ordering::SeqCst);
+    let mut index = state.file_index.read().clone();
+    let mut paths = index
+        .iter()
+        .map(|file| file.path.clone())
+        .collect::<std::collections::HashSet<_>>();
+    let mut changed = false;
+    for file in found {
+        if !paths.insert(file.path.clone()) {
+            continue;
+        }
+        let relative_path = file
+            .path
+            .strip_prefix(root)
+            .unwrap_or(&file.path)
+            .to_string_lossy()
+            .to_string();
+        index.push(crate::state::IndexedFile {
+            path: file.path,
+            relative_path,
+            name: file.name,
+            modified_at: file.modified_at,
+        });
+        changed = true;
+    }
+    let dirs = state::rebuild_dirs_from_index(&index, root);
+    PreparedIndexUpdate {
+        revision,
+        index,
+        dirs,
+        changed,
+    }
+}
+
+fn publish_index_update(
+    state: &WorkspaceState,
+    prepared: PreparedIndexUpdate,
+) -> Result<DeferredIndexDrop, PreparedIndexUpdate> {
+    let mut index = state.file_index.write();
+    if state.file_index_revision.load(Ordering::SeqCst) != prepared.revision {
+        return Err(prepared);
+    }
+    if prepared.changed {
+        let old_index = std::mem::replace(&mut *index, prepared.index);
+        let old_dirs = std::mem::replace(&mut *state.dirs_with_markdown.write(), prepared.dirs);
+        let old_recent_cache = state.recent_files_cache.write().take();
+        state.file_index_revision.fetch_add(1, Ordering::SeqCst);
+        return Ok(DeferredIndexDrop {
+            _index: old_index,
+            _dirs: old_dirs,
+            _recent_cache: old_recent_cache,
+        });
+    }
+    Ok(DeferredIndexDrop {
+        _index: prepared.index,
+        _dirs: prepared.dirs,
+        _recent_cache: None,
+    })
+}
+
+fn publish_prepared_index_for_snapshot(
+    state: &WorkspaceState,
+    root: &Path,
+    epoch: u64,
+    mut prepare: impl FnMut() -> PreparedIndexUpdate,
+) {
+    loop {
+        let prepared = prepare();
+        match state.with_workspace_snapshot(root, epoch, || publish_index_update(state, prepared)) {
+            Some(Err(stale)) => {
+                drop(stale);
                 continue;
             }
-            // Recompute relative_path against the workspace root rather than
-            // `dir` so the search index stays consistent with cold-start
-            // entries.
-            let rel = file
-                .path
-                .strip_prefix(root)
-                .unwrap_or(&file.path)
-                .to_string_lossy()
-                .to_string();
-            let path = file.path.clone();
-            index.push(crate::state::IndexedFile {
-                path: file.path,
-                relative_path: rel,
-                name: file.name,
-                modified_at: file.modified_at,
-            });
-            added.push(path);
+            Some(Ok(displaced)) => drop(displaced),
+            None => {}
         }
+        break;
     }
+}
 
-    if added.is_empty() {
-        return;
-    }
-    state.invalidate_recent_files_cache();
-    let mut dirs = state.dirs_with_markdown.write();
-    for p in added {
-        state::register_ancestors(&mut dirs, &p, root);
-    }
+#[cfg(test)]
+fn add_subtree_to_index(state: &WorkspaceState, dir: &Path, root: &Path) {
+    let prepared = prepare_subtree_merge(state, discover_subtree(dir), root);
+    assert!(publish_index_update(state, prepared).is_ok());
 }
 
 fn event_kind_str(kind: &EventKind) -> Option<&'static str> {
@@ -280,6 +410,7 @@ pub fn start_watcher(
     watcher.watch(&root_path, RecursiveMode::Recursive)?;
 
     let captured_epoch = epoch;
+    let watched_root = root_path.clone();
 
     // Spawn thread to process events
     let handle = app_handle.clone();
@@ -323,23 +454,20 @@ pub fn start_watcher(
                 break;
             };
 
-            // Drop the whole batch if the workspace has moved on.
-            if state.workspace_epoch.load(Ordering::SeqCst) != captured_epoch {
+            if state.workspace_snapshot().as_ref() != Some(&(watched_root.clone(), captured_epoch))
+            {
                 pending.clear();
                 last_emit = Instant::now();
                 continue;
             }
 
             let mut rebuild_ignore = false;
-            let root_for_filter = state.workspace_root.read().clone();
 
             for event in pending.drain(..) {
                 for path in &event.paths {
-                    if let Some(ref root) = root_for_filter {
-                        if should_ignore(path, root) {
-                            wlog!("filter[should_ignore]: {}", path.display());
-                            continue;
-                        }
+                    if should_ignore(path, &watched_root) {
+                        wlog!("filter[should_ignore]: {}", path.display());
+                        continue;
                     }
 
                     // `.gitignore` changes defer to a background rebuild.
@@ -378,9 +506,12 @@ pub fn start_watcher(
                         && path.extension().and_then(|e| e.to_str()) == Some("md")
                         && path.exists()
                     {
-                        state.update_index_modified_at(
-                            path,
-                            crate::commands::fs::modified_time(path),
+                        let modified_at = crate::commands::fs::modified_time(path);
+                        publish_prepared_index_for_snapshot(
+                            &state,
+                            &watched_root,
+                            captured_epoch,
+                            || prepare_mtime_update(&state, &watched_root, path, modified_at),
                         );
                     }
 
@@ -395,6 +526,10 @@ pub fn start_watcher(
                     let payload = FileChangeEvent {
                         path: path.to_string_lossy().to_string(),
                         kind: kind_str.to_string(),
+                        workspace: Some(WorkspaceIdentity {
+                            root: watched_root.to_string_lossy().into_owned(),
+                            epoch: captured_epoch,
+                        }),
                     };
 
                     if is_dir {
@@ -407,10 +542,31 @@ pub fn start_watcher(
                         // `.writer/config` changes reload settings instead.
                         if is_config_file(path) {
                             wlog!("emit settings:changed {}", path.display());
-                            if let Some(ref mut s) = *state.settings.write() {
-                                s.reload_workspace();
-                            }
-                            let _ = handle.emit_to(label.clone(), "settings:changed", ());
+                            let loader = state
+                                .settings
+                                .read()
+                                .as_ref()
+                                .map(|settings| settings.workspace_loader());
+                            let layer = loader.map(|loader| loader.read(&watched_root));
+                            let _ = state.with_workspace_snapshot(
+                                &watched_root,
+                                captured_epoch,
+                                || {
+                                    if let (Some(settings), Some(layer)) =
+                                        (state.settings.write().as_mut(), layer)
+                                    {
+                                        settings.install_workspace_layer(layer);
+                                    }
+                                },
+                            );
+                            let _ = handle.emit_to(
+                                label.clone(),
+                                "settings:changed",
+                                WorkspaceIdentity {
+                                    root: watched_root.to_string_lossy().into_owned(),
+                                    epoch: captured_epoch,
+                                },
+                            );
                             continue;
                         }
 
@@ -440,26 +596,56 @@ pub fn start_watcher(
                     // us which side of the rename this path is.
                     let is_md = path.extension().and_then(|e| e.to_str()) == Some("md");
                     let path_exists = path.exists();
-                    if let Some(ref root) = root_for_filter {
-                        if is_md {
-                            if path_exists {
-                                add_to_index(&state, path, root);
-                            } else {
-                                remove_from_index(&state, path, root);
-                            }
-                        } else if path_exists && is_dir {
-                            // A folder entered the watched tree (Create or
-                            // rename-in). FSEvents won't re-emit Create events
-                            // for descendants, so walk now to keep the index
-                            // in sync.
-                            add_subtree_to_index(&state, path, root);
-                        } else if !path_exists {
-                            // A vanished non-`.md` path could be a renamed-
-                            // away folder; FSEvents may not emit per-child
-                            // events for the descendants, so prune anything
-                            // the index still holds under it.
-                            remove_subtree_from_index(&state, path, root);
+                    if is_md {
+                        if path_exists {
+                            let modified_at = crate::commands::fs::modified_time(path);
+                            let found = vec![discovered_file(path, modified_at)];
+                            publish_prepared_index_for_snapshot(
+                                &state,
+                                &watched_root,
+                                captured_epoch,
+                                || prepare_subtree_merge(&state, found.clone(), &watched_root),
+                            );
+                        } else {
+                            publish_prepared_index_for_snapshot(
+                                &state,
+                                &watched_root,
+                                captured_epoch,
+                                || {
+                                    prepare_index_removal(&state, &watched_root, |file| {
+                                        file.path.as_path() == path.as_path()
+                                    })
+                                },
+                            );
                         }
+                    } else if path_exists && is_dir {
+                        // A folder entered the watched tree (Create or
+                        // rename-in). FSEvents won't re-emit Create events
+                        // for descendants, so walk now to keep the index
+                        // in sync.
+                        let found = discover_subtree(path);
+                        publish_prepared_index_for_snapshot(
+                            &state,
+                            &watched_root,
+                            captured_epoch,
+                            || prepare_subtree_merge(&state, found.clone(), &watched_root),
+                        );
+                    } else if !path_exists {
+                        // A vanished non-`.md` path could be a renamed-
+                        // away folder; FSEvents may not emit per-child
+                        // events for the descendants, so prune anything
+                        // the index still holds under it.
+                        publish_prepared_index_for_snapshot(
+                            &state,
+                            &watched_root,
+                            captured_epoch,
+                            || {
+                                prepare_index_removal(&state, &watched_root, |file| {
+                                    file.path.as_path() == path.as_path()
+                                        || file.path.starts_with(path)
+                                })
+                            },
+                        );
                     }
 
                     // Refresh the parent directory's listing. Without this,
@@ -468,13 +654,18 @@ pub fn start_watcher(
                     if !is_dir {
                         if let Some(parent) = path.parent() {
                             wlog!("emit fs:directory-changed (parent) {}", parent.display());
+                            let parent_payload = FileChangeEvent {
+                                path: parent.to_string_lossy().to_string(),
+                                kind: "modified".to_string(),
+                                workspace: Some(WorkspaceIdentity {
+                                    root: watched_root.to_string_lossy().into_owned(),
+                                    epoch: captured_epoch,
+                                }),
+                            };
                             let _ = handle.emit_to(
                                 label.clone(),
                                 "fs:directory-changed",
-                                &FileChangeEvent {
-                                    path: parent.to_string_lossy().to_string(),
-                                    kind: "modified".to_string(),
-                                },
+                                &parent_payload,
                             );
                         }
                     }
@@ -482,9 +673,12 @@ pub fn start_watcher(
             }
 
             if rebuild_ignore {
-                if let Some(root) = state.workspace_root.read().clone() {
-                    spawn_ignore_rebuild(handle.clone(), label.clone(), root, captured_epoch);
-                }
+                spawn_ignore_rebuild(
+                    handle.clone(),
+                    label.clone(),
+                    watched_root.clone(),
+                    captured_epoch,
+                );
             }
 
             last_emit = Instant::now();
@@ -582,6 +776,7 @@ pub fn start_file_watcher(
                         &FileChangeEvent {
                             path: path.to_string_lossy().to_string(),
                             kind: kind_str.to_string(),
+                            workspace: None,
                         },
                     );
                 }
@@ -609,18 +804,24 @@ fn spawn_ignore_rebuild(
             return;
         };
 
-        // Bail out if the workspace was swapped while we were walking.
-        if state.workspace_epoch.load(Ordering::SeqCst) != captured_epoch {
+        if state
+            .with_workspace_snapshot(&root, captured_epoch, || {
+                *state.workspace_ignore.write() = Some(new_matcher);
+            })
+            .is_none()
+        {
             return;
         }
-        *state.workspace_ignore.write() = Some(new_matcher);
-
         let _ = handle.emit_to(
             window_label,
             "fs:directory-changed",
             FileChangeEvent {
                 path: root.to_string_lossy().to_string(),
                 kind: "modified".to_string(),
+                workspace: Some(WorkspaceIdentity {
+                    root: root.to_string_lossy().into_owned(),
+                    epoch: captured_epoch,
+                }),
             },
         );
     });
@@ -798,6 +999,34 @@ mod tests {
         add_subtree_to_index(&state, &root, &root);
         add_subtree_to_index(&state, &root, &root);
         assert_eq!(state.file_index.read().len(), 1);
+    }
+
+    #[test]
+    fn prepared_index_publication_rejects_a_changed_revision() {
+        let state = WorkspaceState::default();
+        let root = PathBuf::from("/ws");
+        let found = vec![discovered_file(&root.join("new.md"), 1)];
+        let prepared = prepare_subtree_merge(&state, found, &root);
+
+        state.file_index_revision.fetch_add(1, Ordering::SeqCst);
+
+        assert!(publish_index_update(&state, prepared).is_err());
+        assert!(state.file_index.read().is_empty());
+    }
+
+    #[test]
+    fn workspace_identity_serialization_matches_the_shared_contract() {
+        let expected: serde_json::Value = serde_json::from_str(include_str!(
+            "../../shared/workspace-identity.contract.json"
+        ))
+        .unwrap();
+        let actual = serde_json::to_value(WorkspaceIdentity {
+            root: "/workspace".to_string(),
+            epoch: 7,
+        })
+        .unwrap();
+
+        assert_eq!(actual, expected);
     }
 
     #[test]

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,8 +1,7 @@
 import { AppLayout } from "./components/app-layout";
 import { CommandPalette } from "./components/command-palette";
-import { WelcomeScreen } from "./components/welcome";
 import { WindowTitle } from "./components/window-title";
-import { useWorkspace, useIsStartupResolved } from "./hooks/use-workspace";
+import { useIsStartupResolved } from "./hooks/use-workspace";
 import { useFileWatcher } from "./hooks/use-file-watcher";
 import { useKeyboardShortcuts } from "./hooks/use-keyboard-shortcuts";
 import { useMenuEvents } from "./hooks/use-menu-events";
@@ -12,7 +11,6 @@ import "./lib/standalone-watch";
 import "./App.css";
 
 function App() {
-  const { root, chromeMode } = useWorkspace();
   const isStartupResolved = useIsStartupResolved();
 
   useFileWatcher();
@@ -22,17 +20,6 @@ function App() {
 
   if (!isStartupResolved) {
     return null;
-  }
-
-  // Standalone compact windows render the compact layout with no root.
-  if (!root && chromeMode !== "compact-file") {
-    return (
-      <>
-        <WindowTitle />
-        <WelcomeScreen />
-        <CommandPalette />
-      </>
-    );
   }
 
   return (

--- a/apps/desktop/src/components/app-layout.tsx
+++ b/apps/desktop/src/components/app-layout.tsx
@@ -4,23 +4,27 @@ import { EditorArea } from "./editor-area";
 import { EditorTabs } from "./editor-area/editor-tabs";
 import { SidebarToggleButton } from "./sidebar/sidebar-toggle-button";
 import { CompactFileLayout } from "./compact-file-layout";
+import { WelcomeScreen } from "./welcome";
 import { useSidebar } from "@/hooks/use-sidebar";
-import { useWorkspaceChromeMode } from "@/hooks/use-workspace";
+import { useWorkspaceChromeMode, useWorkspaceRoot } from "@/hooks/use-workspace";
+import { resolveAppView } from "@/lib/app-view";
 
 function clampSidebarWidth(width: number, maxSidebarWidth: number) {
   return Math.max(220, Math.min(maxSidebarWidth, Math.round(width)));
 }
 
 export function AppLayout() {
+  const root = useWorkspaceRoot();
   const chromeMode = useWorkspaceChromeMode();
-  if (chromeMode === "compact-file") {
+  const appView = resolveAppView(root, chromeMode);
+  if (appView === "compact-file") {
     return <CompactFileLayout />;
   }
 
-  return <WorkspaceLayout />;
+  return <WorkspaceLayout showWelcome={appView === "workspace-welcome"} />;
 }
 
-function WorkspaceLayout() {
+function WorkspaceLayout({ showWelcome }: { showWelcome: boolean }) {
   const { isSidebarCollapsed, sidebarWidth, setSidebarWidth } = useSidebar();
   const viewportWidth = typeof window === "undefined" ? 1200 : window.innerWidth;
   const maxSidebarWidth = Math.max(280, Math.min(420, Math.floor(viewportWidth * 0.35)));
@@ -114,10 +118,13 @@ function WorkspaceLayout() {
       <div
         data-tauri-drag-region
         className="absolute inset-x-0 top-0 z-30"
-        style={{ height: "var(--chrome-drag-height)" }}
+        style={{
+          height: "var(--chrome-drag-height)",
+          left: isSidebarCollapsed ? 0 : draftSidebarWidth,
+        }}
       />
       <div
-        className="pointer-events-auto absolute left-0 top-0 z-50 flex items-center"
+        className="pointer-events-none absolute left-0 top-0 z-50 flex items-center"
         style={{
           height: "calc(var(--chrome-control-height) + var(--chrome-control-padding) * 2)",
           padding: "var(--chrome-control-padding) 12px var(--chrome-control-padding) 92px",
@@ -125,18 +132,20 @@ function WorkspaceLayout() {
       >
         <SidebarToggleButton />
       </div>
-      <div
-        className="pointer-events-none absolute top-0 z-40"
-        style={{
-          left: tabChromeLeft,
-          right: 12,
-          transition: isSidebarDragging ? "none" : "left 140ms ease-out",
-        }}
-      >
-        <div className="pointer-events-auto">
-          <EditorTabs />
+      {!showWelcome && (
+        <div
+          className="pointer-events-none absolute top-0 z-40"
+          style={{
+            left: tabChromeLeft,
+            right: 12,
+            transition: isSidebarDragging ? "none" : "left 140ms ease-out",
+          }}
+        >
+          <div className="pointer-events-auto">
+            <EditorTabs />
+          </div>
         </div>
-      </div>
+      )}
       <div className="flex h-full min-h-0 flex-col">
         <div className="flex min-h-0 flex-1">
           <div
@@ -161,7 +170,7 @@ function WorkspaceLayout() {
           )}
 
           <div className="relative min-w-0 flex-1 bg-bg">
-            <EditorArea />
+            {showWelcome ? <WelcomeScreen /> : <EditorArea />}
           </div>
         </div>
       </div>

--- a/apps/desktop/src/components/command-palette/index.tsx
+++ b/apps/desktop/src/components/command-palette/index.tsx
@@ -17,7 +17,7 @@ import {
   useSetCommandPaletteSearch,
 } from "@/hooks/use-command-palette";
 import { useSidebar } from "@/hooks/use-sidebar";
-import { useIsCompactFileMode, useWorkspace } from "@/hooks/use-workspace";
+import { useCloseWorkspace, useIsCompactFileMode, useWorkspace } from "@/hooks/use-workspace";
 import {
   useActiveFilePath,
   useActiveTabId,
@@ -67,7 +67,8 @@ export function CommandPalette() {
   const search = useCommandPaletteSearch();
   const setSearch = useSetCommandPaletteSearch();
   const { toggleSidebar } = useSidebar();
-  const { root, isIndexing, openWorkspace, closeWorkspace } = useWorkspace();
+  const { root, isIndexing, openWorkspace } = useWorkspace();
+  const closeWorkspace = useCloseWorkspace();
   const openFile = useOpenFile();
   const closeActiveTab = useCloseActiveTab();
   const closeTab = useCloseTab();

--- a/apps/desktop/src/components/sidebar/context-menu-utils.ts
+++ b/apps/desktop/src/components/sidebar/context-menu-utils.ts
@@ -2,24 +2,25 @@ import { type Platform } from "@/lib/platform";
 
 export { detectPlatform, type Platform } from "@/lib/platform";
 
+const PLATFORM_MENU_LABELS = {
+  macos: {
+    reveal: "Reveal in Finder",
+    openFolder: "Open in Finder",
+  },
+  windows: {
+    reveal: "Reveal in Explorer",
+    openFolder: "Open in Explorer",
+  },
+  linux: {
+    reveal: "Show in Folder",
+    openFolder: "Open in File Manager",
+  },
+} satisfies Record<Platform, { reveal: string; openFolder: string }>;
+
 export function revealLabelForPlatform(platform: Platform): string {
-  switch (platform) {
-    case "macos":
-      return "Reveal in Finder";
-    case "windows":
-      return "Reveal in Explorer";
-    case "linux":
-      return "Show in Folder";
-  }
+  return PLATFORM_MENU_LABELS[platform].reveal;
 }
 
 export function openFolderLabelForPlatform(platform: Platform): string {
-  switch (platform) {
-    case "macos":
-      return "Open in Finder";
-    case "windows":
-      return "Open in Explorer";
-    case "linux":
-      return "Open in File Manager";
-  }
+  return PLATFORM_MENU_LABELS[platform].openFolder;
 }

--- a/apps/desktop/src/components/sidebar/file-browser.tsx
+++ b/apps/desktop/src/components/sidebar/file-browser.tsx
@@ -1,83 +1,28 @@
-import { useState, type MouseEvent } from "react";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { Search01Icon } from "@hugeicons/core-free-icons";
 import { useOpenCommandPalette } from "@/hooks/use-command-palette";
-import { useBooleanSetting, useSetSetting } from "@/hooks/use-settings";
-import { useRefreshDirectory } from "@/hooks/use-file-tree";
-import { useWorkspaceRoot } from "@/hooks/use-workspace";
-import { getWorkspaceIdentity, isCurrentWorkspaceIdentity } from "@/hooks/workspace-api";
+import { useBooleanSetting } from "@/hooks/use-settings";
 import { ScrollFade } from "@/components/scroll-fade";
-import * as tauri from "@/lib/tauri";
-import { createSidebarEntryAndRename } from "./create-sidebar-entry-and-rename";
 import { SidebarNavigator } from "./sidebar-navigator";
-import { showSidebarSurfaceContextMenu } from "./sidebar-surface-context-menu";
-import { openSidebarDirectoryInTerminal } from "./sidebar-terminal-action";
 
-export function FileBrowser() {
+interface FileBrowserProps {
+  renamingPath: string | null;
+  onRenamingPathChange: (path: string | null) => void;
+  everythingCollapsed: boolean;
+  onEverythingCollapsedChange: (collapsed: boolean) => void;
+}
+
+export function FileBrowser({
+  renamingPath,
+  onRenamingPathChange,
+  everythingCollapsed,
+  onEverythingCollapsedChange,
+}: FileBrowserProps) {
   const openCommandPalette = useOpenCommandPalette();
-  const setSetting = useSetSetting();
   const showSearch = useBooleanSetting("appearance.sidebar-show-search");
-  const showRecents = useBooleanSetting("appearance.sidebar-show-recents");
-  const root = useWorkspaceRoot();
-  const refreshDirectory = useRefreshDirectory();
-  const [renamingPath, setRenamingPath] = useState<string | null>(null);
-  const [everythingCollapsed, setEverythingCollapsed] = useState(false);
-
-  const createRootEntry = (kind: tauri.SidebarEntryKind) => {
-    if (!root) return;
-    const identity = getWorkspaceIdentity();
-    void createSidebarEntryAndRename(kind, {
-      expandParent: () => setEverythingCollapsed(false),
-      createEntry: (entryKind) => tauri.createSidebarEntry(root, entryKind),
-      refreshRoot: () => refreshDirectory(root),
-      startRenaming: setRenamingPath,
-      isCurrentWorkspace: () => isCurrentWorkspaceIdentity(identity),
-    }).catch((error: unknown) => {
-      window.alert(
-        `Failed to create ${kind}: ${error instanceof Error ? error.message : String(error)}`,
-      );
-    });
-  };
-
-  const runWorkspaceAction = (label: string, action: () => Promise<void>) => {
-    void action().catch((error: unknown) => {
-      window.alert(`${label}: ${error instanceof Error ? error.message : String(error)}`);
-    });
-  };
-
-  // File and folder rows stop propagation from their own context menus, so
-  // this only fires for the sidebar surface: empty space, section headers,
-  // and the search button.
-  const handleSurfaceContextMenu = (event: MouseEvent<HTMLDivElement>) => {
-    event.preventDefault();
-    void showSidebarSurfaceContextMenu({
-      showSearch,
-      showRecents,
-      workspaceActions: root
-        ? {
-            onNewFile: () => createRootEntry("file"),
-            onNewFolder: () => createRootEntry("folder"),
-            onOpenInTerminal: () => {
-              void openSidebarDirectoryInTerminal(null);
-            },
-            onOpenInFileManager: () =>
-              runWorkspaceAction(
-                "Failed to open workspace folder",
-                tauri.openWorkspaceInFileManager,
-              ),
-          }
-        : null,
-      onToggleSearch: (visible) => {
-        void setSetting("appearance.sidebar-show-search", visible);
-      },
-      onToggleRecents: (visible) => {
-        void setSetting("appearance.sidebar-show-recents", visible);
-      },
-    });
-  };
 
   return (
-    <div className="flex h-full min-h-0 flex-col px-3" onContextMenu={handleSurfaceContextMenu}>
+    <div className="flex h-full min-h-0 flex-col px-3">
       {showSearch && (
         <div
           className="flex items-center"
@@ -109,9 +54,9 @@ export function FileBrowser() {
       <ScrollFade className="min-h-0 flex-1 overflow-y-scroll scrollbar-none">
         <SidebarNavigator
           renamingPath={renamingPath}
-          onRenamingPathChange={setRenamingPath}
+          onRenamingPathChange={onRenamingPathChange}
           everythingCollapsed={everythingCollapsed}
-          onEverythingCollapsedChange={setEverythingCollapsed}
+          onEverythingCollapsedChange={onEverythingCollapsedChange}
         />
       </ScrollFade>
     </div>

--- a/apps/desktop/src/components/sidebar/index.tsx
+++ b/apps/desktop/src/components/sidebar/index.tsx
@@ -1,28 +1,46 @@
 import { FileBrowser } from "./file-browser";
 import { WorkspaceSwitcher } from "./workspace-switcher";
 import { useWorkspaceGeneration } from "@/hooks/use-workspace";
+import { useSidebarSurface } from "./use-sidebar-surface";
 
 export function Sidebar() {
   const workspaceGeneration = useWorkspaceGeneration();
 
+  return <SidebarSurface key={workspaceGeneration} />;
+}
+
+function SidebarSurface() {
+  const surface = useSidebarSurface();
+
   return (
-    <div className="relative h-full overflow-hidden">
+    <div
+      data-sidebar-surface
+      data-workspace-open={surface.hasWorkspace ? "true" : "false"}
+      className="relative h-full overflow-hidden"
+      onContextMenu={surface.onContextMenu}
+    >
       <div
         aria-hidden="true"
         className="pointer-events-none absolute right-0 top-px bottom-px w-px bg-[var(--sidebar-divider-right)]"
       />
       <div className="flex h-full flex-col overflow-hidden">
         <div
+          data-sidebar-surface-top
           data-tauri-drag-region
           className="shrink-0"
           style={{
             height: "calc(var(--chrome-control-height) + var(--chrome-control-padding) * 2)",
           }}
         />
-        <div className="min-h-0 flex-1 overflow-hidden">
-          <FileBrowser key={workspaceGeneration} />
+        <div data-sidebar-surface-content className="min-h-0 flex-1 overflow-hidden">
+          <FileBrowser
+            renamingPath={surface.tree.renamingPath}
+            onRenamingPathChange={surface.tree.onRenamingPathChange}
+            everythingCollapsed={surface.tree.everythingCollapsed}
+            onEverythingCollapsedChange={surface.tree.onEverythingCollapsedChange}
+          />
         </div>
-        <div className="shrink-0 px-3 py-3">
+        <div data-sidebar-surface-bottom className="shrink-0 px-3 py-3">
           <WorkspaceSwitcher />
         </div>
       </div>

--- a/apps/desktop/src/components/sidebar/sidebar-toggle-button.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar-toggle-button.tsx
@@ -11,7 +11,7 @@ export function SidebarToggleButton() {
       onClick={toggleSidebar}
       aria-label={isSidebarVisible ? "Hide sidebar" : "Show sidebar"}
       title={isSidebarVisible ? "Hide sidebar" : "Show sidebar"}
-      className="group flex h-7 w-7 items-center justify-center rounded-md text-[var(--fg-base)] transition-colors hover:bg-[var(--surface-subtle)] hover:transition-none"
+      className="group pointer-events-auto flex h-7 w-7 items-center justify-center rounded-md text-[var(--fg-base)] transition-colors hover:bg-[var(--surface-subtle)] hover:transition-none"
     >
       <span className="opacity-60 transition-opacity group-hover:opacity-100 group-hover:transition-none">
         <HugeiconsIcon icon={SidebarLeftIcon} size={18} color="currentColor" strokeWidth={2} />

--- a/apps/desktop/src/components/sidebar/use-sidebar-surface.ts
+++ b/apps/desktop/src/components/sidebar/use-sidebar-surface.ts
@@ -1,0 +1,80 @@
+import { useState, type MouseEventHandler } from "react";
+import { useRefreshDirectory } from "@/hooks/use-file-tree";
+import { useBooleanSetting, useSetSetting } from "@/hooks/use-settings";
+import { useWorkspaceRoot } from "@/hooks/use-workspace";
+import { getWorkspaceIdentity, isCurrentWorkspaceIdentity } from "@/hooks/workspace-api";
+import * as tauri from "@/lib/tauri";
+import { createSidebarEntryAndRename } from "./create-sidebar-entry-and-rename";
+import { showSidebarSurfaceContextMenu } from "./sidebar-surface-context-menu";
+import { openSidebarDirectoryInTerminal } from "./sidebar-terminal-action";
+
+export function useSidebarSurface() {
+  const setSetting = useSetSetting();
+  const showSearch = useBooleanSetting("appearance.sidebar-show-search");
+  const showRecents = useBooleanSetting("appearance.sidebar-show-recents");
+  const root = useWorkspaceRoot();
+  const refreshDirectory = useRefreshDirectory();
+  const [renamingPath, setRenamingPath] = useState<string | null>(null);
+  const [everythingCollapsed, setEverythingCollapsed] = useState(false);
+
+  const createRootEntry = (kind: tauri.SidebarEntryKind) => {
+    if (!root) return;
+    const identity = getWorkspaceIdentity();
+    void createSidebarEntryAndRename(kind, {
+      expandParent: () => setEverythingCollapsed(false),
+      createEntry: (entryKind) => tauri.createSidebarEntry(root, entryKind),
+      refreshRoot: () => refreshDirectory(root),
+      startRenaming: setRenamingPath,
+      isCurrentWorkspace: () => isCurrentWorkspaceIdentity(identity),
+    }).catch((error: unknown) => {
+      window.alert(
+        `Failed to create ${kind}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    });
+  };
+
+  const runWorkspaceAction = (label: string, action: () => Promise<void>) => {
+    void action().catch((error: unknown) => {
+      window.alert(`${label}: ${error instanceof Error ? error.message : String(error)}`);
+    });
+  };
+
+  const onContextMenu: MouseEventHandler<HTMLDivElement> = (event) => {
+    event.preventDefault();
+    void showSidebarSurfaceContextMenu({
+      showSearch,
+      showRecents,
+      workspaceActions: root
+        ? {
+            onNewFile: () => createRootEntry("file"),
+            onNewFolder: () => createRootEntry("folder"),
+            onOpenInTerminal: () => {
+              void openSidebarDirectoryInTerminal(null);
+            },
+            onOpenInFileManager: () =>
+              runWorkspaceAction(
+                "Failed to open workspace folder",
+                tauri.openWorkspaceInFileManager,
+              ),
+          }
+        : null,
+      onToggleSearch: (visible) => {
+        void setSetting("appearance.sidebar-show-search", visible);
+      },
+      onToggleRecents: (visible) => {
+        void setSetting("appearance.sidebar-show-recents", visible);
+      },
+    });
+  };
+
+  return {
+    hasWorkspace: root !== null,
+    onContextMenu,
+    tree: {
+      renamingPath,
+      onRenamingPathChange: setRenamingPath,
+      everythingCollapsed,
+      onEverythingCollapsedChange: setEverythingCollapsed,
+    },
+  };
+}

--- a/apps/desktop/src/components/sidebar/workspace-switcher.tsx
+++ b/apps/desktop/src/components/sidebar/workspace-switcher.tsx
@@ -1,5 +1,5 @@
 import { useRef } from "react";
-import { useWorkspace } from "@/hooks/use-workspace";
+import { useCloseWorkspace, useWorkspace } from "@/hooks/use-workspace";
 import * as tauri from "@/lib/tauri";
 import {
   showNativeContextMenu,
@@ -12,7 +12,8 @@ function getFolderName(path: string): string {
 }
 
 export function WorkspaceSwitcher() {
-  const { root, recentWorkspaces, openWorkspace, closeWorkspace } = useWorkspace();
+  const { root, recentWorkspaces, openWorkspace } = useWorkspace();
+  const closeWorkspace = useCloseWorkspace();
   const buttonRef = useRef<HTMLButtonElement>(null);
 
   const workspaceName = root ? getFolderName(root) : "No Workspace";

--- a/apps/desktop/src/components/welcome/index.tsx
+++ b/apps/desktop/src/components/welcome/index.tsx
@@ -21,7 +21,7 @@ export function WelcomeScreen() {
   }
 
   return (
-    <div className="flex h-screen items-center justify-center bg-bg text-text-primary">
+    <div className="flex h-full items-center justify-center bg-bg text-text-primary">
       <div className="w-full max-w-[300px] px-6">
         <p className="mb-6 text-center text-[13px] leading-relaxed text-text-muted">
           Add a folder with your specs, docs, notes, or any markdown files.

--- a/apps/desktop/src/hooks/use-file-watcher.ts
+++ b/apps/desktop/src/hooks/use-file-watcher.ts
@@ -5,18 +5,31 @@ import { useSettingsStore } from "@/stores/settings-store";
 import * as editorApi from "./editor-api";
 import * as tauri from "@/lib/tauri";
 import { cancelSave, isSaveInFlight } from "@/lib/save";
+import { isWorkspaceEventCurrent, type WorkspaceIdentity } from "@/lib/workspace-events";
 
 interface FileChangePayload {
   path: string;
   kind: "modified" | "created" | "deleted" | "renamed";
+  workspace: WorkspaceIdentity | null;
+}
+
+interface IndexCompletePayload {
+  workspace: WorkspaceIdentity;
+  fileCount: number;
 }
 
 const WATCHER_DEBUG = import.meta.env.DEV;
 
+function currentWorkspaceIdentity(): WorkspaceIdentity | null {
+  const { root, workspaceEpoch } = useWorkspaceStore.getState();
+  return root !== null && workspaceEpoch !== null ? { root, epoch: workspaceEpoch } : null;
+}
+
 export function useFileWatcher() {
   useEffect(() => {
     const unlistenFile = listen<FileChangePayload>("fs:file-changed", (event) => {
-      const { path, kind } = event.payload;
+      const { path, kind, workspace } = event.payload;
+      if (!isWorkspaceEventCurrent(workspace, currentWorkspaceIdentity())) return;
       if (WATCHER_DEBUG) console.debug("[watcher] fs:file-changed", kind, path);
       useWorkspaceStore.getState().bumpSidebarMetadataVersion();
       const openFiles = editorApi.getOpenFiles();
@@ -35,10 +48,10 @@ export function useFileWatcher() {
       });
     });
 
-    const unlistenIndexComplete = listen<number>("index:complete", (event) => {
-      if (useWorkspaceStore.getState().root) {
+    const unlistenIndexComplete = listen<IndexCompletePayload>("index:complete", (event) => {
+      if (isWorkspaceEventCurrent(event.payload.workspace, currentWorkspaceIdentity())) {
         useWorkspaceStore.setState((state) => ({
-          fileCount: event.payload,
+          fileCount: event.payload.fileCount,
           isIndexing: false,
           sidebarMetadataVersion: state.sidebarMetadataVersion + 1,
         }));
@@ -49,12 +62,14 @@ export function useFileWatcher() {
       useWorkspaceStore.getState().bumpSidebarMetadataVersion();
     });
 
-    const unlistenSettings = listen("settings:changed", () => {
+    const unlistenSettings = listen<WorkspaceIdentity>("settings:changed", (event) => {
+      if (!isWorkspaceEventCurrent(event.payload, currentWorkspaceIdentity())) return;
       void useSettingsStore.getState().loadSettings();
     });
 
     const unlistenDir = listen<FileChangePayload>("fs:directory-changed", (event) => {
-      const { path } = event.payload;
+      const { path, workspace } = event.payload;
+      if (!isWorkspaceEventCurrent(workspace, currentWorkspaceIdentity())) return;
       if (WATCHER_DEBUG) console.debug("[watcher] fs:directory-changed", path);
       const { root, expandedDirs, invalidatePath, refreshDirectory, bumpSidebarMetadataVersion } =
         useWorkspaceStore.getState();

--- a/apps/desktop/src/hooks/use-workspace.ts
+++ b/apps/desktop/src/hooks/use-workspace.ts
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import { useWorkspaceStore } from "@/stores/workspace-store";
 import { getWorkspaceChromeMode } from "@/lib/compact-mode";
 
@@ -7,7 +8,6 @@ export function useWorkspace() {
   const chromeMode = getWorkspaceChromeMode(root, rawChromeMode);
   const isIndexing = useWorkspaceStore((s) => s.isIndexing);
   const openWorkspace = useWorkspaceStore((s) => s.openWorkspace);
-  const closeWorkspace = useWorkspaceStore((s) => s.closeWorkspace);
   const recentWorkspaces = useWorkspaceStore((s) => s.recentWorkspaces);
   const removeRecentWorkspace = useWorkspaceStore((s) => s.removeRecentWorkspace);
   return {
@@ -15,7 +15,6 @@ export function useWorkspace() {
     chromeMode,
     isIndexing,
     openWorkspace,
-    closeWorkspace,
     recentWorkspaces,
     removeRecentWorkspace,
   };
@@ -41,4 +40,17 @@ export function useWorkspaceRoot() {
 
 export function useWorkspaceGeneration() {
   return useWorkspaceStore((s) => s.workspaceGeneration);
+}
+
+/** Close feedback is owned here so every close-workspace entry point reports
+ * the same failure and callers cannot silently diverge. */
+export function useCloseWorkspace() {
+  const closeWorkspace = useWorkspaceStore((s) => s.closeWorkspace);
+  return useCallback(() => {
+    void closeWorkspace().catch((error: unknown) => {
+      window.alert(
+        `Failed to close workspace: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    });
+  }, [closeWorkspace]);
 }

--- a/apps/desktop/src/lib/app-view.ts
+++ b/apps/desktop/src/lib/app-view.ts
@@ -1,0 +1,9 @@
+export type AppView = "compact-file" | "workspace-editor" | "workspace-welcome";
+
+export function resolveAppView(
+  root: string | null,
+  chromeMode: "workspace" | "compact-file",
+): AppView {
+  if (chromeMode === "compact-file") return "compact-file";
+  return root ? "workspace-editor" : "workspace-welcome";
+}

--- a/apps/desktop/src/lib/settings-schema.ts
+++ b/apps/desktop/src/lib/settings-schema.ts
@@ -44,27 +44,24 @@ export type SettingsMap = {
 
 export type SettingKey = keyof SettingsMap;
 
-/** Runtime SettingDef shape exposed to the rest of the app. This is the
- *  generalized form (string-typed `type`, optional fields) — the JSON gives
- *  us tighter literal types via `RawEntry`, but consumers rarely need them.
- *  Mirrors `apps/desktop/src-tauri/src/config.rs::SettingDef`. */
-export interface SettingDef {
-  key: string;
-  label: string;
-  description: string;
-  category: string;
-  type: "string" | "number" | "boolean" | "enum" | "list" | "color" | "range" | "font";
-  options?: string[];
-  min?: number;
-  max?: number;
-  step?: number;
-  cssVar?: string;
-  cssFormat?: "px" | "raw";
-  placeholder?: string;
-  default: unknown;
-}
+type SchemaField<Entry, Key extends PropertyKey> = Entry extends unknown
+  ? Key extends keyof Entry
+    ? Entry[Key]
+    : never
+  : never;
 
-export const SETTINGS_SCHEMA: SettingDef[] = schemaFile.settings as SettingDef[];
+type KeysOfUnion<Entry> = Entry extends unknown ? keyof Entry : never;
+
+/** Generalized consumer shape whose field names and values are derived from
+ *  the imported JSON contract. Optional properties remain convenient for
+ *  generic controls without a cast that can hide schema drift. */
+export type SettingDef = {
+  [Key in keyof RawEntry]: SchemaField<RawEntry, Key>;
+} & {
+  [Key in Exclude<KeysOfUnion<RawEntry>, keyof RawEntry>]?: SchemaField<RawEntry, Key>;
+};
+
+export const SETTINGS_SCHEMA: readonly SettingDef[] = schemaFile.settings;
 
 // ---------- Theme primaries ----------
 

--- a/apps/desktop/src/lib/tauri.ts
+++ b/apps/desktop/src/lib/tauri.ts
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
+import sidebarEntryKinds from "@shared/sidebar-entry-kinds.json";
 import type {
   DirEntry,
   FileContent,
@@ -39,7 +40,7 @@ export function createDirectory(path: string): Promise<DirEntry> {
   return invoke("create_directory", { path });
 }
 
-export type SidebarEntryKind = "file" | "folder";
+export type SidebarEntryKind = keyof typeof sidebarEntryKinds;
 
 export function createSidebarEntry(parentPath: string, kind: SidebarEntryKind): Promise<DirEntry> {
   return invoke("create_sidebar_entry", { parentPath, kind });
@@ -70,6 +71,10 @@ export function revealInFileManager(path: string): Promise<void> {
 // Workspace commands
 export function openWorkspace(path: string): Promise<WorkspaceInfo> {
   return invoke("open_workspace", { path });
+}
+
+export function closeWorkspace(root: string): Promise<void> {
+  return invoke("close_workspace", { root });
 }
 
 export function openWorkspaceInFileManager(): Promise<void> {

--- a/apps/desktop/src/lib/workspace-events.ts
+++ b/apps/desktop/src/lib/workspace-events.ts
@@ -1,0 +1,15 @@
+import identityContract from "@shared/workspace-identity.contract.json";
+
+export type WorkspaceIdentity = typeof identityContract;
+
+export function isWorkspaceEventCurrent(
+  eventWorkspace: WorkspaceIdentity | null,
+  currentWorkspace: WorkspaceIdentity | null,
+) {
+  return (
+    eventWorkspace === null ||
+    (currentWorkspace !== null &&
+      eventWorkspace.root === currentWorkspace.root &&
+      eventWorkspace.epoch === currentWorkspace.epoch)
+  );
+}

--- a/apps/desktop/src/stores/workspace-store.ts
+++ b/apps/desktop/src/stores/workspace-store.ts
@@ -10,6 +10,7 @@ export type WorkspaceChromeMode = "workspace" | "compact-file";
 
 interface WorkspaceState {
   root: string | null;
+  workspaceEpoch: number | null;
   workspaceGeneration: number;
   chromeMode: WorkspaceChromeMode;
   fileCount: number;
@@ -25,7 +26,7 @@ interface WorkspaceState {
   /** Hydrate from a prefetched `RestoreWorkspaceResponse` (startup cold-path
    *  and user-initiated switches via the `restore_workspace` IPC). */
   restoreFromBundle: (bundle: RestoreWorkspaceResponse) => Promise<void>;
-  closeWorkspace: () => void;
+  closeWorkspace: () => Promise<void>;
   setChromeMode: (mode: WorkspaceChromeMode) => void;
   setStartupResolved: () => void;
   refreshDirectory: (path: string) => Promise<void>;
@@ -86,6 +87,7 @@ function withNextWorkspaceGeneration(
 
 export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
   root: null,
+  workspaceEpoch: null,
   workspaceGeneration: 0,
   chromeMode: "workspace",
   fileCount: 0,
@@ -131,6 +133,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     set((state) =>
       withNextWorkspaceGeneration(state, {
         root: info.root,
+        workspaceEpoch: info.epoch,
         chromeMode: "workspace",
         fileCount: info.file_count,
         isIndexing: true,
@@ -152,11 +155,13 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     useEditorStore.getState().ensureLauncherTab();
   },
 
-  closeWorkspace: () => {
+  closeWorkspace: async () => {
     const root = get().root;
     if (!root) return;
     const snapshot = getEditorSessionSnapshot(useEditorStore.getState());
     void saveSession(root, snapshot.tabs, snapshot.activeIndex);
+    await tauri.closeWorkspace(root);
+    if (get().root !== root) return;
     useEditorStore.setState({
       openFiles: new Map(),
       tabs: [],
@@ -166,6 +171,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     set((state) =>
       withNextWorkspaceGeneration(state, {
         root: null,
+        workspaceEpoch: null,
         chromeMode: "workspace",
         fileCount: 0,
         directoryCache: new Map(),
@@ -189,6 +195,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     set((state) =>
       withNextWorkspaceGeneration(state, {
         root: bundle.workspace.root,
+        workspaceEpoch: bundle.workspace.epoch,
         chromeMode: "workspace",
         fileCount: bundle.workspace.file_count,
         isIndexing: true,

--- a/apps/desktop/src/types/fs.ts
+++ b/apps/desktop/src/types/fs.ts
@@ -22,6 +22,7 @@ export interface WorkspaceInfo {
   root: string;
   name: string;
   file_count: number;
+  epoch: number;
 }
 
 export interface SearchResult {

--- a/apps/desktop/tests/app-view.test.ts
+++ b/apps/desktop/tests/app-view.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "vite-plus/test";
+import { resolveAppView } from "../src/lib/app-view";
+
+describe("resolveAppView", () => {
+  test("keeps the workspace shell and welcome content when no workspace is open", () => {
+    expect(resolveAppView(null, "workspace")).toBe("workspace-welcome");
+  });
+
+  test("keeps standalone compact windows sidebar-free", () => {
+    expect(resolveAppView(null, "compact-file")).toBe("compact-file");
+  });
+
+  test("renders the editor inside the workspace shell for an open workspace", () => {
+    expect(resolveAppView("/vault", "workspace")).toBe("workspace-editor");
+  });
+});

--- a/apps/desktop/tests/file-watcher.test.ts
+++ b/apps/desktop/tests/file-watcher.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "vite-plus/test";
+import { isWorkspaceEventCurrent } from "../src/lib/workspace-events";
+import identityContract from "../shared/workspace-identity.contract.json";
+
+describe("workspace watcher event routing", () => {
+  test("shares the serialized workspace identity contract", () => {
+    expect(identityContract).toEqual({ root: "/workspace", epoch: 7 });
+  });
+
+  test("rejects stale workspace events after switches and close", () => {
+    const first = { root: "/workspace-a", epoch: 1 };
+    expect(isWorkspaceEventCurrent(first, first)).toBe(true);
+    expect(isWorkspaceEventCurrent(first, { root: "/workspace-b", epoch: 2 })).toBe(false);
+    expect(isWorkspaceEventCurrent(first, null)).toBe(false);
+    expect(isWorkspaceEventCurrent(first, { root: "/workspace-a", epoch: 3 })).toBe(false);
+  });
+
+  test("keeps unscoped standalone-file events", () => {
+    expect(isWorkspaceEventCurrent(null, null)).toBe(true);
+  });
+});

--- a/apps/desktop/tests/stores.test.ts
+++ b/apps/desktop/tests/stores.test.ts
@@ -1145,8 +1145,18 @@ describe("workspace-store closeWorkspace", () => {
     });
   });
 
-  test("closeWorkspace resets workspace and editor state", () => {
-    useWorkspaceStore.getState().closeWorkspace();
+  test("closeWorkspace invalidates the backend before resetting workspace and editor state", async () => {
+    const close = createDeferred<unknown>();
+    mockedInvoke.mockImplementation((command: string) =>
+      command === "close_workspace" ? close.promise : Promise.resolve(null),
+    );
+    const closing = useWorkspaceStore.getState().closeWorkspace();
+
+    expect(mockedInvoke).toHaveBeenCalledWith("close_workspace", { root: "/test" });
+    expect(useWorkspaceStore.getState().root).toBe("/test");
+
+    close.resolve(null);
+    await closing;
 
     const ws = useWorkspaceStore.getState();
     expect(ws.root).toBeNull();
@@ -1160,9 +1170,10 @@ describe("workspace-store closeWorkspace", () => {
     expect(ed.tabs).toEqual([]);
   });
 
-  test("closeWorkspace is no-op when no workspace is open", () => {
+  test("closeWorkspace is no-op when no workspace is open", async () => {
     useWorkspaceStore.setState({ root: null });
-    useWorkspaceStore.getState().closeWorkspace();
+    await useWorkspaceStore.getState().closeWorkspace();
     expect(useWorkspaceStore.getState().root).toBeNull();
+    expect(mockedInvoke).not.toHaveBeenCalledWith("close_workspace", expect.anything());
   });
 });

--- a/apps/desktop/tests/tauri-ipc.test.ts
+++ b/apps/desktop/tests/tauri-ipc.test.ts
@@ -118,6 +118,12 @@ describe("filesystem IPC wrappers", () => {
 });
 
 describe("workspace IPC wrappers", () => {
+  test("closeWorkspace invalidates the expected workspace root", async () => {
+    mockedInvoke.mockResolvedValue(undefined);
+    await ipc.closeWorkspace("/test");
+    expect(mockedInvoke).toHaveBeenCalledWith("close_workspace", { root: "/test" });
+  });
+
   test("openWorkspace calls correct command", async () => {
     mockedInvoke.mockResolvedValue({ root: "/ws", name: "ws", file_count: 0 });
     await ipc.openWorkspace("/ws");


### PR DESCRIPTION
## Stack

- Depends on #111
- Base branch: worktree/brave-field-9750

## Summary

- guard sidebar creation, file-manager launch, terminal launch, and workspace close against stale root/epoch state
- serialize cross-window global settings updates against the latest on-disk configuration
- make workspace watcher/index publication revision-safe without holding transition guards across scans or large collection drops
- scope backend notifications with a shared root/epoch identity so A-to-B, A-to-none, and same-root ABA events are rejected
- route the sidebar menu through the complete surface, preserve the rootless workspace shell, and centralize close/error feedback
- consolidate platform labels, setting schema metadata, sidebar entry kinds, and workspace event contracts

## Validation

- vp check (one existing warning in apps/desktop/e2e/wdio.conf.js)
- vp test (40 files, 552 tests)
- cargo test (153 tests)
- cargo clippy (existing warnings only)
- cargo fmt --check
- git diff --check
- final Spec and Standards code-review axes pass with no P0-P3 findings

## Known environment limitation

The packaged native E2E run is blocked before compilation by the existing Tauri JavaScript/Rust version mismatch. Development startup smoke and source review passed.