### PR TITLE
Bump version to 0.6.0

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -856,7 +856,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "base64 0.22.1",
  "fontdb",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.5.1"
+version = "0.6.0"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Writer",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "identifier": "com.writer-computer",
   "build": {
     "beforeDevCommand": "vp dev",


### PR DESCRIPTION
Minor bump — opt-in telemetry is a new user-visible feature (PRs #120 and #121). Version fields only, per docs/releasing.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SxuuEfKgyoSBnhL3emWBM7